### PR TITLE
[codex] Hydrate household setup from cloud data

### DIFF
--- a/src/lib/data/cloud-household-state.ts
+++ b/src/lib/data/cloud-household-state.ts
@@ -1,0 +1,100 @@
+import type { Child, HomeScene, IconKey, RoutineType, Task } from '@/lib/types';
+import { TASK_CATALOG_BY_ID } from '@/lib/types';
+import type { ChildProfileRecord, HouseholdRecord, RoutineRecord, RoutineTaskRecord } from './models';
+import { SupabaseChildProfileRepository } from './supabase-child-profile-repository';
+import { SupabaseRoutineRepository } from './supabase-routine-repository';
+import { getSupabaseClient } from '@/lib/supabase/client';
+
+export interface CloudHouseholdState {
+  children: Child[];
+  homeScene: HomeScene;
+}
+
+const DEFAULT_SCHEDULE = {
+  morning: { start: '07:00', end: '09:00' },
+  evening: { start: '17:00', end: '20:00' },
+} as const;
+
+const buildTaskFromCloud = (task: RoutineTaskRecord): Task => {
+  if (task.taskTemplateId) {
+    const template = TASK_CATALOG_BY_ID[task.taskTemplateId];
+    if (template) {
+      return {
+        id: task.id,
+        title: template.title,
+        icon: template.icon,
+        completed: false,
+      };
+    }
+  }
+
+  return {
+    id: task.id,
+    title: task.customTitle ?? 'Custom task',
+    icon: (task.customIcon ?? 'sparkles') as IconKey,
+    completed: false,
+  };
+};
+
+export const mapCloudHouseholdToChildren = (input: {
+  childProfiles: ChildProfileRecord[];
+  routinesByChildId: Record<string, { routines: RoutineRecord[]; routineTasks: RoutineTaskRecord[] }>;
+}) =>
+  input.childProfiles.map((profile) => {
+    const childRoutines = input.routinesByChildId[profile.id] ?? { routines: [], routineTasks: [] };
+    const routines = Object.fromEntries(
+      childRoutines.routines.map((routine) => [routine.type, routine])
+    ) as Partial<Record<RoutineType, RoutineRecord>>;
+    const tasksByRoutineId = Object.fromEntries(
+      childRoutines.routines.map((routine) => [
+        routine.id,
+        childRoutines.routineTasks
+          .filter((task) => task.routineId === routine.id && !task.isArchived)
+          .sort((left, right) => left.sortOrder - right.sortOrder)
+          .map(buildTaskFromCloud),
+      ])
+    ) as Record<string, Task[]>;
+
+    return {
+      id: profile.id,
+      name: profile.name,
+      age: profile.age ?? undefined,
+      ageBucket: profile.ageBucket ?? undefined,
+      avatarAnimal: profile.avatarAnimal ?? undefined,
+      avatarSeed: profile.avatarSeed ?? profile.id,
+      schedule: {
+        morning: routines.morning
+          ? { start: routines.morning.startTime, end: routines.morning.endTime }
+          : { ...DEFAULT_SCHEDULE.morning },
+        evening: routines.evening
+          ? { start: routines.evening.startTime, end: routines.evening.endTime }
+          : { ...DEFAULT_SCHEDULE.evening },
+      },
+      morning: routines.morning ? tasksByRoutineId[routines.morning.id] ?? [] : [],
+      evening: routines.evening ? tasksByRoutineId[routines.evening.id] ?? [] : [],
+    };
+  });
+
+export const loadCloudHouseholdState = async (
+  household: HouseholdRecord
+): Promise<CloudHouseholdState> => {
+  const supabase = getSupabaseClient();
+  if (!supabase) {
+    throw new Error('Supabase is not configured yet.');
+  }
+
+  const childRepository = new SupabaseChildProfileRepository(supabase);
+  const routineRepository = new SupabaseRoutineRepository(supabase);
+  const childProfiles = await childRepository.listByHousehold(household.id);
+  const routinePairs = await Promise.all(
+    childProfiles.map(async (profile) => [profile.id, await routineRepository.listByChild(profile.id)] as const)
+  );
+
+  return {
+    homeScene: household.homeScene,
+    children: mapCloudHouseholdToChildren({
+      childProfiles,
+      routinesByChildId: Object.fromEntries(routinePairs),
+    }),
+  };
+};

