### PR TITLE
[codex] Add auth-aware entry for new devices

### DIFF
--- a/docs/paid-launch-roadmap.md
+++ b/docs/paid-launch-roadmap.md
@@ -1,0 +1,155 @@
+# Paid Launch Roadmap
+
+As of April 20, 2026, Routine Stars is a strong local shared-device routine app with a partial account foundation. The work below prioritizes getting it into a trustworthy first paid release.
+
+## Launch Goal
+
+Ship a first paid version where:
+
+- a parent can buy access outside the app
+- a parent can create or sign in to an account
+- the household data follows them to a second device
+- existing local-only families can move forward safely
+- children still get the same simple tap-and-go experience on shared devices
+
+## Current State
+
+Working today:
+
+- local shared-device setup and routine flows
+- parent auth shell
+- first-run household bootstrap in Supabase
+- auth-aware new-device entry screen
+
+Not finished yet:
+
+- cloud-backed child profile and routine hydration
+- local-to-cloud import
+- cloud-backed daily progress sync
+- purchase entitlement model
+- post-payment fulfillment
+- release operations for a paid launch
+
+## Priority Order
+
+### 1. Finish cloud household configuration sync
+
+This is the highest priority because the product promise breaks without it. Parents must be able to sign in on a second device and see the same children, schedules, and routines.
+
+Includes:
+
+- complete Supabase repositories for child profiles, routines, and progress
+- hydrate app bootstrap from cloud household data
+- persist parent changes back to Supabase
+- keep a local offline cache without making it the source of truth
+
+Related issues:
+
+- #13 Create household data schema, RLS, and sync repositories
+- #16 Make app bootstrap auth-aware without blocking existing shared-device families
+
+### 2. Ship a safe import path for existing local families
+
+This protects early users and prevents silent data loss.
+
+Includes:
+
+- detect existing local setup after sign-in
+- offer `Import this family setup` or `Start fresh instead`
+- preserve incomplete setup safely
+- keep local data until cloud import succeeds
+
+Related issues:
+
+- #14 Build local-to-cloud import and offline cache strategy
+- #17 Add post-login import-or-start-fresh decision for existing local family data
+
+### 3. Add billing outside the app for a one-time 9.99 EUR purchase
+
+Recommended MVP direction:
+
+- use Stripe-hosted checkout outside the app
+- start with Stripe Payment Links for the lowest-friction external checkout
+- use webhook fulfillment to grant a household entitlement after payment
+
+Why this direction:
+
+- Payment Links provide a hosted payment page with very low integration effort
+- Stripe Checkout and Payment Links both support hosted one-time payments
+- Stripe recommends webhook-based fulfillment so purchase access is granted reliably
+
+Operational recommendations:
+
+- sell one household lifetime unlock
+- price it at 9.99 EUR
+- treat it as B2C pricing and set tax behavior intentionally for EU markets
+- define refund handling before launch
+
+Related issues:
+
+- #19 Add billing architecture for external one-time purchase at €9.99
+- #20 Grant paid household access from billing entitlement and webhook fulfillment
+
+Useful references:
+
+- https://docs.stripe.com/payment-links
+- https://docs.stripe.com/payments/checkout/how-checkout-works
+- https://docs.stripe.com/checkout/fulfillment
+- https://docs.stripe.com/tax/products-prices-tax-codes-tax-behavior
+
+### 4. Tie access to a durable paid entitlement
+
+Selling the app is not just taking payment. We need a backend entitlement record that says whether the household has access.
+
+Includes:
+
+- add purchase and entitlement records in Supabase
+- receive Stripe webhook events
+- make fulfillment idempotent
+- expose paid vs unpaid state in app bootstrap and parent settings
+- route unpaid households to the external purchase page
+
+Related issue:
+
+- #20 Grant paid household access from billing entitlement and webhook fulfillment
+
+### 5. Hardening for first paid launch
+
+This is the release-quality layer that makes the product feel trustworthy.
+
+Includes:
+
+- real-device QA across phone and tablet
+- support and refund contact path
+- privacy policy and terms review
+- funnel analytics for purchase and onboarding
+- release checklist for keys, webhooks, redirects, and rollback steps
+
+Related issues:
+
+- #3 Run family-pilot real-device QA on phone and tablet
+- #21 Prepare first paid launch operations: QA, support, legal copy, and analytics
+
+## Small-PR Build Sequence
+
+To keep pull requests reviewable, build in this order:
+
+1. auth-aware entry and bootstrap
+2. cloud repositories for child profiles and routines
+3. bootstrap hydration from cloud household config
+4. import/start-fresh decision UI
+5. local-to-cloud import implementation
+6. progress sync and daily reset rules
+7. external billing setup
+8. entitlement fulfillment and purchase gating
+9. launch operations and QA
+
+## Product Decisions Assumed For Now
+
+Unless we decide otherwise later, this roadmap assumes:
+
+- one parent account owns one household
+- purchase is one-time, not subscription
+- purchase unlock is per household, not per child
+- child use stays password-free on shared devices
+- billing lives outside the app

