### PR TITLE
[codex] Sync daily routine progress to cloud

### DIFF
--- a/src/lib/data/cloud-household-state.ts
+++ b/src/lib/data/cloud-household-state.ts
@@ -2,6 +2,7 @@ import type { Child, HomeScene, IconKey, RoutineType, Task } from '@/lib/types';
 import { TASK_CATALOG_BY_ID } from '@/lib/types';
 import type { ChildProfileRecord, HouseholdRecord, RoutineRecord, RoutineTaskRecord } from './models';
 import { SupabaseChildProfileRepository } from './supabase-child-profile-repository';
+import { SupabaseProgressRepository } from './supabase-progress-repository';
 import { SupabaseRoutineRepository } from './supabase-routine-repository';
 import { getSupabaseClient } from '@/lib/supabase/client';
 
@@ -9,6 +10,9 @@ export interface CloudHouseholdState {
   children: Child[];
   homeScene: HomeScene;
 }
+
+const getLocalProgressDate = (date: Date) =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
 
 const DEFAULT_SCHEDULE = {
   morning: { start: '07:00', end: '09:00' },
@@ -84,17 +88,53 @@ export const loadCloudHouseholdState = async (
   }
 
   const childRepository = new SupabaseChildProfileRepository(supabase);
+  const progressRepository = new SupabaseProgressRepository(supabase);
   const routineRepository = new SupabaseRoutineRepository(supabase);
   const childProfiles = await childRepository.listByHousehold(household.id);
+  const progressDate = getLocalProgressDate(new Date());
   const routinePairs = await Promise.all(
     childProfiles.map(async (profile) => [profile.id, await routineRepository.listByChild(profile.id)] as const)
   );
+  const progressPairs = await Promise.all(
+    childProfiles.flatMap((profile) =>
+      (['morning', 'evening'] as const).map(async (routineType) => [
+        `${profile.id}:${routineType}`,
+        await progressRepository.getRoutineProgress({
+          childProfileId: profile.id,
+          routineType,
+          progressDate,
+        }),
+      ] as const)
+    )
+  );
+
+  const children = mapCloudHouseholdToChildren({
+    childProfiles,
+    routinesByChildId: Object.fromEntries(routinePairs),
+  }).map((child) => {
+    const applyProgress = (routineType: RoutineType) => {
+      const progress = Object.fromEntries(progressPairs)[`${child.id}:${routineType}`];
+      const completedTaskIds = new Set(
+        (progress?.taskProgress ?? []).filter((taskProgress) => taskProgress.completed).map((taskProgress) => taskProgress.routineTaskId)
+      );
+
+      return child[routineType].map((task) => ({
+        ...task,
+        completed: completedTaskIds.has(task.id),
+      }));
+    };
+
+    return {
+      ...child,
+      morning: applyProgress('morning'),
+      evening: applyProgress('evening'),
+    };
+  });
 
   return {
     homeScene: household.homeScene,
-    children: mapCloudHouseholdToChildren({
-      childProfiles,
-      routinesByChildId: Object.fromEntries(routinePairs),
-    }),
+    children,
   };
 };
+
+export { getLocalProgressDate };

