### PR TITLE
[codex] Document native-first billing architecture

### DIFF
--- a/docs/native-billing-architecture.md
+++ b/docs/native-billing-architecture.md
@@ -1,0 +1,120 @@
+# Native Billing Architecture
+
+As of April 20, 2026, Routine Stars should plan its first paid native launch around store-compliant billing, not external web checkout.
+
+## Decision
+
+For a native-first launch, use:
+
+- Apple App Store: one-time non-consumable In-App Purchase for a household lifetime unlock
+- Google Play: one-time non-consumable product for a household lifetime unlock
+
+Do not make external checkout the primary native-app purchase path for MVP.
+
+## Why
+
+Routine Stars sells digital app access. On both Apple and Google Play, that keeps us inside digital-goods billing rules for a native store app.
+
+External web billing is still useful later for web sales, support workflows, or approved regional programs, but it is not the safest default path for a first native paid launch.
+
+## What This Means
+
+The commercial product should be:
+
+- free app download
+- one parent account per household
+- one-time `EUR 9.99` household lifetime unlock
+- restore purchases on new devices through the parent account
+
+This is a better fit than a paid-upfront app because:
+
+- we still need parent sign-in and cloud sync after install
+- free download lowers install friction for families evaluating the app
+- store purchase restoration maps naturally to household entitlement sync
+- Android and iOS both support one-time unlock products
+
+## Platform Notes
+
+### Apple
+
+Apple's current guidance still treats digital features and access as App Store billing territory for native apps. Apple also states that paid apps and in-app purchases are subject to commission, with a reduced rate available through the App Store Small Business Program.
+
+Implication:
+
+- if Routine Stars is a native App Store app, the safe MVP is App Store monetization
+- a one-time non-consumable unlock is the cleanest fit for the product shape
+- external purchase links are not a universal escape hatch and add policy complexity
+
+### Google Play
+
+Google Play's current billing docs explicitly support one-time products for digital upgrades and permanent unlocks. Google also documents that digital goods sold through Play are subject to the Play service fee, with 15% available on the first USD 1M for enrolled developers.
+
+Implication:
+
+- Google Play should use a non-consumable one-time product for the household unlock
+- any external-offer path should be treated as an advanced follow-on, not the MVP billing path
+
+## Recommended MVP Architecture
+
+1. Parent creates or signs in to a Routine Stars account.
+2. App checks household entitlement status from Supabase.
+3. If unpaid, parent sees a calm parent-gated purchase screen.
+4. Native app launches store purchase flow.
+5. App validates the purchase with backend verification.
+6. Backend writes a durable household entitlement record.
+7. All signed-in devices read the same paid status from Supabase.
+
+## Data Model Additions
+
+Add backend records for:
+
+- `household_entitlements`
+- `purchase_events`
+- `store_accounts` or purchase-source metadata
+
+Each entitlement should include:
+
+- household id
+- platform (`ios` or `android`)
+- store product id
+- source transaction id / purchase token
+- entitlement status
+- granted timestamp
+- verification timestamp
+
+## Implementation Priorities
+
+1. Finish household sync and daily progress sync.
+2. Add a purchase gate in parent flows only.
+3. Implement Apple non-consumable purchase flow.
+4. Implement Google Play one-time product flow.
+5. Add server-side verification and durable entitlement writes.
+6. Add restore-purchases flows on both platforms.
+7. Add refund and revoked-entitlement handling.
+
+## Explicit Non-Goals For MVP
+
+- Stripe checkout as the primary purchase path inside native apps
+- subscriptions
+- per-child pricing
+- family sharing across multiple paid households
+- advanced regional external-offer programs
+
+## Sources
+
+- Apple App Review Guidelines:
+  [https://developer.apple.com/app-store/review/guidelines/](https://developer.apple.com/app-store/review/guidelines/)
+- Apple App Store Small Business Program:
+  [https://developer.apple.com/app-store/small-business-program/](https://developer.apple.com/app-store/small-business-program/)
+- Apple membership details and commission summary:
+  [https://developer.apple.com/programs/whats-included/](https://developer.apple.com/programs/whats-included/)
+- Apple In-App Purchase:
+  [https://developer.apple.com/in-app-purchase/](https://developer.apple.com/in-app-purchase/)
+- Google Play one-time products:
+  [https://developer.android.com/google/play/billing/one-time-products](https://developer.android.com/google/play/billing/one-time-products)
+- Google Play service fees:
+  [https://support.google.com/googleplay/android-developer/answer/10632485](https://support.google.com/googleplay/android-developer/answer/10632485)
+- Google Play service fee overview:
+  [https://support.google.com/googleplay/android-developer/answer/112622](https://support.google.com/googleplay/android-developer/answer/112622)
+- Google Play external offers:
+  [https://developer.android.com/google/play/billing/external](https://developer.android.com/google/play/billing/external)

--- a/docs/paid-launch-roadmap.md
+++ b/docs/paid-launch-roadmap.md
@@ -6,7 +6,7 @@ As of April 20, 2026, Routine Stars is a strong local shared-device routine app 
 
 Ship a first paid version where:
 
-- a parent can buy access outside the app
+- a parent can buy access in a store-compliant way for native apps
 - a parent can create or sign in to an account
 - the household data follows them to a second device
 - existing local-only families can move forward safely
@@ -64,38 +64,35 @@ Related issues:
 - #14 Build local-to-cloud import and offline cache strategy
 - #17 Add post-login import-or-start-fresh decision for existing local family data
 
-### 3. Add billing outside the app for a one-time 9.99 EUR purchase
+### 3. Add native-first billing for a one-time 9.99 EUR household unlock
 
 Recommended MVP direction:
 
-- use Stripe-hosted checkout outside the app
-- start with Stripe Payment Links for the lowest-friction external checkout
-- use webhook fulfillment to grant a household entitlement after payment
+- use a non-consumable one-time unlock on Apple
+- use a non-consumable one-time product on Google Play
+- map store purchases to a backend household entitlement
 
 Why this direction:
 
-- Payment Links provide a hosted payment page with very low integration effort
-- Stripe Checkout and Payment Links both support hosted one-time payments
-- Stripe recommends webhook-based fulfillment so purchase access is granted reliably
+- Routine Stars is planning a native-first launch
+- digital app access in native store apps still falls under store billing rules
+- a household lifetime unlock matches the product and avoids subscription complexity
 
 Operational recommendations:
 
-- sell one household lifetime unlock
-- price it at 9.99 EUR
-- treat it as B2C pricing and set tax behavior intentionally for EU markets
-- define refund handling before launch
+- ship as a free download with a one-time `EUR 9.99` parent unlock
+- restore purchases across devices through the parent account
+- keep the purchase gate parent-only
+- define refund and revoked-entitlement handling before launch
 
 Related issues:
 
 - #19 Add billing architecture for external one-time purchase at €9.99
 - #20 Grant paid household access from billing entitlement and webhook fulfillment
 
-Useful references:
+Decision doc:
 
-- https://docs.stripe.com/payment-links
-- https://docs.stripe.com/payments/checkout/how-checkout-works
-- https://docs.stripe.com/checkout/fulfillment
-- https://docs.stripe.com/tax/products-prices-tax-codes-tax-behavior
+- `docs/native-billing-architecture.md`
 
 ### 4. Tie access to a durable paid entitlement
 
@@ -104,10 +101,10 @@ Selling the app is not just taking payment. We need a backend entitlement record
 Includes:
 
 - add purchase and entitlement records in Supabase
-- receive Stripe webhook events
+- receive store verification events or backend verification results
 - make fulfillment idempotent
 - expose paid vs unpaid state in app bootstrap and parent settings
-- route unpaid households to the external purchase page
+- route unpaid households to a parent-gated purchase flow
 
 Related issue:
 
@@ -140,7 +137,7 @@ To keep pull requests reviewable, build in this order:
 4. import/start-fresh decision UI
 5. local-to-cloud import implementation
 6. progress sync and daily reset rules
-7. external billing setup
+7. native billing setup
 8. entitlement fulfillment and purchase gating
 9. launch operations and QA
 
@@ -152,4 +149,4 @@ Unless we decide otherwise later, this roadmap assumes:
 - purchase is one-time, not subscription
 - purchase unlock is per household, not per child
 - child use stays password-free on shared devices
-- billing lives outside the app
+- native apps use store-compliant billing for digital access


### PR DESCRIPTION
## Summary
Documents the native-first monetization decision so the repo no longer assumes external checkout for the first paid launch.

## What changed
- adds a `docs/native-billing-architecture.md` decision doc
- updates the paid launch roadmap to reflect store-compliant billing for native apps
- aligns the billing issue tracking with the new direction

## Why
Routine Stars is now targeting a native-first launch. That changes the safest billing path for digital access and affects the entitlement architecture we should build next.

## Validation
- documentation-only change

## Related issues
- Addresses #19
- Supports #20
- Supports #18