### PR TITLE
[codex] Add local-to-cloud family import flow

### DIFF
--- a/src/components/ImportFamilySetupScreen.tsx
+++ b/src/components/ImportFamilySetupScreen.tsx
@@ -1,0 +1,93 @@
+import { ArrowRight, CloudUpload, LoaderCircle, Sparkles } from 'lucide-react';
+
+interface ImportFamilySetupScreenProps {
+  onImport: () => void;
+  onStartFresh: () => void;
+  isImporting: boolean;
+  error?: string | null;
+}
+
+export const ImportFamilySetupScreen = ({
+  onImport,
+  onStartFresh,
+  isImporting,
+  error,
+}: ImportFamilySetupScreenProps) => (
+  <div className="relative min-h-svh overflow-hidden px-5 py-10 md:px-6 md:py-14">
+    <div className="absolute inset-x-0 top-0 -z-10 mx-auto h-72 w-[42rem] max-w-full rounded-full bg-primary/10 blur-3xl" />
+    <div className="absolute left-6 top-24 -z-10 h-28 w-28 rounded-full bg-accent/20 blur-2xl" />
+    <div className="absolute right-8 top-16 -z-10 h-36 w-36 rounded-full bg-success/15 blur-2xl" />
+
+    <div className="mx-auto max-w-4xl rounded-[36px] border border-border bg-card/95 p-7 shadow-card md:p-9">
+      <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 text-sm font-black uppercase tracking-[0.22em] text-primary">
+        <CloudUpload size={16} />
+        Bring Your Family Setup
+      </div>
+
+      <h1 className="mt-6 text-4xl font-bold text-foreground md:text-5xl">
+        We found routines already saved on this device
+      </h1>
+      <p className="mt-4 max-w-2xl text-lg text-muted-foreground">
+        You can import this family setup into your parent account or start fresh for this household instead.
+      </p>
+
+      <div className="mt-8 grid gap-4 md:grid-cols-2">
+        <div className="rounded-[28px] bg-primary/8 p-5">
+          <p className="text-sm font-black uppercase tracking-[0.2em] text-primary">Recommended</p>
+          <h2 className="mt-3 text-2xl font-bold text-foreground">Import this family setup</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Keep the children, routines, schedules, and home scene already saved on this device.
+          </p>
+        </div>
+
+        <div className="rounded-[28px] bg-muted/55 p-5">
+          <p className="text-sm font-black uppercase tracking-[0.2em] text-muted-foreground">Alternative</p>
+          <h2 className="mt-3 text-2xl font-bold text-foreground">Start fresh instead</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Leave this device&apos;s old setup behind and create a brand-new household setup in your account.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-8 rounded-[28px] border border-border bg-background/80 p-5">
+        <div className="flex items-center gap-2 text-foreground">
+          <Sparkles size={18} className="text-primary" />
+          <p className="text-sm font-black uppercase tracking-[0.18em]">Import notes</p>
+        </div>
+        <div className="mt-4 grid gap-3 text-sm text-muted-foreground md:grid-cols-3">
+          <p>1. Children, schedules, and routines move into your account.</p>
+          <p>2. Daily completion progress does not get merged into cloud yet.</p>
+          <p>3. This device keeps working for kids after setup is ready.</p>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mt-6 rounded-2xl border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+        <button
+          type="button"
+          onClick={onImport}
+          disabled={isImporting}
+          className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-3 text-sm font-bold text-primary-foreground shadow-button transition-transform active:translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isImporting ? <LoaderCircle size={16} className="animate-spin" /> : <CloudUpload size={16} />}
+          Import this family setup
+        </button>
+
+        <button
+          type="button"
+          onClick={onStartFresh}
+          disabled={isImporting}
+          className="inline-flex items-center justify-center gap-2 rounded-full border border-border bg-background px-5 py-3 text-sm font-bold text-foreground transition-colors hover:border-primary/40 hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <ArrowRight size={16} />
+          Start fresh instead
+        </button>
+      </div>
+    </div>
+  </div>
+);

--- a/src/lib/data/cloud-household-state.ts
+++ b/src/lib/data/cloud-household-state.ts
@@ -1,0 +1,100 @@
+import type { Child, HomeScene, IconKey, RoutineType, Task } from '@/lib/types';
+import { TASK_CATALOG_BY_ID } from '@/lib/types';
+import type { ChildProfileRecord, HouseholdRecord, RoutineRecord, RoutineTaskRecord } from './models';
+import { SupabaseChildProfileRepository } from './supabase-child-profile-repository';
+import { SupabaseRoutineRepository } from './supabase-routine-repository';
+import { getSupabaseClient } from '@/lib/supabase/client';
+
+export interface CloudHouseholdState {
+  children: Child[];
+  homeScene: HomeScene;
+}
+
+const DEFAULT_SCHEDULE = {
+  morning: { start: '07:00', end: '09:00' },
+  evening: { start: '17:00', end: '20:00' },
+} as const;
+
+const buildTaskFromCloud = (task: RoutineTaskRecord): Task => {
+  if (task.taskTemplateId) {
+    const template = TASK_CATALOG_BY_ID[task.taskTemplateId];
+    if (template) {
+      return {
+        id: task.id,
+        title: template.title,
+        icon: template.icon,
+        completed: false,
+      };
+    }
+  }
+
+  return {
+    id: task.id,
+    title: task.customTitle ?? 'Custom task',
+    icon: (task.customIcon ?? 'sparkles') as IconKey,
+    completed: false,
+  };
+};
+
+export const mapCloudHouseholdToChildren = (input: {
+  childProfiles: ChildProfileRecord[];
+  routinesByChildId: Record<string, { routines: RoutineRecord[]; routineTasks: RoutineTaskRecord[] }>;
+}) =>
+  input.childProfiles.map((profile) => {
+    const childRoutines = input.routinesByChildId[profile.id] ?? { routines: [], routineTasks: [] };
+    const routines = Object.fromEntries(
+      childRoutines.routines.map((routine) => [routine.type, routine])
+    ) as Partial<Record<RoutineType, RoutineRecord>>;
+    const tasksByRoutineId = Object.fromEntries(
+      childRoutines.routines.map((routine) => [
+        routine.id,
+        childRoutines.routineTasks
+          .filter((task) => task.routineId === routine.id && !task.isArchived)
+          .sort((left, right) => left.sortOrder - right.sortOrder)
+          .map(buildTaskFromCloud),
+      ])
+    ) as Record<string, Task[]>;
+
+    return {
+      id: profile.id,
+      name: profile.name,
+      age: profile.age ?? undefined,
+      ageBucket: profile.ageBucket ?? undefined,
+      avatarAnimal: profile.avatarAnimal ?? undefined,
+      avatarSeed: profile.avatarSeed ?? profile.id,
+      schedule: {
+        morning: routines.morning
+          ? { start: routines.morning.startTime, end: routines.morning.endTime }
+          : { ...DEFAULT_SCHEDULE.morning },
+        evening: routines.evening
+          ? { start: routines.evening.startTime, end: routines.evening.endTime }
+          : { ...DEFAULT_SCHEDULE.evening },
+      },
+      morning: routines.morning ? tasksByRoutineId[routines.morning.id] ?? [] : [],
+      evening: routines.evening ? tasksByRoutineId[routines.evening.id] ?? [] : [],
+    };
+  });
+
+export const loadCloudHouseholdState = async (
+  household: HouseholdRecord
+): Promise<CloudHouseholdState> => {
+  const supabase = getSupabaseClient();
+  if (!supabase) {
+    throw new Error('Supabase is not configured yet.');
+  }
+
+  const childRepository = new SupabaseChildProfileRepository(supabase);
+  const routineRepository = new SupabaseRoutineRepository(supabase);
+  const childProfiles = await childRepository.listByHousehold(household.id);
+  const routinePairs = await Promise.all(
+    childProfiles.map(async (profile) => [profile.id, await routineRepository.listByChild(profile.id)] as const)
+  );
+
+  return {
+    homeScene: household.homeScene,
+    children: mapCloudHouseholdToChildren({
+      childProfiles,
+      routinesByChildId: Object.fromEntries(routinePairs),
+    }),
+  };
+};