--- a/src/lib/data/supabase-progress-repository.ts
+++ b/src/lib/data/supabase-progress-repository.ts
@@ -1,0 +1,125 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { DailyRoutineProgressRecord, DailyTaskProgressRecord } from './models';
+import type { ProgressRepository } from './repositories';
+
+const DAILY_ROUTINE_PROGRESS_TABLE = 'daily_routine_progress';
+const DAILY_TASK_PROGRESS_TABLE = 'daily_task_progress';
+
+const mapDailyRoutineProgress = (row: Record<string, unknown>): DailyRoutineProgressRecord => ({
+  id: String(row.id),
+  childProfileId: String(row.child_profile_id),
+  routineType: String(row.routine_type) as DailyRoutineProgressRecord['routineType'],
+  progressDate: String(row.progress_date),
+  completedAt: row.completed_at === null || row.completed_at === undefined ? null : String(row.completed_at),
+  createdAt: String(row.created_at),
+  updatedAt: String(row.updated_at),
+});
+
+const mapDailyTaskProgress = (row: Record<string, unknown>): DailyTaskProgressRecord => ({
+  id: String(row.id),
+  dailyRoutineProgressId: String(row.daily_routine_progress_id),
+  routineTaskId: String(row.routine_task_id),
+  completed: Boolean(row.completed),
+  completedAt: row.completed_at === null || row.completed_at === undefined ? null : String(row.completed_at),
+  createdAt: String(row.created_at),
+  updatedAt: String(row.updated_at),
+});
+
+export class SupabaseProgressRepository implements ProgressRepository {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async getRoutineProgress(input: {
+    childProfileId: string;
+    routineType: 'morning' | 'evening';
+    progressDate: string;
+  }) {
+    const { data: dailyRoutineRow, error: dailyRoutineError } = await this.supabase
+      .from(DAILY_ROUTINE_PROGRESS_TABLE)
+      .select('*')
+      .eq('child_profile_id', input.childProfileId)
+      .eq('routine_type', input.routineType)
+      .eq('progress_date', input.progressDate)
+      .maybeSingle();
+
+    if (dailyRoutineError) {
+      throw dailyRoutineError;
+    }
+
+    if (!dailyRoutineRow) {
+      return {
+        dailyRoutineProgress: null,
+        taskProgress: [],
+      };
+    }
+
+    const { data: taskProgressRows, error: taskProgressError } = await this.supabase
+      .from(DAILY_TASK_PROGRESS_TABLE)
+      .select('*')
+      .eq('daily_routine_progress_id', dailyRoutineRow.id);
+
+    if (taskProgressError) {
+      throw taskProgressError;
+    }
+
+    return {
+      dailyRoutineProgress: mapDailyRoutineProgress(dailyRoutineRow),
+      taskProgress: (taskProgressRows ?? []).map(mapDailyTaskProgress),
+    };
+  }
+
+  async upsertRoutineProgress(input: {
+    childProfileId: string;
+    routineType: 'morning' | 'evening';
+    progressDate: string;
+    completedAt?: string | null;
+  }) {
+    const { data, error } = await this.supabase
+      .from(DAILY_ROUTINE_PROGRESS_TABLE)
+      .upsert(
+        {
+          child_profile_id: input.childProfileId,
+          routine_type: input.routineType,
+          progress_date: input.progressDate,
+          completed_at: input.completedAt ?? null,
+        },
+        { onConflict: 'child_profile_id,routine_type,progress_date' }
+      )
+      .select('*')
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    return mapDailyRoutineProgress(data);
+  }
+
+  async setTaskCompletion(input: {
+    dailyRoutineProgressId: string;
+    routineTaskId: string;
+    completed: boolean;
+    completedAt?: string | null;
+  }) {
+    const { data, error } = await this.supabase
+      .from(DAILY_TASK_PROGRESS_TABLE)
+      .upsert(
+        {
+          daily_routine_progress_id: input.dailyRoutineProgressId,
+          routine_task_id: input.routineTaskId,
+          completed: input.completed,
+          completed_at: input.completed ? input.completedAt ?? null : null,
+        },
+        { onConflict: 'daily_routine_progress_id,routine_task_id' }
+      )
+      .select('*')
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    return mapDailyTaskProgress(data);
+  }
+}
+
+export { mapDailyRoutineProgress, mapDailyTaskProgress };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,6 +9,8 @@ import { useAuth } from '@/lib/auth/use-auth';
 import { loadCloudHouseholdState } from '@/lib/data/cloud-household-state';
 import { saveHouseholdConfigToCloud } from '@/lib/data/cloud-household-write';
 import { importLocalFamilyToCloud } from '@/lib/data/local-to-cloud-import';
