### PR TITLE
[codex] Sync household configuration changes to cloud

### DIFF
--- a/src/lib/data/cloud-household-write.ts
+++ b/src/lib/data/cloud-household-write.ts
@@ -1,0 +1,80 @@
+import type { Child, HomeScene, RoutineType } from '@/lib/types';
+import type { HouseholdRecord } from './models';
+import { TASK_CATALOG } from '@/lib/types';
+import { SupabaseChildProfileRepository } from './supabase-child-profile-repository';
+import { SupabaseHouseholdRepository } from './supabase-household-repository';
+import { SupabaseRoutineRepository } from './supabase-routine-repository';
+import { getSupabaseClient } from '@/lib/supabase/client';
+
+const findTemplateForTask = (
+  title: string,
+  icon: string,
+  routine: RoutineType
+) =>
+  TASK_CATALOG[routine].find((task) => task.title === title && task.icon === icon) ?? null;
+
+export const saveHouseholdConfigToCloud = async (input: {
+  household: HouseholdRecord;
+  children: Child[];
+  homeScene: HomeScene;
+  removeMissingChildren?: boolean;
+}) => {
+  const supabase = getSupabaseClient();
+  if (!supabase) {
+    throw new Error('Supabase is not configured yet.');
+  }
+
+  const householdRepository = new SupabaseHouseholdRepository(supabase);
+  const childRepository = new SupabaseChildProfileRepository(supabase);
+  const routineRepository = new SupabaseRoutineRepository(supabase);
+
+  await householdRepository.updateHomeScene(input.household.id, input.homeScene);
+
+  if (input.removeMissingChildren) {
+    const existingChildren = await childRepository.listByHousehold(input.household.id);
+    const localChildIds = new Set(input.children.map((child) => child.id));
+
+    await Promise.all(
+      existingChildren
+        .filter((childProfile) => !localChildIds.has(childProfile.id))
+        .map((childProfile) => childRepository.remove(childProfile.id))
+    );
+  }
+
+  for (const child of input.children) {
+    const savedChild = await childRepository.upsert({
+      id: child.id,
+      householdId: input.household.id,
+      name: child.name,
+      age: child.age ?? null,
+      ageBucket: child.ageBucket ?? null,
+      avatarAnimal: child.avatarAnimal ?? null,
+      avatarSeed: child.avatarSeed ?? null,
+    });
+
+    for (const routineType of ['morning', 'evening'] as const) {
+      const routine = await routineRepository.upsertRoutine({
+        id: `${savedChild.id}-${routineType}`,
+        childProfileId: savedChild.id,
+        type: routineType,
+        startTime: child.schedule?.[routineType].start ?? (routineType === 'morning' ? '07:00' : '17:00'),
+        endTime: child.schedule?.[routineType].end ?? (routineType === 'morning' ? '09:00' : '20:00'),
+      });
+
+      await routineRepository.replaceRoutineTasks({
+        routineId: routine.id,
+        tasks: child[routineType].map((task, index) => {
+          const matchedTemplate = findTemplateForTask(task.title, task.icon, routineType);
+
+          return {
+            taskTemplateId: matchedTemplate?.id ?? null,
+            customTitle: matchedTemplate ? null : task.title,
+            customIcon: matchedTemplate ? null : task.icon,
+            sortOrder: index,
+            isArchived: false,
+          };
+        }),
+      });
+    }
+  }
+};

--- a/src/lib/data/local-to-cloud-import.ts
+++ b/src/lib/data/local-to-cloud-import.ts
@@ -1,68 +1,13 @@
-import type { Child, HomeScene, RoutineType } from '@/lib/types';
+import type { Child, HomeScene } from '@/lib/types';
 import type { HouseholdRecord } from './models';