--- a/src/lib/data/supabase-child-profile-repository.ts
+++ b/src/lib/data/supabase-child-profile-repository.ts
@@ -1,0 +1,73 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { ChildProfileRecord } from './models';
+import type { ChildProfileRepository } from './repositories';
+
+const CHILD_PROFILES_TABLE = 'child_profiles';
+
+const mapChildProfile = (row: Record<string, unknown>): ChildProfileRecord => ({
+  id: String(row.id),
+  householdId: String(row.household_id),
+  name: String(row.name),
+  age: row.age === null || row.age === undefined ? null : Number(row.age),
+  ageBucket: (row.age_bucket === null || row.age_bucket === undefined ? null : String(row.age_bucket)) as ChildProfileRecord['ageBucket'],
+  avatarAnimal:
+    row.avatar_animal === null || row.avatar_animal === undefined ? null : String(row.avatar_animal),
+  avatarSeed: row.avatar_seed === null || row.avatar_seed === undefined ? null : String(row.avatar_seed),
+  createdAt: String(row.created_at),
+  updatedAt: String(row.updated_at),
+});
+
+const toChildProfilePayload = (profile: Omit<ChildProfileRecord, 'createdAt' | 'updatedAt'>) => ({
+  id: profile.id,
+  household_id: profile.householdId,
+  name: profile.name,
+  age: profile.age,
+  age_bucket: profile.ageBucket,
+  avatar_animal: profile.avatarAnimal,
+  avatar_seed: profile.avatarSeed,
+});
+
+export class SupabaseChildProfileRepository implements ChildProfileRepository {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async listByHousehold(householdId: string) {
+    const { data, error } = await this.supabase
+      .from(CHILD_PROFILES_TABLE)
+      .select('*')
+      .eq('household_id', householdId)
+      .order('created_at', { ascending: true });
+
+    if (error) {
+      throw error;
+    }
+
+    return (data ?? []).map(mapChildProfile);
+  }
+
+  async upsert(profile: Omit<ChildProfileRecord, 'createdAt' | 'updatedAt'>) {
+    const { data, error } = await this.supabase
+      .from(CHILD_PROFILES_TABLE)
+      .upsert(toChildProfilePayload(profile), { onConflict: 'id' })
+      .select('*')
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    return mapChildProfile(data);
+  }
+
+  async remove(childProfileId: string) {
+    const { error } = await this.supabase
+      .from(CHILD_PROFILES_TABLE)
+      .delete()
+      .eq('id', childProfileId);
+
+    if (error) {
+      throw error;
+    }
+  }
+}
+
+export { mapChildProfile };