--- a/src/lib/data/local-to-cloud-import.ts
+++ b/src/lib/data/local-to-cloud-import.ts
@@ -1,0 +1,68 @@
+import type { Child, HomeScene, RoutineType } from '@/lib/types';
+import type { HouseholdRecord } from './models';
+import { TASK_CATALOG } from '@/lib/types';
+import { SupabaseChildProfileRepository } from './supabase-child-profile-repository';
+import { SupabaseHouseholdRepository } from './supabase-household-repository';
+import { SupabaseRoutineRepository } from './supabase-routine-repository';
+import { getSupabaseClient } from '@/lib/supabase/client';
+
+const findTemplateForTask = (
+  title: string,
+  icon: string,
+  routine: RoutineType
+) =>
+  TASK_CATALOG[routine].find((task) => task.title === title && task.icon === icon) ?? null;
+
+export const importLocalFamilyToCloud = async (input: {
+  household: HouseholdRecord;
+  children: Child[];
+  homeScene: HomeScene;
+}) => {
+  const supabase = getSupabaseClient();
+  if (!supabase) {
+    throw new Error('Supabase is not configured yet.');
+  }
+
+  const householdRepository = new SupabaseHouseholdRepository(supabase);
+  const childRepository = new SupabaseChildProfileRepository(supabase);
+  const routineRepository = new SupabaseRoutineRepository(supabase);
+
+  await householdRepository.updateHomeScene(input.household.id, input.homeScene);
+
+  for (const child of input.children) {
+    const importedChild = await childRepository.upsert({
+      id: crypto.randomUUID(),
+      householdId: input.household.id,
+      name: child.name,
+      age: child.age ?? null,
+      ageBucket: child.ageBucket ?? null,
+      avatarAnimal: child.avatarAnimal ?? null,
+      avatarSeed: child.avatarSeed ?? null,
+    });
+
+    for (const routineType of ['morning', 'evening'] as const) {
+      const routine = await routineRepository.upsertRoutine({
+        id: crypto.randomUUID(),
+        childProfileId: importedChild.id,
+        type: routineType,
+        startTime: child.schedule?.[routineType].start ?? (routineType === 'morning' ? '07:00' : '17:00'),
+        endTime: child.schedule?.[routineType].end ?? (routineType === 'morning' ? '09:00' : '20:00'),
+      });
+
+      await routineRepository.replaceRoutineTasks({
+        routineId: routine.id,
+        tasks: child[routineType].map((task, index) => {
+          const matchedTemplate = findTemplateForTask(task.title, task.icon, routineType);
+
+          return {
+            taskTemplateId: matchedTemplate?.id ?? null,
+            customTitle: matchedTemplate ? null : task.title,
+            customIcon: matchedTemplate ? null : task.icon,
+            sortOrder: index,
+            isArchived: false,
+          };
+        }),
+      });
+    }
+  }
+};

--- a/src/lib/data/repositories.ts
+++ b/src/lib/data/repositories.ts
@@ -16,6 +16,7 @@ export interface HouseholdRepository {
     timezone: string;
   }): Promise<HouseholdRecord>;
   listMembers(householdId: string): Promise<HouseholdMemberRecord[]>;