--- a/src/components/AccountEntryScreen.tsx
+++ b/src/components/AccountEntryScreen.tsx
@@ -1,0 +1,77 @@
+import { ArrowRight, Cloud, Sparkles } from 'lucide-react';
+import { AccountSettingsCard } from './AccountSettingsCard';
+import { useAuth } from '@/lib/auth/use-auth';
+
+interface AccountEntryScreenProps {
+  onContinueLocalSetup: () => void;
+}
+
+export const AccountEntryScreen = ({ onContinueLocalSetup }: AccountEntryScreenProps) => {
+  const { configured } = useAuth();
+
+  return (
+    <div className="relative min-h-svh overflow-hidden px-5 py-10 md:px-6 md:py-14">
+      <div className="absolute inset-x-0 top-0 -z-10 mx-auto h-72 w-[42rem] max-w-full rounded-full bg-primary/10 blur-3xl" />
+      <div className="absolute left-6 top-24 -z-10 h-28 w-28 rounded-full bg-accent/20 blur-2xl" />
+      <div className="absolute right-8 top-16 -z-10 h-36 w-36 rounded-full bg-success/15 blur-2xl" />
+
+      <div className="mx-auto grid max-w-6xl gap-8 xl:grid-cols-[minmax(0,1.1fr)_440px] xl:items-start">
+        <section className="rounded-[36px] border border-border bg-card/95 p-7 shadow-card md:p-9">
+          <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 text-sm font-black uppercase tracking-[0.22em] text-primary">
+            <Cloud size={16} />
+            New Device Setup
+          </div>
+
+          <h1 className="mt-6 text-4xl font-bold text-foreground md:text-5xl">
+            Bring your family routines onto this device
+          </h1>
+          <p className="mt-4 max-w-2xl text-lg text-muted-foreground">
+            Parents can sign in to connect this iPad to the household, while kids still get the same quick tap-and-go
+            routine flow once setup is finished.
+          </p>
+
+          <div className="mt-8 grid gap-4 md:grid-cols-2">
+            <div className="rounded-[28px] bg-primary/8 p-5">
+              <p className="text-sm font-black uppercase tracking-[0.2em] text-primary">Recommended</p>
+              <h2 className="mt-3 text-2xl font-bold text-foreground">Sign in or create a parent account</h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Best for shared households and future sync across phones, tablets, and family devices.
+              </p>
+            </div>
+
+            <div className="rounded-[28px] bg-muted/55 p-5">
+              <p className="text-sm font-black uppercase tracking-[0.2em] text-muted-foreground">Local option</p>
+              <h2 className="mt-3 text-2xl font-bold text-foreground">Set up only this device for now</h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                You can stay local today and come back to the parent account flow later from Parent Settings.
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-8 rounded-[28px] border border-border bg-background/80 p-5">
+            <div className="flex items-center gap-2 text-foreground">
+              <Sparkles size={18} className="text-primary" />
+              <p className="text-sm font-black uppercase tracking-[0.18em]">What happens next</p>
+            </div>
+            <div className="mt-4 grid gap-3 text-sm text-muted-foreground md:grid-cols-3">
+              <p>1. Parent signs in with an email link or chooses local-only setup.</p>
+              <p>2. Household setup stays parent-led and child-friendly.</p>
+              <p>3. Kids return here later and just tap their profile to begin.</p>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={onContinueLocalSetup}
+            className="mt-8 inline-flex items-center gap-2 rounded-full border border-border bg-background px-5 py-3 text-sm font-bold text-foreground transition-colors hover:border-primary/40 hover:text-primary"
+          >
+            <ArrowRight size={16} />
+            {configured ? 'Continue with local-only setup' : 'Set up this device locally'}
+          </button>
+        </section>
+
+        <AccountSettingsCard />
+      </div>
+    </div>
+  );
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,6 +28,6 @@ export type Child = {
   evening: Task[];
 };
 
-export type AppView = 'setup' | 'home' | 'routine' | 'parent';
+export type AppView = 'account' | 'setup' | 'home' | 'routine' | 'parent';
 
 export { AGE_BUCKETS, DEFAULT_CHILDREN, groupTasksByAge, ICON_OPTIONS, TASK_CATALOG, TASK_CATALOG_BY_ID, TASK_LIBRARY };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
 import { ChildSelector } from '@/components/ChildSelector';
+import { AccountEntryScreen } from '@/components/AccountEntryScreen';
 import { InitialSetup } from '@/components/InitialSetup';
 import { RoutineView } from '@/components/RoutineView';
 import { ParentSettings } from '@/components/ParentSettings';
+import { useAuth } from '@/lib/auth/use-auth';
 import type { AppView, Child, HomeScene, RoutineType } from '@/lib/types';
 import {
   clearLocalAppState,
@@ -61,6 +63,7 @@ const getDisplayRoutine = (child: Child, now: Date): RoutineType => {
 const createSetupChildren = (): Child[] => [];
 
 const Index = () => {
+  const { status: authStatus } = useAuth();
   const [view, setView] = useState<AppView>('setup');
   const [children, setChildren] = useState<Child[]>(createSetupChildren);
   const [activeChildId, setActiveChildId] = useState<string | null>(null);
@@ -86,8 +89,12 @@ const Index = () => {
     setNow(new Date());
   }, []);
 
-  // Load from localStorage with daily reset
+  // Load from localStorage once auth has settled so startup can be account-aware.
   useEffect(() => {
+    if (authStatus === 'loading') {
+      return;
+    }
+
     const storedState = loadLocalAppState();
     if (storedState) {
       const today = new Date().toDateString();
@@ -103,16 +110,22 @@ const Index = () => {
       }
       setSetupComplete(storedState.setupComplete);
       setHomeScene(storedState.homeScene);
-      setView(storedState.setupComplete ? 'home' : 'setup');
+      setView(
+        storedState.setupComplete
+          ? 'home'
+          : storedState.children.length > 0 || authStatus === 'signed_in'
+            ? 'setup'
+            : 'account'
+      );
     } else {
       setChildren(createSetupChildren());
       setSetupComplete(false);
       setHomeScene('bike');
-      setView('setup');
+      setView(authStatus === 'signed_in' ? 'setup' : 'account');
     }
 
     setIsReady(true);
-  }, []);
+  }, [authStatus]);
 
   useEffect(() => {
     const timer = window.setInterval(() => {
@@ -181,6 +194,10 @@ const Index = () => {
 
   if (!isReady) {
     return null;
+  }
+
+  if (view === 'account') {
+    return <AccountEntryScreen onContinueLocalSetup={() => setView('setup')} />;
   }
 
   if (view === 'setup') {

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -4,6 +4,23 @@ import Index from "@/pages/Index";
 import { CURRENT_LOCAL_APP_STATE_VERSION } from "@/lib/storage/local-app-state";
 import type { Child } from "@/lib/types";
 
+const authState = {
+  configured: true,
+  status: "signed_out",
+  user: null,
+  householdStatus: "idle",
+  household: null,
+  error: null,
+  clearError: vi.fn(),
+  sendEmailLink: vi.fn(),
+  retryHousehold: vi.fn(),
+  signOut: vi.fn(),
+};
+
+vi.mock("@/lib/auth/use-auth", () => ({
+  useAuth: () => authState,
+}));
+
 const today = () => new Date().toDateString();
 
 const yesterday = () => {
@@ -115,6 +132,21 @@ vi.mock("@/components/InitialSetup", () => ({
   ),
 }));
 
+vi.mock("@/components/AccountEntryScreen", () => ({
+  AccountEntryScreen: ({
+    onContinueLocalSetup,
+  }: {
+    onContinueLocalSetup: () => void;
+  }) => (
+    <div>
+      <div data-testid="account-entry-screen">account-entry</div>
+      <button type="button" onClick={onContinueLocalSetup}>
+        continue-local-setup
+      </button>
+    </div>
+  ),
+}));
+
 const createStoredState = (completed: boolean, lastReset: string) => ({
   children: [
     {
@@ -133,6 +165,16 @@ const createStoredState = (completed: boolean, lastReset: string) => ({
 describe("Index", () => {
   beforeEach(() => {
     localStorage.clear();
+    authState.configured = true;
+    authState.status = "signed_out";
+    authState.user = null;
+    authState.householdStatus = "idle";
+    authState.household = null;
+    authState.error = null;
+    authState.clearError.mockReset();
+    authState.sendEmailLink.mockReset();
+    authState.retryHousehold.mockReset();
+    authState.signOut.mockReset();
   });
 
   it("resets completed tasks when stored data is from a previous day", async () => {
@@ -201,7 +243,24 @@ describe("Index", () => {
     expect(screen.getByTestId("active-routine")).toHaveTextContent("evening");
   });
 
-  it("shows the initial setup flow when there is no saved data", async () => {
+  it("shows the account entry flow when there is no saved data and no signed-in parent", async () => {
+    render(<Index />);
+
+    expect(await screen.findByTestId("account-entry-screen")).toBeInTheDocument();
+  });
+
+  it("lets a parent continue into local-only setup from the account entry flow", async () => {
+    render(<Index />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "continue-local-setup" }));
+
+    expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
+  });
+
+  it("opens setup immediately on a fresh device when the parent is already signed in", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+
     render(<Index />);
 
     expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
@@ -237,6 +296,7 @@ describe("Index", () => {
   it("completes first-run setup and persists the configured routines", async () => {
     render(<Index />);
 
+    fireEvent.click(await screen.findByRole("button", { name: "continue-local-setup" }));
     fireEvent.click(await screen.findByRole("button", { name: "finish-setup" }));
 
     expect(await screen.findByTestId("child-count")).toHaveTextContent("1");


### PR DESCRIPTION
## Summary
Adds an auth-aware first-run entry screen for fresh devices so parents can sign in before dropping into family setup.

## What changed
- adds a dedicated account entry screen for new devices
- updates app bootstrap to consider auth state before choosing the first screen
- keeps existing configured shared devices on the child/home flow
- adds a paid-launch roadmap doc to capture the sellable-release priority order

## Why
Fresh devices were immediately opening the family setup flow, which made the account-backed household experience confusing and blocked the intended multi-device path.

## Validation
- `npm test -- --run`

## Related issues
- Closes #15
- Addresses #16
- Supports #18