--- a/src/lib/data/supabase-routine-repository.ts
+++ b/src/lib/data/supabase-routine-repository.ts
@@ -1,0 +1,127 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { RoutineRecord, RoutineTaskRecord } from './models';
+import type { RoutineRepository } from './repositories';
+
+const ROUTINES_TABLE = 'routines';
+const ROUTINE_TASKS_TABLE = 'routine_tasks';
+
+const mapRoutine = (row: Record<string, unknown>): RoutineRecord => ({
+  id: String(row.id),
+  childProfileId: String(row.child_profile_id),
+  type: String(row.type) as RoutineRecord['type'],
+  startTime: String(row.start_time),
+  endTime: String(row.end_time),
+  createdAt: String(row.created_at),
+  updatedAt: String(row.updated_at),
+});
+
+const mapRoutineTask = (row: Record<string, unknown>): RoutineTaskRecord => ({
+  id: String(row.id),
+  routineId: String(row.routine_id),
+  taskTemplateId:
+    row.task_template_id === null || row.task_template_id === undefined ? null : String(row.task_template_id),
+  customTitle: row.custom_title === null || row.custom_title === undefined ? null : String(row.custom_title),
+  customIcon: row.custom_icon === null || row.custom_icon === undefined ? null : String(row.custom_icon) as RoutineTaskRecord['customIcon'],
+  sortOrder: Number(row.sort_order),
+  isArchived: Boolean(row.is_archived),
+  createdAt: String(row.created_at),
+  updatedAt: String(row.updated_at),
+});
+
+const toRoutinePayload = (routine: Omit<RoutineRecord, 'createdAt' | 'updatedAt'>) => ({
+  id: routine.id,
+  child_profile_id: routine.childProfileId,
+  type: routine.type,
+  start_time: routine.startTime,
+  end_time: routine.endTime,
+});
+
+export class SupabaseRoutineRepository implements RoutineRepository {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async listByChild(childProfileId: string) {
+    const { data: routineRows, error: routineError } = await this.supabase
+      .from(ROUTINES_TABLE)
+      .select('*')
+      .eq('child_profile_id', childProfileId)
+      .order('created_at', { ascending: true });
+
+    if (routineError) {
+      throw routineError;
+    }
+
+    const routines = (routineRows ?? []).map(mapRoutine);
+    if (routines.length === 0) {
+      return { routines, routineTasks: [] };
+    }
+
+    const { data: taskRows, error: taskError } = await this.supabase
+      .from(ROUTINE_TASKS_TABLE)
+      .select('*')
+      .in('routine_id', routines.map((routine) => routine.id))
+      .order('sort_order', { ascending: true });
+
+    if (taskError) {
+      throw taskError;
+    }
+
+    return {
+      routines,
+      routineTasks: (taskRows ?? []).map(mapRoutineTask),
+    };
+  }
+
+  async upsertRoutine(input: Omit<RoutineRecord, 'createdAt' | 'updatedAt'>) {
+    const { data, error } = await this.supabase
+      .from(ROUTINES_TABLE)
+      .upsert(toRoutinePayload(input), { onConflict: 'child_profile_id,type' })
+      .select('*')
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    return mapRoutine(data);
+  }
+
+  async replaceRoutineTasks(input: {
+    routineId: string;
+    tasks: Array<Omit<RoutineTaskRecord, 'id' | 'routineId' | 'createdAt' | 'updatedAt'>>;
+  }) {
+    const { error: deleteError } = await this.supabase
+      .from(ROUTINE_TASKS_TABLE)
+      .delete()
+      .eq('routine_id', input.routineId);
+
+    if (deleteError) {
+      throw deleteError;
+    }
+
+    if (input.tasks.length === 0) {
+      return [];
+    }
+
+    const payload = input.tasks.map((task, index) => ({
+      routine_id: input.routineId,
+      task_template_id: task.taskTemplateId,
+      custom_title: task.customTitle,
+      custom_icon: task.customIcon,
+      sort_order: task.sortOrder ?? index,
+      is_archived: task.isArchived,
+    }));
+
+    const { data, error } = await this.supabase
+      .from(ROUTINE_TASKS_TABLE)
+      .insert(payload)
+      .select('*');
+
+    if (error) {
+      throw error;
+    }
+
+    return (data ?? []).map(mapRoutineTask).sort((left, right) => left.sortOrder - right.sortOrder);
+  }
+}
+
+export { mapRoutine, mapRoutineTask };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,6 +5,7 @@ import { InitialSetup } from '@/components/InitialSetup';
 import { RoutineView } from '@/components/RoutineView';
 import { ParentSettings } from '@/components/ParentSettings';
 import { useAuth } from '@/lib/auth/use-auth';