+  updateHomeScene(householdId: string, homeScene: HouseholdRecord['homeScene']): Promise<HouseholdRecord>;
 }
 
 export interface ChildProfileRepository {

--- a/src/lib/data/supabase-child-profile-repository.ts
+++ b/src/lib/data/supabase-child-profile-repository.ts
@@ -1,0 +1,73 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { ChildProfileRecord } from './models';
+import type { ChildProfileRepository } from './repositories';
+
+const CHILD_PROFILES_TABLE = 'child_profiles';
+
+const mapChildProfile = (row: Record<string, unknown>): ChildProfileRecord => ({
+  id: String(row.id),
+  householdId: String(row.household_id),
+  name: String(row.name),
+  age: row.age === null || row.age === undefined ? null : Number(row.age),
+  ageBucket: (row.age_bucket === null || row.age_bucket === undefined ? null : String(row.age_bucket)) as ChildProfileRecord['ageBucket'],
+  avatarAnimal:
+    row.avatar_animal === null || row.avatar_animal === undefined ? null : String(row.avatar_animal),
+  avatarSeed: row.avatar_seed === null || row.avatar_seed === undefined ? null : String(row.avatar_seed),
+  createdAt: String(row.created_at),
+  updatedAt: String(row.updated_at),
+});
+
+const toChildProfilePayload = (profile: Omit<ChildProfileRecord, 'createdAt' | 'updatedAt'>) => ({
+  id: profile.id,
+  household_id: profile.householdId,
+  name: profile.name,
+  age: profile.age,
+  age_bucket: profile.ageBucket,
+  avatar_animal: profile.avatarAnimal,
+  avatar_seed: profile.avatarSeed,
+});
+
+export class SupabaseChildProfileRepository implements ChildProfileRepository {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async listByHousehold(householdId: string) {
+    const { data, error } = await this.supabase
+      .from(CHILD_PROFILES_TABLE)
+      .select('*')
+      .eq('household_id', householdId)
+      .order('created_at', { ascending: true });
+
+    if (error) {
+      throw error;
+    }
+
+    return (data ?? []).map(mapChildProfile);
+  }
+
+  async upsert(profile: Omit<ChildProfileRecord, 'createdAt' | 'updatedAt'>) {
+    const { data, error } = await this.supabase
+      .from(CHILD_PROFILES_TABLE)
+      .upsert(toChildProfilePayload(profile), { onConflict: 'id' })
+      .select('*')
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    return mapChildProfile(data);
+  }
+
+  async remove(childProfileId: string) {
+    const { error } = await this.supabase
+      .from(CHILD_PROFILES_TABLE)
+      .delete()
+      .eq('id', childProfileId);
+
+    if (error) {
+      throw error;
+    }
+  }
+}
+
+export { mapChildProfile };

--- a/src/lib/data/supabase-household-repository.ts
+++ b/src/lib/data/supabase-household-repository.ts
@@ -66,4 +66,19 @@ export class SupabaseHouseholdRepository implements HouseholdRepository {
 
     return (data ?? []).map(mapMember);
   }
+
+  async updateHomeScene(householdId: string, homeScene: HouseholdRecord['homeScene']) {
+    const { data, error } = await this.supabase
+      .from(HOUSEHOLDS_TABLE)
+      .update({ home_scene: homeScene })
+      .eq('id', householdId)
+      .select('*')
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    return mapHousehold(data);
+  }
 }

--- a/src/lib/data/supabase-routine-repository.ts
+++ b/src/lib/data/supabase-routine-repository.ts
@@ -1,0 +1,127 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { RoutineRecord, RoutineTaskRecord } from './models';
+import type { RoutineRepository } from './repositories';
+
+const ROUTINES_TABLE = 'routines';
+const ROUTINE_TASKS_TABLE = 'routine_tasks';
+
+const mapRoutine = (row: Record<string, unknown>): RoutineRecord => ({
+  id: String(row.id),
+  childProfileId: String(row.child_profile_id),
+  type: String(row.type) as RoutineRecord['type'],
+  startTime: String(row.start_time),
+  endTime: String(row.end_time),
+  createdAt: String(row.created_at),
+  updatedAt: String(row.updated_at),
+});
+
+const mapRoutineTask = (row: Record<string, unknown>): RoutineTaskRecord => ({
+  id: String(row.id),
+  routineId: String(row.routine_id),
+  taskTemplateId:
+    row.task_template_id === null || row.task_template_id === undefined ? null : String(row.task_template_id),
+  customTitle: row.custom_title === null || row.custom_title === undefined ? null : String(row.custom_title),
+  customIcon: row.custom_icon === null || row.custom_icon === undefined ? null : String(row.custom_icon) as RoutineTaskRecord['customIcon'],
+  sortOrder: Number(row.sort_order),
+  isArchived: Boolean(row.is_archived),
+  createdAt: String(row.created_at),
+  updatedAt: String(row.updated_at),
+});
+
+const toRoutinePayload = (routine: Omit<RoutineRecord, 'createdAt' | 'updatedAt'>) => ({
+  id: routine.id,
+  child_profile_id: routine.childProfileId,
+  type: routine.type,
+  start_time: routine.startTime,
+  end_time: routine.endTime,
+});
+
+export class SupabaseRoutineRepository implements RoutineRepository {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async listByChild(childProfileId: string) {
+    const { data: routineRows, error: routineError } = await this.supabase
+      .from(ROUTINES_TABLE)
+      .select('*')
+      .eq('child_profile_id', childProfileId)
+      .order('created_at', { ascending: true });
+
+    if (routineError) {
+      throw routineError;
+    }
+
+    const routines = (routineRows ?? []).map(mapRoutine);
+    if (routines.length === 0) {
+      return { routines, routineTasks: [] };
+    }
+
+    const { data: taskRows, error: taskError } = await this.supabase
+      .from(ROUTINE_TASKS_TABLE)
+      .select('*')
+      .in('routine_id', routines.map((routine) => routine.id))
+      .order('sort_order', { ascending: true });
+
+    if (taskError) {
+      throw taskError;
+    }
+
+    return {
+      routines,
+      routineTasks: (taskRows ?? []).map(mapRoutineTask),
+    };
+  }
+
+  async upsertRoutine(input: Omit<RoutineRecord, 'createdAt' | 'updatedAt'>) {
+    const { data, error } = await this.supabase
+      .from(ROUTINES_TABLE)
+      .upsert(toRoutinePayload(input), { onConflict: 'child_profile_id,type' })
+      .select('*')
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    return mapRoutine(data);
+  }
+
+  async replaceRoutineTasks(input: {
+    routineId: string;
+    tasks: Array<Omit<RoutineTaskRecord, 'id' | 'routineId' | 'createdAt' | 'updatedAt'>>;
+  }) {
+    const { error: deleteError } = await this.supabase
+      .from(ROUTINE_TASKS_TABLE)
+      .delete()
+      .eq('routine_id', input.routineId);
+
+    if (deleteError) {
+      throw deleteError;
+    }
+
+    if (input.tasks.length === 0) {
+      return [];
+    }
+
+    const payload = input.tasks.map((task, index) => ({
+      routine_id: input.routineId,
+      task_template_id: task.taskTemplateId,
+      custom_title: task.customTitle,
+      custom_icon: task.customIcon,
+      sort_order: task.sortOrder ?? index,
+      is_archived: task.isArchived,
+    }));
+
+    const { data, error } = await this.supabase
+      .from(ROUTINE_TASKS_TABLE)
+      .insert(payload)
+      .select('*');
+
+    if (error) {
+      throw error;
+    }
+
+    return (data ?? []).map(mapRoutineTask).sort((left, right) => left.sortOrder - right.sortOrder);
+  }
+}
+
+export { mapRoutine, mapRoutineTask };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,6 +28,6 @@ export type Child = {
   evening: Task[];
 };
 