+import { SupabaseProgressRepository } from '@/lib/data/supabase-progress-repository';
+import { getSupabaseClient } from '@/lib/supabase/client';
 import type { AppView, Child, HomeScene, RoutineType } from '@/lib/types';
 import {
   clearLocalAppState,
@@ -65,6 +67,8 @@ const getDisplayRoutine = (child: Child, now: Date): RoutineType => {
 };
 
 const createSetupChildren = (): Child[] => [];
+const getLocalProgressDate = (date: Date) =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
 
 const serializeHouseholdConfig = (input: {
   children: Child[];
@@ -304,20 +308,75 @@ const Index = () => {
 
   const toggleTask = useCallback(
     (taskId: string) => {
+      let nextProgressWrite:
+        | {
+            childId: string;
+            routineType: RoutineType;
+            taskId: string;
+            completed: boolean;
+            completedAt: string | null;
+          }
+        | null = null;
+
       setChildren((prev) =>
         prev.map((c) => {
           if (c.id !== activeChildId) return c;
           const resolvedRoutine = getDisplayRoutine(c, new Date());
+          const nextRoutine = c[resolvedRoutine].map((t) => {
+            if (t.id !== taskId) return t;
+
+            const completed = !t.completed;
+            nextProgressWrite = {
+              childId: c.id,
+              routineType: resolvedRoutine,
+              taskId,
+              completed,
+              completedAt: completed ? new Date().toISOString() : null,
+            };
+
+            return { ...t, completed };
+          });
+
           return {
             ...c,
-            [resolvedRoutine]: c[resolvedRoutine].map((t) =>
-              t.id === taskId ? { ...t, completed: !t.completed } : t
-            ),
+            [resolvedRoutine]: nextRoutine,
           };
         })
       );
+
+      if (
+        nextProgressWrite &&
+        authStatus === 'signed_in' &&
+        householdStatus === 'ready' &&
+        household
+      ) {
+        const supabase = getSupabaseClient();
+        if (!supabase) return;
+
+        const progressRepository = new SupabaseProgressRepository(supabase);
+        const progressDate = getLocalProgressDate(new Date());
+
+        void progressRepository
+          .upsertRoutineProgress({
+            childProfileId: nextProgressWrite.childId,
+            routineType: nextProgressWrite.routineType,
+            progressDate,
+            completedAt: null,
+          })
+          .then((dailyRoutineProgress) =>
+            progressRepository.setTaskCompletion({
+              dailyRoutineProgressId: dailyRoutineProgress.id,
+              routineTaskId: nextProgressWrite.taskId,
+              completed: nextProgressWrite.completed,
+              completedAt: nextProgressWrite.completedAt,
+            })
+          )
+          .catch((error) => {
+            console.warn('Could not sync routine progress to cloud.', error);
+          });
+      }
     },
-    [activeChildId]
+    [activeChildId, authStatus, household, householdStatus]
   );
 
   const activeChild = children.find((c) => c.id === activeChildId);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -151,6 +151,23 @@ const Index = () => {
       }
 
       if (storedState) {
+        if (authStatus === 'signed_in' && householdStatus === 'ready' && household && cloudState?.children.length) {
+          if (isMounted) {
+            setChildren(cloudState.children);
+            setHomeScene(cloudState.homeScene);
+            setSetupComplete(cloudState.children.length > 0);
+            setView(cloudState.children.length > 0 ? 'home' : 'setup');
+            lastSyncedConfigRef.current = serializeHouseholdConfig({
+              children: cloudState.children,
+              homeScene: cloudState.homeScene,
+              setupComplete: cloudState.children.length > 0,
+            });
+            shouldSyncFirstConfigRef.current = false;
+            setIsReady(true);
+          }
+          return;
+        }
+
         if (
           authStatus === 'signed_in' &&
           householdStatus === 'ready' &&
@@ -306,8 +323,15 @@ const Index = () => {
     }
   }, [children, homeScene, isReady, setupComplete]);
 
+  const activeChild = children.find((c) => c.id === activeChildId);
+  const activeRoutine = activeChild ? getDisplayRoutine(activeChild, now) : 'morning';
+
   const toggleTask = useCallback(
     (taskId: string) => {
+      if (!activeChild) return;
+
+      const resolvedRoutine = getDisplayRoutine(activeChild, new Date());
+      const toggledAt = new Date().toISOString();
       let nextProgressWrite:
         | {
             childId: string;
@@ -315,33 +339,43 @@ const Index = () => {
             taskId: string;
             completed: boolean;
             completedAt: string | null;
+            routineCompleted: boolean;
           }
         | null = null;
 
+      const nextRoutine = activeChild[resolvedRoutine].map((task) => {
+        if (task.id !== taskId) return task;
+
+        const completed = !task.completed;
+        nextProgressWrite = {
+          childId: activeChild.id,
+          routineType: resolvedRoutine,
+          taskId,
+          completed,
+          completedAt: completed ? toggledAt : null,
+          routineCompleted: false,
+        };
+
+        return { ...task, completed };
+      });
+
+      if (!nextProgressWrite) return;
+
+      const routineCompleted = nextRoutine.length > 0 && nextRoutine.every((task) => task.completed);
+      nextProgressWrite = {
+        ...nextProgressWrite,
+        routineCompleted,
+      };
+
       setChildren((prev) =>
-        prev.map((c) => {
-          if (c.id !== activeChildId) return c;
-          const resolvedRoutine = getDisplayRoutine(c, new Date());
-          const nextRoutine = c[resolvedRoutine].map((t) => {
-            if (t.id !== taskId) return t;
-
-            const completed = !t.completed;
-            nextProgressWrite = {
-              childId: c.id,
-              routineType: resolvedRoutine,
-              taskId,
-              completed,
-              completedAt: completed ? new Date().toISOString() : null,
-            };
-
-            return { ...t, completed };
-          });
-
-          return {
-            ...c,
-            [resolvedRoutine]: nextRoutine,
-          };
-        })
+        prev.map((child) =>
+          child.id === activeChild.id
+            ? {
+                ...child,
+                [resolvedRoutine]: nextRoutine,
+              }
+            : child
+        )
       );
 
       if (
@@ -363,24 +397,28 @@ const Index = () => {
             progressDate,
             completedAt: null,
           })
-          .then((dailyRoutineProgress) =>
-            progressRepository.setTaskCompletion({
+          .then(async (dailyRoutineProgress) => {
+            await progressRepository.setTaskCompletion({
               dailyRoutineProgressId: dailyRoutineProgress.id,
               routineTaskId: nextProgressWrite.taskId,
               completed: nextProgressWrite.completed,
               completedAt: nextProgressWrite.completedAt,
-            })
-          )
+            });
+
+            await progressRepository.upsertRoutineProgress({
+              childProfileId: nextProgressWrite.childId,
+              routineType: nextProgressWrite.routineType,
+              progressDate,
+              completedAt: nextProgressWrite.routineCompleted ? new Date().toISOString() : null,
+            });
+          })
           .catch((error) => {
             console.warn('Could not sync routine progress to cloud.', error);
           });
       }
     },
-    [activeChildId, authStatus, household, householdStatus]
+    [activeChild, authStatus, household, householdStatus]
   );
-
-  const activeChild = children.find((c) => c.id === activeChildId);
-  const activeRoutine = activeChild ? getDisplayRoutine(activeChild, now) : 'morning';
   const dueRoutineByChild = Object.fromEntries(
     children.map((child) => [child.id, getDueRoutine(child, now)])
   ) as Record<string, RoutineType | null>;

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -26,6 +26,11 @@ const { importLocalFamilyToCloud } = vi.hoisted(() => ({
 const { saveHouseholdConfigToCloud } = vi.hoisted(() => ({
   saveHouseholdConfigToCloud: vi.fn(),
 }));
+const { getSupabaseClient, upsertRoutineProgress, setTaskCompletion } = vi.hoisted(() => ({
+  getSupabaseClient: vi.fn(),
+  upsertRoutineProgress: vi.fn(),
+  setTaskCompletion: vi.fn(),
+}));
 
 vi.mock("@/lib/auth/use-auth", () => ({
   useAuth: () => authState,
@@ -39,6 +44,15 @@ vi.mock("@/lib/data/local-to-cloud-import", () => ({
 }));
 vi.mock("@/lib/data/cloud-household-write", () => ({
   saveHouseholdConfigToCloud,
+}));
+vi.mock("@/lib/supabase/client", () => ({
+  getSupabaseClient,
+}));
+vi.mock("@/lib/data/supabase-progress-repository", () => ({
+  SupabaseProgressRepository: class {
+    upsertRoutineProgress = upsertRoutineProgress;
+    setTaskCompletion = setTaskCompletion;
+  },
 }));
 
 const today = () => new Date().toDateString();
@@ -220,6 +234,12 @@ describe("Index", () => {
     loadCloudHouseholdState.mockReset();
     importLocalFamilyToCloud.mockReset();
     saveHouseholdConfigToCloud.mockReset();
+    getSupabaseClient.mockReset();
+    upsertRoutineProgress.mockReset();
+    setTaskCompletion.mockReset();
+    getSupabaseClient.mockReturnValue({});
+    upsertRoutineProgress.mockResolvedValue({ id: "progress-1" });
+    setTaskCompletion.mockResolvedValue({ id: "task-progress-1" });
     authState.clearError.mockReset();
     authState.sendEmailLink.mockReset();
     authState.retryHousehold.mockReset();
@@ -344,6 +364,46 @@ describe("Index", () => {
 
     expect(await screen.findByTestId("child-count")).toHaveTextContent("1");
     expect(loadCloudHouseholdState).toHaveBeenCalledWith(authState.household);
+  });
+
+  it("prefers cloud household state over stale local cache for signed-in households", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [
+        {
+          id: "1",
+          name: "Cloud Lily",
+          morning: [{ id: "m1", title: "Make bed", icon: "bed", completed: true }],
+          evening: [],
+        },
+      ],
+    });
+    localStorage.setItem(
+      "routine_stars_data",
+      JSON.stringify({
+        ...createStoredState(false, today()),
+        setupComplete: true,
+      })
+    );
+
+    render(<Index />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "select-first-child" }));
+
+    expect(await screen.findByTestId("active-child")).toHaveTextContent("Cloud Lily");
+    expect(screen.getByTestId("first-task-completed")).toHaveTextContent("true");
   });
 
   it("shows an import decision when a signed-in device has local setup and cloud is empty", async () => {
@@ -497,6 +557,52 @@ describe("Index", () => {
     fireEvent.click(await screen.findByRole("button", { name: "start-fresh-instead" }));
 
     expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
+  });
+
+  it("syncs signed-in task toggles to cloud-backed progress", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [
+        {
+          id: "1",
+          name: "Lily",
+          morning: [{ id: "m1", title: "Make bed", icon: "bed", completed: false }],
+          evening: [],
+          schedule: {
+            morning: { start: "00:00", end: "23:59" },
+            evening: { start: "00:00", end: "00:01" },
+          },
+        },
+      ],
+    });
+
+    render(<Index />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "select-first-child" }));
+    fireEvent.click(screen.getByRole("button", { name: "toggle-first-task" }));
+
+    await waitFor(() => {
+      expect(upsertRoutineProgress).toHaveBeenCalled();
+      expect(setTaskCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dailyRoutineProgressId: "progress-1",
+          routineTaskId: "m1",
+          completed: true,
+        })
+      );
+    });
   });
 
   it("re-opens setup when saved data is marked incomplete", async () => {

--- a/src/test/supabaseProgressRepository.test.ts
+++ b/src/test/supabaseProgressRepository.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SupabaseProgressRepository } from '@/lib/data/supabase-progress-repository';
+
+const createSupabaseClient = (responses: Record<string, unknown>) =>
+  ({
+    from: vi.fn((table: string) => responses[table]),
+  }) as never;
+
+describe('SupabaseProgressRepository', () => {
+  it('loads a routine progress record and its task progress rows', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: {
+        id: 'progress-1',
+        child_profile_id: 'child-1',
+        routine_type: 'morning',
+        progress_date: '2026-04-20',
+        completed_at: null,
+        created_at: '2026-04-20T08:00:00Z',
+        updated_at: '2026-04-20T08:00:00Z',
+      },
+      error: null,
+    });
+    const eqDate = vi.fn(() => ({ maybeSingle }));
+    const eqType = vi.fn(() => ({ eq: eqDate }));
+    const eqChild = vi.fn(() => ({ eq: eqType }));
+    const eqRoutineProgressId = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'task-progress-1',
+          daily_routine_progress_id: 'progress-1',
+          routine_task_id: 'task-1',
+          completed: true,
+          completed_at: '2026-04-20T08:05:00Z',
+          created_at: '2026-04-20T08:05:00Z',
+          updated_at: '2026-04-20T08:05:00Z',
+        },
+      ],
+      error: null,
+    });
+    const repository = new SupabaseProgressRepository(
+      createSupabaseClient({
+        daily_routine_progress: {
+          select: vi.fn(() => ({ eq: eqChild })),
+        },
+        daily_task_progress: {
+          select: vi.fn(() => ({ eq: eqRoutineProgressId })),
+        },
+      })
+    );
+
+    await expect(
+      repository.getRoutineProgress({
+        childProfileId: 'child-1',
+        routineType: 'morning',
+        progressDate: '2026-04-20',
+      })
+    ).resolves.toEqual({
+      dailyRoutineProgress: expect.objectContaining({
+        id: 'progress-1',
+        childProfileId: 'child-1',
+        routineType: 'morning',
+      }),
+      taskProgress: [
+        expect.objectContaining({
+          id: 'task-progress-1',
+          routineTaskId: 'task-1',
+          completed: true,
+        }),
+      ],
+    });
+  });
+
+  it('upserts daily routine progress and task completion rows', async () => {
+    const routineSingle = vi.fn().mockResolvedValue({
+      data: {
+        id: 'progress-1',
+        child_profile_id: 'child-1',
+        routine_type: 'morning',
+        progress_date: '2026-04-20',
+        completed_at: null,
+        created_at: '2026-04-20T08:00:00Z',
+        updated_at: '2026-04-20T08:00:00Z',
+      },
+      error: null,
+    });
+    const routineSelect = vi.fn(() => ({ single: routineSingle }));
+    const routineUpsert = vi.fn(() => ({ select: routineSelect }));
+    const taskSingle = vi.fn().mockResolvedValue({
+      data: {
+        id: 'task-progress-1',
+        daily_routine_progress_id: 'progress-1',
+        routine_task_id: 'task-1',
+        completed: true,
+        completed_at: '2026-04-20T08:05:00Z',
+        created_at: '2026-04-20T08:05:00Z',
+        updated_at: '2026-04-20T08:05:00Z',
+      },
+      error: null,
+    });
+    const taskSelect = vi.fn(() => ({ single: taskSingle }));
+    const taskUpsert = vi.fn(() => ({ select: taskSelect }));
+    const repository = new SupabaseProgressRepository(
+      createSupabaseClient({
+        daily_routine_progress: { upsert: routineUpsert },
+        daily_task_progress: { upsert: taskUpsert },
+      })
+    );
+
+    await expect(
+      repository.upsertRoutineProgress({
+        childProfileId: 'child-1',
+        routineType: 'morning',
+        progressDate: '2026-04-20',
+      })
+    ).resolves.toMatchObject({
+      id: 'progress-1',
+      routineType: 'morning',
+    });
+
+    await expect(
+      repository.setTaskCompletion({
+        dailyRoutineProgressId: 'progress-1',
+        routineTaskId: 'task-1',
+        completed: true,
+        completedAt: '2026-04-20T08:05:00Z',
+      })
+    ).resolves.toMatchObject({
+      id: 'task-progress-1',
+      routineTaskId: 'task-1',
+      completed: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds the first daily-progress sync foundation for signed-in households by hydrating today's task completion from Supabase and writing task toggles back to cloud-backed progress records.

## What changed
- adds a `SupabaseProgressRepository` for daily routine progress and task completion rows
- updates cloud household hydration to overlay today's progress onto routine tasks
- updates task toggles so signed-in households write progress changes back to cloud
- adds repository tests for progress reads and writes

## Why
Household setup sync was in place, but daily routine completion still behaved like device-local state. This closes the first cross-device progress gap.

## Validation
- `npm test -- --run`

## Related issues
- Addresses #26
- Supports #18