-import { TASK_CATALOG } from '@/lib/types';
-import { SupabaseChildProfileRepository } from './supabase-child-profile-repository';
-import { SupabaseHouseholdRepository } from './supabase-household-repository';
-import { SupabaseRoutineRepository } from './supabase-routine-repository';
-import { getSupabaseClient } from '@/lib/supabase/client';
-
-const findTemplateForTask = (
-  title: string,
-  icon: string,
-  routine: RoutineType
-) =>
-  TASK_CATALOG[routine].find((task) => task.title === title && task.icon === icon) ?? null;
+import { saveHouseholdConfigToCloud } from './cloud-household-write';
 
 export const importLocalFamilyToCloud = async (input: {
   household: HouseholdRecord;
   children: Child[];
   homeScene: HomeScene;
-}) => {
-  const supabase = getSupabaseClient();
-  if (!supabase) {
-    throw new Error('Supabase is not configured yet.');
-  }
-
-  const householdRepository = new SupabaseHouseholdRepository(supabase);
-  const childRepository = new SupabaseChildProfileRepository(supabase);
-  const routineRepository = new SupabaseRoutineRepository(supabase);
-
-  await householdRepository.updateHomeScene(input.household.id, input.homeScene);
-
-  for (const child of input.children) {
-    const importedChild = await childRepository.upsert({
-      id: crypto.randomUUID(),
-      householdId: input.household.id,
-      name: child.name,
-      age: child.age ?? null,
-      ageBucket: child.ageBucket ?? null,
-      avatarAnimal: child.avatarAnimal ?? null,
-      avatarSeed: child.avatarSeed ?? null,
-    });
-
-    for (const routineType of ['morning', 'evening'] as const) {
-      const routine = await routineRepository.upsertRoutine({
-        id: crypto.randomUUID(),
-        childProfileId: importedChild.id,
-        type: routineType,
-        startTime: child.schedule?.[routineType].start ?? (routineType === 'morning' ? '07:00' : '17:00'),
-        endTime: child.schedule?.[routineType].end ?? (routineType === 'morning' ? '09:00' : '20:00'),
-      });
-
-      await routineRepository.replaceRoutineTasks({
-        routineId: routine.id,
-        tasks: child[routineType].map((task, index) => {
-          const matchedTemplate = findTemplateForTask(task.title, task.icon, routineType);
-
-          return {
-            taskTemplateId: matchedTemplate?.id ?? null,
-            customTitle: matchedTemplate ? null : task.title,
-            customIcon: matchedTemplate ? null : task.icon,
-            sortOrder: index,
-            isArchived: false,
-          };
-        }),
-      });
-    }
-  }
-};
+}) =>
+  saveHouseholdConfigToCloud({
+    ...input,
+    removeMissingChildren: false,
+  });

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { ChildSelector } from '@/components/ChildSelector';
 import { AccountEntryScreen } from '@/components/AccountEntryScreen';
 import { ImportFamilySetupScreen } from '@/components/ImportFamilySetupScreen';
@@ -7,6 +7,7 @@ import { RoutineView } from '@/components/RoutineView';
 import { ParentSettings } from '@/components/ParentSettings';
 import { useAuth } from '@/lib/auth/use-auth';
 import { loadCloudHouseholdState } from '@/lib/data/cloud-household-state';