+import { loadCloudHouseholdState } from '@/lib/data/cloud-household-state';
 import type { AppView, Child, HomeScene, RoutineType } from '@/lib/types';
 import {
   clearLocalAppState,
@@ -63,7 +64,7 @@ const getDisplayRoutine = (child: Child, now: Date): RoutineType => {
 const createSetupChildren = (): Child[] => [];
 
 const Index = () => {
-  const { status: authStatus } = useAuth();
+  const { status: authStatus, householdStatus, household } = useAuth();
   const [view, setView] = useState<AppView>('setup');
   const [children, setChildren] = useState<Child[]>(createSetupChildren);
   const [activeChildId, setActiveChildId] = useState<string | null>(null);
@@ -91,41 +92,75 @@ const Index = () => {
 
   // Load from localStorage once auth has settled so startup can be account-aware.
   useEffect(() => {
-    if (authStatus === 'loading') {
+    if (authStatus === 'loading' || (authStatus === 'signed_in' && householdStatus === 'loading')) {
       return;
     }
 
-    const storedState = loadLocalAppState();
-    if (storedState) {
-      const today = new Date().toDateString();
-      if (storedState.lastReset !== today) {
-        const reset = storedState.children.map((c: Child) => ({
-          ...c,
-          morning: c.morning.map((t: Child['morning'][0]) => ({ ...t, completed: false })),
-          evening: c.evening.map((t: Child['evening'][0]) => ({ ...t, completed: false })),
-        }));
-        setChildren(reset);
-      } else {
-        setChildren(storedState.children);
-      }
-      setSetupComplete(storedState.setupComplete);
-      setHomeScene(storedState.homeScene);
-      setView(
-        storedState.setupComplete
-          ? 'home'
-          : storedState.children.length > 0 || authStatus === 'signed_in'
-            ? 'setup'
-            : 'account'
-      );
-    } else {
-      setChildren(createSetupChildren());
-      setSetupComplete(false);
-      setHomeScene('bike');
-      setView(authStatus === 'signed_in' ? 'setup' : 'account');
-    }
+    let isMounted = true;
 
-    setIsReady(true);
-  }, [authStatus]);
+    const bootstrap = async () => {
+      const storedState = loadLocalAppState();
+      if (storedState) {
+        const today = new Date().toDateString();
+        if (storedState.lastReset !== today) {
+          const reset = storedState.children.map((c: Child) => ({
+            ...c,
+            morning: c.morning.map((t: Child['morning'][0]) => ({ ...t, completed: false })),
+            evening: c.evening.map((t: Child['evening'][0]) => ({ ...t, completed: false })),
+          }));
+          if (isMounted) {
+            setChildren(reset);
+          }
+        } else if (isMounted) {
+          setChildren(storedState.children);
+        }
+
+        if (isMounted) {
+          setSetupComplete(storedState.setupComplete);
+          setHomeScene(storedState.homeScene);
+          setView(
+            storedState.setupComplete
+              ? 'home'
+              : storedState.children.length > 0 || authStatus === 'signed_in'
+                ? 'setup'
+                : 'account'
+          );
+          setIsReady(true);
+        }
+        return;
+      }
+
+      if (authStatus === 'signed_in' && householdStatus === 'ready' && household) {
+        try {
+          const cloudState = await loadCloudHouseholdState(household);
+          if (!isMounted) return;
+
+          setChildren(cloudState.children);
+          setHomeScene(cloudState.homeScene);
+          setSetupComplete(cloudState.children.length > 0);
+          setView(cloudState.children.length > 0 ? 'home' : 'setup');
+          setIsReady(true);
+          return;
+        } catch (error) {
+          console.warn('Could not load cloud household state.', error);
+        }
+      }
+
+      if (isMounted) {
+        setChildren(createSetupChildren());
+        setSetupComplete(false);
+        setHomeScene('bike');
+        setView(authStatus === 'signed_in' ? 'setup' : 'account');
+        setIsReady(true);
+      }
+    };
+
+    void bootstrap();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [authStatus, household, householdStatus]);
 
   useEffect(() => {
     const timer = window.setInterval(() => {

--- a/src/test/cloudHouseholdState.test.ts
+++ b/src/test/cloudHouseholdState.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { mapCloudHouseholdToChildren } from '@/lib/data/cloud-household-state';
+
+describe('mapCloudHouseholdToChildren', () => {
+  it('maps cloud child profiles, routines, and template tasks into app children', () => {
+    expect(
+      mapCloudHouseholdToChildren({
+        childProfiles: [
+          {
+            id: 'child-1',
+            householdId: 'house-1',
+            name: 'Lily',
+            age: 5,
+            ageBucket: '4-6',
+            avatarAnimal: 'cat',
+            avatarSeed: 'seed-1',
+            createdAt: '2026-04-20T10:00:00Z',
+            updatedAt: '2026-04-20T10:00:00Z',
+          },
+        ],
+        routinesByChildId: {
+          'child-1': {
+            routines: [
+              {
+                id: 'routine-morning',
+                childProfileId: 'child-1',
+                type: 'morning',
+                startTime: '07:30',
+                endTime: '08:30',
+                createdAt: '2026-04-20T10:00:00Z',
+                updatedAt: '2026-04-20T10:00:00Z',
+              },
+              {
+                id: 'routine-evening',
+                childProfileId: 'child-1',
+                type: 'evening',
+                startTime: '18:00',
+                endTime: '19:30',
+                createdAt: '2026-04-20T10:00:00Z',
+                updatedAt: '2026-04-20T10:00:00Z',
+              },
+            ],
+            routineTasks: [
+              {
+                id: 'task-2',
+                routineId: 'routine-morning',
+                taskTemplateId: null,
+                customTitle: 'Water plant',
+                customIcon: 'sparkles',
+                sortOrder: 1,
+                isArchived: false,
+                createdAt: '2026-04-20T10:00:00Z',
+                updatedAt: '2026-04-20T10:00:00Z',
+              },
+              {
+                id: 'task-1',
+                routineId: 'routine-morning',
+                taskTemplateId: 'brush-teeth',
+                customTitle: null,
+                customIcon: null,
+                sortOrder: 0,
+                isArchived: false,
+                createdAt: '2026-04-20T10:00:00Z',
+                updatedAt: '2026-04-20T10:00:00Z',
+              },
+              {
+                id: 'task-3',
+                routineId: 'routine-evening',
+                taskTemplateId: 'go-to-bed',
+                customTitle: null,
+                customIcon: null,
+                sortOrder: 0,
+                isArchived: false,
+                createdAt: '2026-04-20T10:00:00Z',
+                updatedAt: '2026-04-20T10:00:00Z',
+              },
+            ],
+          },
+        },
+      })
+    ).toEqual([
+      {
+        id: 'child-1',
+        name: 'Lily',
+        age: 5,
+        ageBucket: '4-6',
+        avatarAnimal: 'cat',
+        avatarSeed: 'seed-1',
+        schedule: {
+          morning: { start: '07:30', end: '08:30' },
+          evening: { start: '18:00', end: '19:30' },
+        },
+        morning: [
+          { id: 'task-1', title: 'Brush teeth', icon: 'brush', completed: false },
+          { id: 'task-2', title: 'Water plant', icon: 'sparkles', completed: false },
+        ],
+        evening: [{ id: 'task-3', title: 'Go to bed', icon: 'moon-star', completed: false }],
+      },
+    ]);
+  });
+});

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -17,8 +17,16 @@ const authState = {
   signOut: vi.fn(),
 };
 
+const { loadCloudHouseholdState } = vi.hoisted(() => ({
+  loadCloudHouseholdState: vi.fn(),
+}));
+
 vi.mock("@/lib/auth/use-auth", () => ({
   useAuth: () => authState,
+}));
+
+vi.mock("@/lib/data/cloud-household-state", () => ({
+  loadCloudHouseholdState,
 }));
 
 const today = () => new Date().toDateString();
@@ -171,6 +179,7 @@ describe("Index", () => {
     authState.householdStatus = "idle";
     authState.household = null;
     authState.error = null;
+    loadCloudHouseholdState.mockReset();
     authState.clearError.mockReset();
     authState.sendEmailLink.mockReset();
     authState.retryHousehold.mockReset();
@@ -264,6 +273,37 @@ describe("Index", () => {
     render(<Index />);
 
     expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
+  });
+
+  it("hydrates cloud household data on a fresh signed-in device", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [
+        {
+          id: "1",
+          name: "Lily",
+          morning: [{ id: "m1", title: "Make bed", icon: "bed", completed: false }],
+          evening: [{ id: "e1", title: "Go to bed", icon: "moon-star", completed: false }],
+        },
+      ],
+    });
+
+    render(<Index />);
+
+    expect(await screen.findByTestId("child-count")).toHaveTextContent("1");
+    expect(loadCloudHouseholdState).toHaveBeenCalledWith(authState.household);
   });
 
   it("re-opens setup when saved data is marked incomplete", async () => {

--- a/src/test/supabaseChildProfileRepository.test.ts
+++ b/src/test/supabaseChildProfileRepository.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SupabaseChildProfileRepository } from '@/lib/data/supabase-child-profile-repository';
+
+const createSupabaseClient = (fromImpl: (table: string) => unknown) =>
+  ({
+    from: vi.fn(fromImpl),
+  }) as never;
+
+describe('SupabaseChildProfileRepository', () => {
+  it('lists child profiles by household and maps the row shape', async () => {
+    const order = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'child-1',
+          household_id: 'house-1',
+          name: 'Lily',
+          age: 5,
+          age_bucket: '4-6',
+          avatar_animal: 'cat',
+          avatar_seed: 'seed-1',
+          created_at: '2026-04-20T10:00:00Z',
+          updated_at: '2026-04-20T10:00:00Z',
+        },
+      ],
+      error: null,
+    });
+    const eq = vi.fn(() => ({ order }));
+    const select = vi.fn(() => ({ eq }));
+    const repository = new SupabaseChildProfileRepository(
+      createSupabaseClient(() => ({ select }))
+    );
+
+    await expect(repository.listByHousehold('house-1')).resolves.toEqual([
+      {
+        id: 'child-1',
+        householdId: 'house-1',
+        name: 'Lily',
+        age: 5,
+        ageBucket: '4-6',
+        avatarAnimal: 'cat',
+        avatarSeed: 'seed-1',
+        createdAt: '2026-04-20T10:00:00Z',
+        updatedAt: '2026-04-20T10:00:00Z',
+      },
+    ]);
+
+    expect(eq).toHaveBeenCalledWith('household_id', 'house-1');
+    expect(order).toHaveBeenCalledWith('created_at', { ascending: true });
+  });
+
+  it('upserts child profiles using snake_case payloads', async () => {
+    const single = vi.fn().mockResolvedValue({
+      data: {
+        id: 'child-1',
+        household_id: 'house-1',
+        name: 'Lily',
+        age: 5,
+        age_bucket: '4-6',
+        avatar_animal: null,
+        avatar_seed: 'seed-1',
+        created_at: '2026-04-20T10:00:00Z',
+        updated_at: '2026-04-20T10:05:00Z',
+      },
+      error: null,
+    });
+    const select = vi.fn(() => ({ single }));
+    const upsert = vi.fn(() => ({ select }));
+    const repository = new SupabaseChildProfileRepository(
+      createSupabaseClient(() => ({ upsert }))
+    );
+
+    await expect(
+      repository.upsert({
+        id: 'child-1',
+        householdId: 'house-1',
+        name: 'Lily',
+        age: 5,
+        ageBucket: '4-6',
+        avatarAnimal: null,
+        avatarSeed: 'seed-1',
+      })
+    ).resolves.toMatchObject({
+      id: 'child-1',
+      householdId: 'house-1',
+      name: 'Lily',
+    });
+
+    expect(upsert).toHaveBeenCalledWith(
+      {
+        id: 'child-1',
+        household_id: 'house-1',
+        name: 'Lily',
+        age: 5,
+        age_bucket: '4-6',
+        avatar_animal: null,
+        avatar_seed: 'seed-1',
+      },
+      { onConflict: 'id' }
+    );
+  });
+});

--- a/src/test/supabaseRoutineRepository.test.ts
+++ b/src/test/supabaseRoutineRepository.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SupabaseRoutineRepository } from '@/lib/data/supabase-routine-repository';
+
+const createSupabaseClient = (responses: Record<string, unknown>) =>
+  ({
+    from: vi.fn((table: string) => responses[table]),
+  }) as never;
+
+describe('SupabaseRoutineRepository', () => {
+  it('lists routines and their tasks for a child profile', async () => {
+    const routineOrder = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'routine-1',
+          child_profile_id: 'child-1',
+          type: 'morning',
+          start_time: '07:00',
+          end_time: '09:00',
+          created_at: '2026-04-20T10:00:00Z',
+          updated_at: '2026-04-20T10:00:00Z',
+        },
+      ],
+      error: null,
+    });
+    const taskOrder = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'task-1',
+          routine_id: 'routine-1',
+          task_template_id: 'brush-teeth',
+          custom_title: null,
+          custom_icon: null,
+          sort_order: 0,
+          is_archived: false,
+          created_at: '2026-04-20T10:00:00Z',
+          updated_at: '2026-04-20T10:00:00Z',
+        },
+      ],
+      error: null,
+    });
+    const repository = new SupabaseRoutineRepository(
+      createSupabaseClient({
+        routines: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({ order: routineOrder })),
+          })),
+        },
+        routine_tasks: {
+          select: vi.fn(() => ({
+            in: vi.fn(() => ({ order: taskOrder })),
+          })),
+        },
+      })
+    );
+
+    await expect(repository.listByChild('child-1')).resolves.toEqual({
+      routines: [
+        {
+          id: 'routine-1',
+          childProfileId: 'child-1',
+          type: 'morning',
+          startTime: '07:00',
+          endTime: '09:00',
+          createdAt: '2026-04-20T10:00:00Z',
+          updatedAt: '2026-04-20T10:00:00Z',
+        },
+      ],
+      routineTasks: [
+        {
+          id: 'task-1',
+          routineId: 'routine-1',
+          taskTemplateId: 'brush-teeth',
+          customTitle: null,
+          customIcon: null,
+          sortOrder: 0,
+          isArchived: false,
+          createdAt: '2026-04-20T10:00:00Z',
+          updatedAt: '2026-04-20T10:00:00Z',
+        },
+      ],
+    });
+  });
+
+  it('upserts routines using the child/type unique key', async () => {
+    const single = vi.fn().mockResolvedValue({
+      data: {
+        id: 'routine-1',
+        child_profile_id: 'child-1',
+        type: 'morning',
+        start_time: '07:00',
+        end_time: '09:00',
+        created_at: '2026-04-20T10:00:00Z',
+        updated_at: '2026-04-20T10:05:00Z',
+      },
+      error: null,
+    });
+    const select = vi.fn(() => ({ single }));
+    const upsert = vi.fn(() => ({ select }));
+    const repository = new SupabaseRoutineRepository(
+      createSupabaseClient({
+        routines: { upsert },
+      })
+    );
+
+    await expect(
+      repository.upsertRoutine({
+        id: 'routine-1',
+        childProfileId: 'child-1',
+        type: 'morning',
+        startTime: '07:00',
+        endTime: '09:00',
+      })
+    ).resolves.toMatchObject({
+      id: 'routine-1',
+      childProfileId: 'child-1',
+      type: 'morning',
+    });
+
+    expect(upsert).toHaveBeenCalledWith(
+      {
+        id: 'routine-1',
+        child_profile_id: 'child-1',
+        type: 'morning',
+        start_time: '07:00',
+        end_time: '09:00',
+      },
+      { onConflict: 'child_profile_id,type' }
+    );
+  });
+
+  it('replaces routine tasks by clearing old rows and inserting the new set', async () => {
+    const deleteEq = vi.fn().mockResolvedValue({ error: null });
+    const insertSelect = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'task-2',
+          routine_id: 'routine-1',
+          task_template_id: null,
+          custom_title: 'Pack lunch',
+          custom_icon: 'chef-hat',
+          sort_order: 1,
+          is_archived: false,
+          created_at: '2026-04-20T10:00:00Z',
+          updated_at: '2026-04-20T10:00:00Z',
+        },
+        {
+          id: 'task-1',
+          routine_id: 'routine-1',
+          task_template_id: 'brush-teeth',
+          custom_title: null,
+          custom_icon: null,
+          sort_order: 0,
+          is_archived: false,
+          created_at: '2026-04-20T10:00:00Z',
+          updated_at: '2026-04-20T10:00:00Z',
+        },
+      ],
+      error: null,
+    });
+    const insert = vi.fn(() => ({ select: insertSelect }));
+    const repository = new SupabaseRoutineRepository(
+      createSupabaseClient({
+        routine_tasks: {
+          delete: vi.fn(() => ({ eq: deleteEq })),
+          insert,
+        },
+      })
+    );
+
+    await expect(
+      repository.replaceRoutineTasks({
+        routineId: 'routine-1',
+        tasks: [
+          {
+            taskTemplateId: 'brush-teeth',
+            customTitle: null,
+            customIcon: null,
+            sortOrder: 0,
+            isArchived: false,
+          },
+          {
+            taskTemplateId: null,
+            customTitle: 'Pack lunch',
+            customIcon: 'chef-hat',
+            sortOrder: 1,
+            isArchived: false,
+          },
+        ],
+      })
+    ).resolves.toEqual([
+      expect.objectContaining({ id: 'task-1', sortOrder: 0 }),
+      expect.objectContaining({ id: 'task-2', sortOrder: 1 }),
+    ]);
+
+    expect(deleteEq).toHaveBeenCalledWith('routine_id', 'routine-1');
+    expect(insert).toHaveBeenCalledWith([
+      {
+        routine_id: 'routine-1',
+        task_template_id: 'brush-teeth',
+        custom_title: null,
+        custom_icon: null,
+        sort_order: 0,
+        is_archived: false,
+      },
+      {
+        routine_id: 'routine-1',
+        task_template_id: null,
+        custom_title: 'Pack lunch',
+        custom_icon: 'chef-hat',
+        sort_order: 1,
+        is_archived: false,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
Adds the first read-only cloud household hydration layer so a signed-in parent on a fresh device can load child profiles and routine setup from Supabase.

## What changed
- adds Supabase repositories for child profiles and routines
- adds a cloud household mapper that converts normalized records into the current app child model
- updates bootstrap so a signed-in device with no local data can load household setup from cloud
- adds tests for repositories, mapping, and Index bootstrap behavior

## Why
The account shell existed, but a second device still could not actually see household setup. This closes the first real sync gap without yet changing import or write paths.

## Validation
- `npm test -- --run`

## Related issues
- Addresses #13
- Supports #16
- Supports #18