-export type AppView = 'account' | 'setup' | 'home' | 'routine' | 'parent';
+export type AppView = 'account' | 'import' | 'setup' | 'home' | 'routine' | 'parent';
 
 export { AGE_BUCKETS, DEFAULT_CHILDREN, groupTasksByAge, ICON_OPTIONS, TASK_CATALOG, TASK_CATALOG_BY_ID, TASK_LIBRARY };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect, useCallback } from 'react';
 import { ChildSelector } from '@/components/ChildSelector';
 import { AccountEntryScreen } from '@/components/AccountEntryScreen';
+import { ImportFamilySetupScreen } from '@/components/ImportFamilySetupScreen';
 import { InitialSetup } from '@/components/InitialSetup';
 import { RoutineView } from '@/components/RoutineView';
 import { ParentSettings } from '@/components/ParentSettings';
 import { useAuth } from '@/lib/auth/use-auth';
 import { loadCloudHouseholdState } from '@/lib/data/cloud-household-state';
+import { importLocalFamilyToCloud } from '@/lib/data/local-to-cloud-import';
 import type { AppView, Child, HomeScene, RoutineType } from '@/lib/types';
 import {
   clearLocalAppState,
@@ -70,6 +72,8 @@ const Index = () => {
   const [activeChildId, setActiveChildId] = useState<string | null>(null);
   const [setupComplete, setSetupComplete] = useState(false);
   const [isReady, setIsReady] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [isImporting, setIsImporting] = useState(false);
   const [now, setNow] = useState(() => new Date());
   const [homeScene, setHomeScene] = useState<HomeScene>('bike');
 
@@ -100,7 +104,34 @@ const Index = () => {
 
     const bootstrap = async () => {
       const storedState = loadLocalAppState();
+      let cloudState: Awaited<ReturnType<typeof loadCloudHouseholdState>> | null = null;
+
+      if (authStatus === 'signed_in' && householdStatus === 'ready' && household) {
+        try {
+          cloudState = await loadCloudHouseholdState(household);
+        } catch (error) {
+          console.warn('Could not load cloud household state.', error);
+        }
+      }
+
       if (storedState) {
+        if (
+          authStatus === 'signed_in' &&
+          householdStatus === 'ready' &&
+          household &&
+          storedState.children.length > 0 &&
+          (cloudState?.children.length ?? 0) === 0
+        ) {
+          if (isMounted) {
+            setChildren(storedState.children);
+            setHomeScene(storedState.homeScene);
+            setSetupComplete(storedState.setupComplete);
+            setView('import');
+            setIsReady(true);
+          }
+          return;
+        }
+
         const today = new Date().toDateString();
         if (storedState.lastReset !== today) {
           const reset = storedState.children.map((c: Child) => ({
@@ -130,20 +161,15 @@ const Index = () => {
         return;
       }
 
-      if (authStatus === 'signed_in' && householdStatus === 'ready' && household) {
-        try {
-          const cloudState = await loadCloudHouseholdState(household);
-          if (!isMounted) return;
+      if (cloudState) {
+        if (!isMounted) return;
 
-          setChildren(cloudState.children);
-          setHomeScene(cloudState.homeScene);
-          setSetupComplete(cloudState.children.length > 0);
-          setView(cloudState.children.length > 0 ? 'home' : 'setup');
-          setIsReady(true);
-          return;
-        } catch (error) {
-          console.warn('Could not load cloud household state.', error);
-        }
+        setChildren(cloudState.children);
+        setHomeScene(cloudState.homeScene);
+        setSetupComplete(cloudState.children.length > 0);
+        setView(cloudState.children.length > 0 ? 'home' : 'setup');
+        setIsReady(true);
+        return;
       }
 
       if (isMounted) {
@@ -233,6 +259,47 @@ const Index = () => {
 
   if (view === 'account') {
     return <AccountEntryScreen onContinueLocalSetup={() => setView('setup')} />;
+  }
+
+  if (view === 'import') {
+    return (
+      <ImportFamilySetupScreen
+        isImporting={isImporting}
+        error={importError}
+        onImport={() => {
+          if (!household) return;
+
+          setIsImporting(true);
+          setImportError(null);
+
+          void importLocalFamilyToCloud({
+            household,
+            children,
+            homeScene,
+          })
+            .then(() => {
+              setSetupComplete(children.length > 0);
+              setView(children.length > 0 ? 'home' : 'setup');
+            })
+            .catch((error) => {
+              setImportError(
+                error instanceof Error ? error.message : 'Could not import this family setup right now.'
+              );
+            })
+            .finally(() => {
+              setIsImporting(false);
+            });
+        }}
+        onStartFresh={() => {
+          clearLocalAppState();
+          setChildren(createSetupChildren());
+          setSetupComplete(false);
+          setHomeScene('bike');
+          setView('setup');
+          setImportError(null);
+        }}
+      />
+    );
   }
 
   if (view === 'setup') {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,6 +5,7 @@ import { InitialSetup } from '@/components/InitialSetup';
 import { RoutineView } from '@/components/RoutineView';
 import { ParentSettings } from '@/components/ParentSettings';
 import { useAuth } from '@/lib/auth/use-auth';
+import { loadCloudHouseholdState } from '@/lib/data/cloud-household-state';
 import type { AppView, Child, HomeScene, RoutineType } from '@/lib/types';
 import {
   clearLocalAppState,
@@ -63,7 +64,7 @@ const getDisplayRoutine = (child: Child, now: Date): RoutineType => {
 const createSetupChildren = (): Child[] => [];
 
 const Index = () => {
-  const { status: authStatus } = useAuth();
+  const { status: authStatus, householdStatus, household } = useAuth();
   const [view, setView] = useState<AppView>('setup');
   const [children, setChildren] = useState<Child[]>(createSetupChildren);
   const [activeChildId, setActiveChildId] = useState<string | null>(null);
@@ -91,41 +92,75 @@ const Index = () => {
 
   // Load from localStorage once auth has settled so startup can be account-aware.
   useEffect(() => {
-    if (authStatus === 'loading') {
+    if (authStatus === 'loading' || (authStatus === 'signed_in' && householdStatus === 'loading')) {
       return;
     }
 
-    const storedState = loadLocalAppState();
-    if (storedState) {
-      const today = new Date().toDateString();
-      if (storedState.lastReset !== today) {
-        const reset = storedState.children.map((c: Child) => ({
-          ...c,
-          morning: c.morning.map((t: Child['morning'][0]) => ({ ...t, completed: false })),
-          evening: c.evening.map((t: Child['evening'][0]) => ({ ...t, completed: false })),
-        }));
-        setChildren(reset);
-      } else {
-        setChildren(storedState.children);
-      }
-      setSetupComplete(storedState.setupComplete);
-      setHomeScene(storedState.homeScene);
-      setView(
-        storedState.setupComplete
-          ? 'home'
-          : storedState.children.length > 0 || authStatus === 'signed_in'
-            ? 'setup'
-            : 'account'
-      );
-    } else {
-      setChildren(createSetupChildren());
-      setSetupComplete(false);
-      setHomeScene('bike');
-      setView(authStatus === 'signed_in' ? 'setup' : 'account');
-    }
+    let isMounted = true;
 
-    setIsReady(true);
-  }, [authStatus]);
+    const bootstrap = async () => {
+      const storedState = loadLocalAppState();
+      if (storedState) {
+        const today = new Date().toDateString();
+        if (storedState.lastReset !== today) {
+          const reset = storedState.children.map((c: Child) => ({
+            ...c,
+            morning: c.morning.map((t: Child['morning'][0]) => ({ ...t, completed: false })),
+            evening: c.evening.map((t: Child['evening'][0]) => ({ ...t, completed: false })),
+          }));
+          if (isMounted) {
+            setChildren(reset);
+          }
+        } else if (isMounted) {
+          setChildren(storedState.children);
+        }
+
+        if (isMounted) {
+          setSetupComplete(storedState.setupComplete);
+          setHomeScene(storedState.homeScene);
+          setView(
+            storedState.setupComplete
+              ? 'home'
+              : storedState.children.length > 0 || authStatus === 'signed_in'
+                ? 'setup'
+                : 'account'
+          );
+          setIsReady(true);
+        }
+        return;
+      }
+
+      if (authStatus === 'signed_in' && householdStatus === 'ready' && household) {
+        try {
+          const cloudState = await loadCloudHouseholdState(household);
+          if (!isMounted) return;
+
+          setChildren(cloudState.children);
+          setHomeScene(cloudState.homeScene);
+          setSetupComplete(cloudState.children.length > 0);
+          setView(cloudState.children.length > 0 ? 'home' : 'setup');
+          setIsReady(true);
+          return;
+        } catch (error) {
+          console.warn('Could not load cloud household state.', error);
+        }
+      }
+
+      if (isMounted) {
+        setChildren(createSetupChildren());
+        setSetupComplete(false);
+        setHomeScene('bike');
+        setView(authStatus === 'signed_in' ? 'setup' : 'account');
+        setIsReady(true);
+      }
+    };
+
+    void bootstrap();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [authStatus, household, householdStatus]);
 
   useEffect(() => {
     const timer = window.setInterval(() => {

--- a/src/test/cloudHouseholdState.test.ts
+++ b/src/test/cloudHouseholdState.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { mapCloudHouseholdToChildren } from '@/lib/data/cloud-household-state';
+
+describe('mapCloudHouseholdToChildren', () => {
+  it('maps cloud child profiles, routines, and template tasks into app children', () => {
+    expect(
+      mapCloudHouseholdToChildren({
+        childProfiles: [
+          {
+            id: 'child-1',
+            householdId: 'house-1',
+            name: 'Lily',
+            age: 5,
+            ageBucket: '4-6',
+            avatarAnimal: 'cat',
+            avatarSeed: 'seed-1',
+            createdAt: '2026-04-20T10:00:00Z',
+            updatedAt: '2026-04-20T10:00:00Z',
+          },
+        ],
+        routinesByChildId: {
+          'child-1': {
+            routines: [
+              {
+                id: 'routine-morning',
+                childProfileId: 'child-1',
+                type: 'morning',
+                startTime: '07:30',
+                endTime: '08:30',
+                createdAt: '2026-04-20T10:00:00Z',
+                updatedAt: '2026-04-20T10:00:00Z',
+              },
+              {
+                id: 'routine-evening',
+                childProfileId: 'child-1',
+                type: 'evening',
+                startTime: '18:00',
+                endTime: '19:30',
+                createdAt: '2026-04-20T10:00:00Z',
+                updatedAt: '2026-04-20T10:00:00Z',
+              },
+            ],
+            routineTasks: [
+              {
+                id: 'task-2',
+                routineId: 'routine-morning',
+                taskTemplateId: null,
+                customTitle: 'Water plant',
+                customIcon: 'sparkles',
+                sortOrder: 1,
+                isArchived: false,
+                createdAt: '2026-04-20T10:00:00Z',
+                updatedAt: '2026-04-20T10:00:00Z',
+              },
+              {
+                id: 'task-1',
+                routineId: 'routine-morning',
+                taskTemplateId: 'brush-teeth',
+                customTitle: null,
+                customIcon: null,
+                sortOrder: 0,
+                isArchived: false,
+                createdAt: '2026-04-20T10:00:00Z',
+                updatedAt: '2026-04-20T10:00:00Z',
+              },
+              {
+                id: 'task-3',
+                routineId: 'routine-evening',
+                taskTemplateId: 'go-to-bed',
+                customTitle: null,
+                customIcon: null,
+                sortOrder: 0,
+                isArchived: false,
+                createdAt: '2026-04-20T10:00:00Z',
+                updatedAt: '2026-04-20T10:00:00Z',
+              },
+            ],
+          },
+        },
+      })
+    ).toEqual([
+      {
+        id: 'child-1',
+        name: 'Lily',
+        age: 5,
+        ageBucket: '4-6',
+        avatarAnimal: 'cat',
+        avatarSeed: 'seed-1',
+        schedule: {
+          morning: { start: '07:30', end: '08:30' },
+          evening: { start: '18:00', end: '19:30' },
+        },
+        morning: [
+          { id: 'task-1', title: 'Brush teeth', icon: 'brush', completed: false },
+          { id: 'task-2', title: 'Water plant', icon: 'sparkles', completed: false },
+        ],
+        evening: [{ id: 'task-3', title: 'Go to bed', icon: 'moon-star', completed: false }],
+      },
+    ]);
+  });
+});

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -20,6 +20,9 @@ const authState = {
 const { loadCloudHouseholdState } = vi.hoisted(() => ({
   loadCloudHouseholdState: vi.fn(),
 }));
+const { importLocalFamilyToCloud } = vi.hoisted(() => ({
+  importLocalFamilyToCloud: vi.fn(),
+}));
 
 vi.mock("@/lib/auth/use-auth", () => ({
   useAuth: () => authState,
@@ -27,6 +30,9 @@ vi.mock("@/lib/auth/use-auth", () => ({
 
 vi.mock("@/lib/data/cloud-household-state", () => ({
   loadCloudHouseholdState,
+}));
+vi.mock("@/lib/data/local-to-cloud-import", () => ({
+  importLocalFamilyToCloud,
 }));
 
 const today = () => new Date().toDateString();
@@ -155,6 +161,32 @@ vi.mock("@/components/AccountEntryScreen", () => ({
   ),
 }));
 
+vi.mock("@/components/ImportFamilySetupScreen", () => ({
+  ImportFamilySetupScreen: ({
+    onImport,
+    onStartFresh,
+    isImporting,
+    error,
+  }: {
+    onImport: () => void;
+    onStartFresh: () => void;
+    isImporting: boolean;
+    error?: string | null;
+  }) => (
+    <div>
+      <div data-testid="import-family-setup-screen">import-family-setup</div>
+      <div data-testid="import-state">{String(isImporting)}</div>
+      <div data-testid="import-error">{error ?? ""}</div>
+      <button type="button" onClick={onImport}>
+        import-family-setup
+      </button>
+      <button type="button" onClick={onStartFresh}>
+        start-fresh-instead
+      </button>
+    </div>
+  ),
+}));
+
 const createStoredState = (completed: boolean, lastReset: string) => ({
   children: [
     {
@@ -180,6 +212,7 @@ describe("Index", () => {
     authState.household = null;
     authState.error = null;
     loadCloudHouseholdState.mockReset();
+    importLocalFamilyToCloud.mockReset();
     authState.clearError.mockReset();
     authState.sendEmailLink.mockReset();
     authState.retryHousehold.mockReset();
@@ -304,6 +337,112 @@ describe("Index", () => {
 
     expect(await screen.findByTestId("child-count")).toHaveTextContent("1");
     expect(loadCloudHouseholdState).toHaveBeenCalledWith(authState.household);
+  });
+
+  it("shows an import decision when a signed-in device has local setup and cloud is empty", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [],
+    });
+    localStorage.setItem(
+      "routine_stars_data",
+      JSON.stringify({
+        ...createStoredState(false, today()),
+        setupComplete: true,
+        homeScene: "school",
+      })
+    );
+
+    render(<Index />);
+
+    expect(await screen.findByTestId("import-family-setup-screen")).toBeInTheDocument();
+  });
+
+  it("imports local setup into the cloud household when requested", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [],
+    });
+    importLocalFamilyToCloud.mockResolvedValue(undefined);
+    localStorage.setItem(
+      "routine_stars_data",
+      JSON.stringify({
+        ...createStoredState(false, today()),
+        setupComplete: true,
+        homeScene: "school",
+      })
+    );
+
+    render(<Index />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "import-family-setup" }));
+
+    await waitFor(() => {
+      expect(importLocalFamilyToCloud).toHaveBeenCalledWith(
+        expect.objectContaining({
+          household: authState.household,
+          homeScene: "school",
+        })
+      );
+    });
+
+    expect(await screen.findByTestId("child-count")).toHaveTextContent("1");
+  });
+
+  it("lets a parent start fresh instead of importing existing local setup", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [],
+    });
+    localStorage.setItem(
+      "routine_stars_data",
+      JSON.stringify({
+        ...createStoredState(false, today()),
+        setupComplete: true,
+      })
+    );
+
+    render(<Index />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "start-fresh-instead" }));
+
+    expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
   });
 
   it("re-opens setup when saved data is marked incomplete", async () => {

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -17,8 +17,16 @@ const authState = {
   signOut: vi.fn(),
 };
 
+const { loadCloudHouseholdState } = vi.hoisted(() => ({
+  loadCloudHouseholdState: vi.fn(),
+}));
+
 vi.mock("@/lib/auth/use-auth", () => ({
   useAuth: () => authState,
+}));
+
+vi.mock("@/lib/data/cloud-household-state", () => ({
+  loadCloudHouseholdState,
 }));
 
 const today = () => new Date().toDateString();
@@ -171,6 +179,7 @@ describe("Index", () => {
     authState.householdStatus = "idle";
     authState.household = null;
     authState.error = null;
+    loadCloudHouseholdState.mockReset();
     authState.clearError.mockReset();
     authState.sendEmailLink.mockReset();
     authState.retryHousehold.mockReset();
@@ -264,6 +273,37 @@ describe("Index", () => {
     render(<Index />);
 
     expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
+  });
+
+  it("hydrates cloud household data on a fresh signed-in device", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [
+        {
+          id: "1",
+          name: "Lily",
+          morning: [{ id: "m1", title: "Make bed", icon: "bed", completed: false }],
+          evening: [{ id: "e1", title: "Go to bed", icon: "moon-star", completed: false }],
+        },
+      ],
+    });
+
+    render(<Index />);
+
+    expect(await screen.findByTestId("child-count")).toHaveTextContent("1");
+    expect(loadCloudHouseholdState).toHaveBeenCalledWith(authState.household);
   });
 
   it("re-opens setup when saved data is marked incomplete", async () => {

--- a/src/test/localToCloudImport.test.ts
+++ b/src/test/localToCloudImport.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { importLocalFamilyToCloud } from '@/lib/data/local-to-cloud-import';
+
+const {
+  getSupabaseClient,
+  updateHomeScene,
+  upsertChildProfile,
+  upsertRoutine,
+  replaceRoutineTasks,
+} = vi.hoisted(() => ({
+  getSupabaseClient: vi.fn(),
+  updateHomeScene: vi.fn(),
+  upsertChildProfile: vi.fn(),
+  upsertRoutine: vi.fn(),
+  replaceRoutineTasks: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/client', () => ({
+  getSupabaseClient,
+}));
+
+vi.mock('@/lib/data/supabase-household-repository', () => ({
+  SupabaseHouseholdRepository: class {
+    updateHomeScene = updateHomeScene;
+  },
+}));
+
+vi.mock('@/lib/data/supabase-child-profile-repository', () => ({
+  SupabaseChildProfileRepository: class {
+    upsert = upsertChildProfile;
+  },
+}));
+
+vi.mock('@/lib/data/supabase-routine-repository', () => ({
+  SupabaseRoutineRepository: class {
+    upsertRoutine = upsertRoutine;
+    replaceRoutineTasks = replaceRoutineTasks;
+  },
+}));
+
+describe('importLocalFamilyToCloud', () => {
+  beforeEach(() => {
+    getSupabaseClient.mockReturnValue({});
+    updateHomeScene.mockReset();
+    upsertChildProfile.mockReset();
+    upsertRoutine.mockReset();
+    replaceRoutineTasks.mockReset();
+    updateHomeScene.mockResolvedValue(undefined);
+    upsertChildProfile.mockResolvedValue({
+      id: 'cloud-child-1',
+    });
+    upsertRoutine
+      .mockResolvedValueOnce({ id: 'cloud-routine-morning' })
+      .mockResolvedValueOnce({ id: 'cloud-routine-evening' });
+    replaceRoutineTasks.mockResolvedValue([]);
+  });
+
+  it('imports local children, schedules, and tasks into the cloud household', async () => {
+    await importLocalFamilyToCloud({
+      household: {
+        id: 'house-1',
+        name: 'Routine Stars Family',
+        timezone: 'Europe/Madrid',
+        homeScene: 'bike',
+        createdByUserId: 'user-1',
+        createdAt: '2026-04-20T10:00:00Z',
+        updatedAt: '2026-04-20T10:00:00Z',
+      },
+      homeScene: 'school',
+      children: [
+        {
+          id: 'local-child-1',
+          name: 'Lily',
+          age: 5,
+          ageBucket: '4-6',
+          avatarAnimal: 'cat',
+          avatarSeed: 'seed-1',
+          schedule: {
+            morning: { start: '07:30', end: '08:30' },
+            evening: { start: '18:00', end: '19:30' },
+          },
+          morning: [
+            { id: 'm1', title: 'Brush teeth', icon: 'brush', completed: true },
+            { id: 'm2', title: 'Water plant', icon: 'sparkles', completed: false },
+          ],
+          evening: [{ id: 'e1', title: 'Go to bed', icon: 'moon-star', completed: false }],
+        },
+      ],
+    });
+
+    expect(updateHomeScene).toHaveBeenCalledWith('house-1', 'school');
+    expect(upsertChildProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        householdId: 'house-1',
+        name: 'Lily',
+      })
+    );
+    expect(upsertRoutine).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        childProfileId: 'cloud-child-1',
+        type: 'morning',
+        startTime: '07:30',
+        endTime: '08:30',
+      })
+    );
+    expect(replaceRoutineTasks).toHaveBeenNthCalledWith(1, {
+      routineId: 'cloud-routine-morning',
+      tasks: [
+        {
+          taskTemplateId: 'brush-teeth',
+          customTitle: null,
+          customIcon: null,
+          sortOrder: 0,
+          isArchived: false,
+        },
+        {
+          taskTemplateId: null,
+          customTitle: 'Water plant',
+          customIcon: 'sparkles',
+          sortOrder: 1,
+          isArchived: false,
+        },
+      ],
+    });
+  });
+});

--- a/src/test/supabaseChildProfileRepository.test.ts
+++ b/src/test/supabaseChildProfileRepository.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SupabaseChildProfileRepository } from '@/lib/data/supabase-child-profile-repository';
+
+const createSupabaseClient = (fromImpl: (table: string) => unknown) =>
+  ({
+    from: vi.fn(fromImpl),
+  }) as never;
+
+describe('SupabaseChildProfileRepository', () => {
+  it('lists child profiles by household and maps the row shape', async () => {
+    const order = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'child-1',
+          household_id: 'house-1',
+          name: 'Lily',
+          age: 5,
+          age_bucket: '4-6',
+          avatar_animal: 'cat',
+          avatar_seed: 'seed-1',
+          created_at: '2026-04-20T10:00:00Z',
+          updated_at: '2026-04-20T10:00:00Z',
+        },
+      ],
+      error: null,
+    });
+    const eq = vi.fn(() => ({ order }));
+    const select = vi.fn(() => ({ eq }));
+    const repository = new SupabaseChildProfileRepository(
+      createSupabaseClient(() => ({ select }))
+    );
+
+    await expect(repository.listByHousehold('house-1')).resolves.toEqual([
+      {
+        id: 'child-1',
+        householdId: 'house-1',
+        name: 'Lily',
+        age: 5,
+        ageBucket: '4-6',
+        avatarAnimal: 'cat',
+        avatarSeed: 'seed-1',
+        createdAt: '2026-04-20T10:00:00Z',
+        updatedAt: '2026-04-20T10:00:00Z',
+      },
+    ]);
+
+    expect(eq).toHaveBeenCalledWith('household_id', 'house-1');
+    expect(order).toHaveBeenCalledWith('created_at', { ascending: true });
+  });
+
+  it('upserts child profiles using snake_case payloads', async () => {
+    const single = vi.fn().mockResolvedValue({
+      data: {
+        id: 'child-1',
+        household_id: 'house-1',
+        name: 'Lily',
+        age: 5,
+        age_bucket: '4-6',
+        avatar_animal: null,
+        avatar_seed: 'seed-1',
+        created_at: '2026-04-20T10:00:00Z',
+        updated_at: '2026-04-20T10:05:00Z',
+      },
+      error: null,
+    });
+    const select = vi.fn(() => ({ single }));
+    const upsert = vi.fn(() => ({ select }));
+    const repository = new SupabaseChildProfileRepository(
+      createSupabaseClient(() => ({ upsert }))
+    );
+
+    await expect(
+      repository.upsert({
+        id: 'child-1',
+        householdId: 'house-1',
+        name: 'Lily',
+        age: 5,
+        ageBucket: '4-6',
+        avatarAnimal: null,
+        avatarSeed: 'seed-1',
+      })
+    ).resolves.toMatchObject({
+      id: 'child-1',
+      householdId: 'house-1',
+      name: 'Lily',
+    });
+
+    expect(upsert).toHaveBeenCalledWith(
+      {
+        id: 'child-1',
+        household_id: 'house-1',
+        name: 'Lily',
+        age: 5,
+        age_bucket: '4-6',
+        avatar_animal: null,
+        avatar_seed: 'seed-1',
+      },
+      { onConflict: 'id' }
+    );
+  });
+});

--- a/src/test/supabaseRoutineRepository.test.ts
+++ b/src/test/supabaseRoutineRepository.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SupabaseRoutineRepository } from '@/lib/data/supabase-routine-repository';
+
+const createSupabaseClient = (responses: Record<string, unknown>) =>
+  ({
+    from: vi.fn((table: string) => responses[table]),
+  }) as never;
+
+describe('SupabaseRoutineRepository', () => {
+  it('lists routines and their tasks for a child profile', async () => {
+    const routineOrder = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'routine-1',
+          child_profile_id: 'child-1',
+          type: 'morning',
+          start_time: '07:00',
+          end_time: '09:00',
+          created_at: '2026-04-20T10:00:00Z',
+          updated_at: '2026-04-20T10:00:00Z',
+        },
+      ],
+      error: null,
+    });
+    const taskOrder = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'task-1',
+          routine_id: 'routine-1',
+          task_template_id: 'brush-teeth',
+          custom_title: null,
+          custom_icon: null,
+          sort_order: 0,
+          is_archived: false,
+          created_at: '2026-04-20T10:00:00Z',
+          updated_at: '2026-04-20T10:00:00Z',
+        },
+      ],
+      error: null,
+    });
+    const repository = new SupabaseRoutineRepository(
+      createSupabaseClient({
+        routines: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({ order: routineOrder })),
+          })),
+        },
+        routine_tasks: {
+          select: vi.fn(() => ({
+            in: vi.fn(() => ({ order: taskOrder })),
+          })),
+        },
+      })
+    );
+
+    await expect(repository.listByChild('child-1')).resolves.toEqual({
+      routines: [
+        {
+          id: 'routine-1',
+          childProfileId: 'child-1',
+          type: 'morning',
+          startTime: '07:00',
+          endTime: '09:00',
+          createdAt: '2026-04-20T10:00:00Z',
+          updatedAt: '2026-04-20T10:00:00Z',
+        },
+      ],
+      routineTasks: [
+        {
+          id: 'task-1',
+          routineId: 'routine-1',
+          taskTemplateId: 'brush-teeth',
+          customTitle: null,
+          customIcon: null,
+          sortOrder: 0,
+          isArchived: false,
+          createdAt: '2026-04-20T10:00:00Z',
+          updatedAt: '2026-04-20T10:00:00Z',
+        },
+      ],
+    });
+  });
+
+  it('upserts routines using the child/type unique key', async () => {
+    const single = vi.fn().mockResolvedValue({
+      data: {
+        id: 'routine-1',
+        child_profile_id: 'child-1',
+        type: 'morning',
+        start_time: '07:00',
+        end_time: '09:00',
+        created_at: '2026-04-20T10:00:00Z',
+        updated_at: '2026-04-20T10:05:00Z',
+      },
+      error: null,
+    });
+    const select = vi.fn(() => ({ single }));
+    const upsert = vi.fn(() => ({ select }));
+    const repository = new SupabaseRoutineRepository(
+      createSupabaseClient({
+        routines: { upsert },
+      })
+    );
+
+    await expect(
+      repository.upsertRoutine({
+        id: 'routine-1',
+        childProfileId: 'child-1',
+        type: 'morning',
+        startTime: '07:00',
+        endTime: '09:00',
+      })
+    ).resolves.toMatchObject({
+      id: 'routine-1',
+      childProfileId: 'child-1',
+      type: 'morning',
+    });
+
+    expect(upsert).toHaveBeenCalledWith(
+      {
+        id: 'routine-1',
+        child_profile_id: 'child-1',
+        type: 'morning',
+        start_time: '07:00',
+        end_time: '09:00',
+      },
+      { onConflict: 'child_profile_id,type' }
+    );
+  });
+
+  it('replaces routine tasks by clearing old rows and inserting the new set', async () => {
+    const deleteEq = vi.fn().mockResolvedValue({ error: null });
+    const insertSelect = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'task-2',
+          routine_id: 'routine-1',
+          task_template_id: null,
+          custom_title: 'Pack lunch',
+          custom_icon: 'chef-hat',
+          sort_order: 1,
+          is_archived: false,
+          created_at: '2026-04-20T10:00:00Z',
+          updated_at: '2026-04-20T10:00:00Z',
+        },
+        {
+          id: 'task-1',
+          routine_id: 'routine-1',
+          task_template_id: 'brush-teeth',
+          custom_title: null,
+          custom_icon: null,
+          sort_order: 0,
+          is_archived: false,
+          created_at: '2026-04-20T10:00:00Z',
+          updated_at: '2026-04-20T10:00:00Z',
+        },
+      ],
+      error: null,
+    });
+    const insert = vi.fn(() => ({ select: insertSelect }));
+    const repository = new SupabaseRoutineRepository(
+      createSupabaseClient({
+        routine_tasks: {
+          delete: vi.fn(() => ({ eq: deleteEq })),
+          insert,
+        },
+      })
+    );
+
+    await expect(
+      repository.replaceRoutineTasks({
+        routineId: 'routine-1',
+        tasks: [
+          {
+            taskTemplateId: 'brush-teeth',
+            customTitle: null,
+            customIcon: null,
+            sortOrder: 0,
+            isArchived: false,
+          },
+          {
+            taskTemplateId: null,
+            customTitle: 'Pack lunch',
+            customIcon: 'chef-hat',
+            sortOrder: 1,
+            isArchived: false,
+          },
+        ],
+      })
+    ).resolves.toEqual([
+      expect.objectContaining({ id: 'task-1', sortOrder: 0 }),
+      expect.objectContaining({ id: 'task-2', sortOrder: 1 }),
+    ]);
+
+    expect(deleteEq).toHaveBeenCalledWith('routine_id', 'routine-1');
+    expect(insert).toHaveBeenCalledWith([
+      {
+        routine_id: 'routine-1',
+        task_template_id: 'brush-teeth',
+        custom_title: null,
+        custom_icon: null,
+        sort_order: 0,
+        is_archived: false,
+      },
+      {
+        routine_id: 'routine-1',
+        task_template_id: null,
+        custom_title: 'Pack lunch',
+        custom_icon: 'chef-hat',
+        sort_order: 1,
+        is_archived: false,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
Adds the first explicit import/start-fresh decision after sign-in on devices that already have local family data, plus the initial local-to-cloud import implementation for household setup.

## What changed
- adds an import decision screen for signed-in devices with local setup and an empty cloud household
- adds a local-to-cloud import helper for children, routines, schedules, tasks, and home scene
- updates bootstrap to route into the import decision instead of silently choosing local or cloud
- adds tests for import decisions and import payload mapping

## Why
Parents need a safe and explicit way to bring an existing device setup into their account without silent merges or confusing bootstrap behavior.

## Validation
- `npm test -- --run`

## Related issues
- Addresses #14
- Addresses #17
- Supports #18