+import { saveHouseholdConfigToCloud } from '@/lib/data/cloud-household-write';
 import { importLocalFamilyToCloud } from '@/lib/data/local-to-cloud-import';
 import type { AppView, Child, HomeScene, RoutineType } from '@/lib/types';
 import {
@@ -65,6 +66,35 @@ const getDisplayRoutine = (child: Child, now: Date): RoutineType => {
 
 const createSetupChildren = (): Child[] => [];
 
+const serializeHouseholdConfig = (input: {
+  children: Child[];
+  homeScene: HomeScene;
+  setupComplete: boolean;
+}) =>
+  JSON.stringify({
+    children: input.children.map((child) => ({
+      id: child.id,
+      name: child.name,
+      age: child.age ?? null,
+      ageBucket: child.ageBucket ?? null,
+      avatarAnimal: child.avatarAnimal ?? null,
+      avatarSeed: child.avatarSeed ?? null,
+      schedule: child.schedule ?? null,
+      morning: child.morning.map((task) => ({
+        id: task.id,
+        title: task.title,
+        icon: task.icon,
+      })),
+      evening: child.evening.map((task) => ({
+        id: task.id,
+        title: task.title,
+        icon: task.icon,
+      })),
+    })),
+    homeScene: input.homeScene,
+    setupComplete: input.setupComplete,
+  });
+
 const Index = () => {
   const { status: authStatus, householdStatus, household } = useAuth();
   const [view, setView] = useState<AppView>('setup');
@@ -76,6 +106,8 @@ const Index = () => {
   const [isImporting, setIsImporting] = useState(false);
   const [now, setNow] = useState(() => new Date());
   const [homeScene, setHomeScene] = useState<HomeScene>('bike');
+  const lastSyncedConfigRef = useRef<string | null>(null);
+  const shouldSyncFirstConfigRef = useRef(false);
 
   const resetToFreshSetup = useCallback(() => {
     clearLocalAppState();
@@ -168,6 +200,16 @@ const Index = () => {
         setHomeScene(cloudState.homeScene);
         setSetupComplete(cloudState.children.length > 0);
         setView(cloudState.children.length > 0 ? 'home' : 'setup');
+        if (cloudState.children.length > 0) {
+          lastSyncedConfigRef.current = serializeHouseholdConfig({
+            children: cloudState.children,
+            homeScene: cloudState.homeScene,
+            setupComplete: true,
+          });
+          shouldSyncFirstConfigRef.current = false;
+        } else if (authStatus === 'signed_in') {
+          shouldSyncFirstConfigRef.current = true;
+        }
         setIsReady(true);
         return;
       }
@@ -177,6 +219,7 @@ const Index = () => {
         setSetupComplete(false);
         setHomeScene('bike');
         setView(authStatus === 'signed_in' ? 'setup' : 'account');
+        shouldSyncFirstConfigRef.current = authStatus === 'signed_in';
         setIsReady(true);
       }
     };
@@ -187,6 +230,41 @@ const Index = () => {
       isMounted = false;
     };
   }, [authStatus, household, householdStatus]);
+
+  const householdConfigSignature = useMemo(
+    () => serializeHouseholdConfig({ children, homeScene, setupComplete }),
+    [children, homeScene, setupComplete]
+  );
+
+  useEffect(() => {
+    if (!isReady || authStatus !== 'signed_in' || householdStatus !== 'ready' || !household || !setupComplete) {
+      lastSyncedConfigRef.current = null;
+      return;
+    }
+
+    if (lastSyncedConfigRef.current === null) {
+      if (!shouldSyncFirstConfigRef.current) {
+        lastSyncedConfigRef.current = householdConfigSignature;
+        return;
+      }
+    }
+
+    if (lastSyncedConfigRef.current === householdConfigSignature) {
+      return;
+    }
+
+    shouldSyncFirstConfigRef.current = false;
+    lastSyncedConfigRef.current = householdConfigSignature;
+
+    void saveHouseholdConfigToCloud({
+      household,
+      children,
+      homeScene,
+      removeMissingChildren: true,
+    }).catch((error) => {
+      console.warn('Could not sync household configuration to cloud.', error);
+    });
+  }, [authStatus, children, homeScene, household, householdConfigSignature, householdStatus, isReady, setupComplete]);
 
   useEffect(() => {
     const timer = window.setInterval(() => {
@@ -277,9 +355,18 @@ const Index = () => {
             children,
             homeScene,
           })
-            .then(() => {
-              setSetupComplete(children.length > 0);
-              setView(children.length > 0 ? 'home' : 'setup');
+            .then(async () => {
+              const cloudState = await loadCloudHouseholdState(household);
+              setChildren(cloudState.children);
+              setHomeScene(cloudState.homeScene);
+              setSetupComplete(cloudState.children.length > 0);
+              setView(cloudState.children.length > 0 ? 'home' : 'setup');
+              lastSyncedConfigRef.current = serializeHouseholdConfig({
+                children: cloudState.children,
+                homeScene: cloudState.homeScene,
+                setupComplete: cloudState.children.length > 0,
+              });
+              shouldSyncFirstConfigRef.current = false;
             })
             .catch((error) => {
               setImportError(
@@ -297,6 +384,7 @@ const Index = () => {
           setHomeScene('bike');
           setView('setup');
           setImportError(null);
+          shouldSyncFirstConfigRef.current = true;
         }}
       />
     );

--- a/src/test/cloudHouseholdWrite.test.ts
+++ b/src/test/cloudHouseholdWrite.test.ts
@@ -1,15 +1,19 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { importLocalFamilyToCloud } from '@/lib/data/local-to-cloud-import';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { saveHouseholdConfigToCloud } from '@/lib/data/cloud-household-write';
 
 const {
   getSupabaseClient,
   updateHomeScene,
+  listChildProfiles,
+  removeChildProfile,
   upsertChildProfile,
   upsertRoutine,
   replaceRoutineTasks,
 } = vi.hoisted(() => ({
   getSupabaseClient: vi.fn(),
   updateHomeScene: vi.fn(),
+  listChildProfiles: vi.fn(),
+  removeChildProfile: vi.fn(),
   upsertChildProfile: vi.fn(),
   upsertRoutine: vi.fn(),
   replaceRoutineTasks: vi.fn(),
@@ -27,6 +31,8 @@ vi.mock('@/lib/data/supabase-household-repository', () => ({
 
 vi.mock('@/lib/data/supabase-child-profile-repository', () => ({
   SupabaseChildProfileRepository: class {
+    listByHousehold = listChildProfiles;
+    remove = removeChildProfile;
     upsert = upsertChildProfile;
   },
 }));
@@ -38,25 +44,28 @@ vi.mock('@/lib/data/supabase-routine-repository', () => ({
   },
 }));
 
-describe('importLocalFamilyToCloud', () => {
+describe('saveHouseholdConfigToCloud', () => {
   beforeEach(() => {
     getSupabaseClient.mockReturnValue({});
     updateHomeScene.mockReset();
+    listChildProfiles.mockReset();
+    removeChildProfile.mockReset();
     upsertChildProfile.mockReset();
     upsertRoutine.mockReset();
     replaceRoutineTasks.mockReset();
     updateHomeScene.mockResolvedValue(undefined);
+    listChildProfiles.mockResolvedValue([]);
     upsertChildProfile.mockResolvedValue({
-      id: 'cloud-child-1',
+      id: 'child-1',
     });
     upsertRoutine
-      .mockResolvedValueOnce({ id: 'cloud-routine-morning' })
-      .mockResolvedValueOnce({ id: 'cloud-routine-evening' });
+      .mockResolvedValueOnce({ id: 'child-1-morning' })
+      .mockResolvedValueOnce({ id: 'child-1-evening' });
     replaceRoutineTasks.mockResolvedValue([]);
   });
 
-  it('imports local children, schedules, and tasks into the cloud household', async () => {
-    await importLocalFamilyToCloud({
+  it('writes household scene, children, routines, and tasks to the cloud household', async () => {
+    await saveHouseholdConfigToCloud({
       household: {
         id: 'house-1',
         name: 'Routine Stars Family',
@@ -69,7 +78,7 @@ describe('importLocalFamilyToCloud', () => {
       homeScene: 'school',
       children: [
         {
-          id: 'local-child-1',
+          id: 'child-1',
           name: 'Lily',
           age: 5,
           ageBucket: '4-6',
@@ -86,11 +95,14 @@ describe('importLocalFamilyToCloud', () => {
           evening: [{ id: 'e1', title: 'Go to bed', icon: 'moon-star', completed: false }],
         },
       ],
+      removeMissingChildren: true,
     });
 
     expect(updateHomeScene).toHaveBeenCalledWith('house-1', 'school');
+    expect(listChildProfiles).toHaveBeenCalledWith('house-1');
     expect(upsertChildProfile).toHaveBeenCalledWith(
       expect.objectContaining({
+        id: 'child-1',
         householdId: 'house-1',
         name: 'Lily',
       })
@@ -98,14 +110,15 @@ describe('importLocalFamilyToCloud', () => {
     expect(upsertRoutine).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        childProfileId: 'cloud-child-1',
+        id: 'child-1-morning',
+        childProfileId: 'child-1',
         type: 'morning',
         startTime: '07:30',
         endTime: '08:30',
       })
     );
     expect(replaceRoutineTasks).toHaveBeenNthCalledWith(1, {
-      routineId: 'cloud-routine-morning',
+      routineId: 'child-1-morning',
       tasks: [
         {
           taskTemplateId: 'brush-teeth',
@@ -123,5 +136,36 @@ describe('importLocalFamilyToCloud', () => {
         },
       ],
     });
+  });
+
+  it('removes cloud children that no longer exist locally when requested', async () => {
+    listChildProfiles.mockResolvedValue([
+      { id: 'child-stale' },
+      { id: 'child-1' },
+    ]);
+
+    await saveHouseholdConfigToCloud({
+      household: {
+        id: 'house-1',
+        name: 'Routine Stars Family',
+        timezone: 'Europe/Madrid',
+        homeScene: 'bike',
+        createdByUserId: 'user-1',
+        createdAt: '2026-04-20T10:00:00Z',
+        updatedAt: '2026-04-20T10:00:00Z',
+      },
+      homeScene: 'bike',
+      children: [
+        {
+          id: 'child-1',
+          name: 'Lily',
+          morning: [],
+          evening: [],
+        },
+      ],
+      removeMissingChildren: true,
+    });
+
+    expect(removeChildProfile).toHaveBeenCalledWith('child-stale');
   });
 });

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -23,6 +23,9 @@ const { loadCloudHouseholdState } = vi.hoisted(() => ({
 const { importLocalFamilyToCloud } = vi.hoisted(() => ({
   importLocalFamilyToCloud: vi.fn(),
 }));
+const { saveHouseholdConfigToCloud } = vi.hoisted(() => ({
+  saveHouseholdConfigToCloud: vi.fn(),
+}));
 
 vi.mock("@/lib/auth/use-auth", () => ({
   useAuth: () => authState,
@@ -33,6 +36,9 @@ vi.mock("@/lib/data/cloud-household-state", () => ({
 }));
 vi.mock("@/lib/data/local-to-cloud-import", () => ({
   importLocalFamilyToCloud,
+}));
+vi.mock("@/lib/data/cloud-household-write", () => ({
+  saveHouseholdConfigToCloud,
 }));
 
 const today = () => new Date().toDateString();
@@ -213,6 +219,7 @@ describe("Index", () => {
     authState.error = null;
     loadCloudHouseholdState.mockReset();
     importLocalFamilyToCloud.mockReset();
+    saveHouseholdConfigToCloud.mockReset();
     authState.clearError.mockReset();
     authState.sendEmailLink.mockReset();
     authState.retryHousehold.mockReset();
@@ -388,6 +395,20 @@ describe("Index", () => {
       children: [],
     });
     importLocalFamilyToCloud.mockResolvedValue(undefined);
+    loadCloudHouseholdState.mockResolvedValueOnce({
+      homeScene: "kite",
+      children: [],
+    }).mockResolvedValueOnce({
+      homeScene: "school",
+      children: [
+        {
+          id: "1",
+          name: "Lily",
+          morning: [{ id: "m1", title: "Make bed", icon: "bed", completed: false }],
+          evening: [{ id: "e1", title: "Go to bed", icon: "moon-star", completed: false }],
+        },
+      ],
+    });
     localStorage.setItem(
       "routine_stars_data",
       JSON.stringify({
@@ -411,6 +432,39 @@ describe("Index", () => {
     });
 
     expect(await screen.findByTestId("child-count")).toHaveTextContent("1");
+  });
+
+  it("syncs configuration changes to cloud after signed-in setup is completed", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [],
+    });
+    saveHouseholdConfigToCloud.mockResolvedValue(undefined);
+
+    render(<Index />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "finish-setup" }));
+
+    await waitFor(() => {
+      expect(saveHouseholdConfigToCloud).toHaveBeenCalledWith(
+        expect.objectContaining({
+          household: authState.household,
+          removeMissingChildren: true,
+        })
+      );
+    });
   });
 
   it("lets a parent start fresh instead of importing existing local setup", async () => {


### PR DESCRIPTION
## Summary
Adds the first cloud write-sync path so signed-in household configuration changes can persist back to Supabase after setup and import.

## What changed
- adds a shared cloud household write helper for children, routines, tasks, and home scene
- updates the import path to reuse the shared write helper and keep cloud/local child ids aligned
- adds a signed-in config sync effect so completed setup changes can be written back to cloud
- reloads cloud household state after import so the app continues with cloud-backed ids
- adds tests for cloud write behavior and the first signed-in setup sync

## Why
Read-only hydration was not enough for a real multi-device product. Once a parent edits setup, those changes need to persist back to the household so the next device sees them too.

## Validation
- `npm test -- --run`

## Related issues
- Addresses #13
- Supports #14
- Supports #18