### PR TITLE
[codex] Add household entitlement foundation

### DIFF
--- a/docs/supabase-schema-overview.md
+++ b/docs/supabase-schema-overview.md
@@ -3,6 +3,7 @@
 This project now includes the first household-sync migration in:
 
 - [20260410194500_create_household_schema.sql](/Users/doraangelov/CodexProjects/daily-star-chart/supabase/migrations/20260410194500_create_household_schema.sql)
+- [20260420184000_add_household_entitlements.sql](/Users/doraangelov/CodexProjects/daily-star-chart/supabase/migrations/20260420184000_add_household_entitlements.sql)
 
 ## Tables
 
@@ -13,6 +14,8 @@ This project now includes the first household-sync migration in:
 - `routine_tasks`
 - `daily_routine_progress`
 - `daily_task_progress`
+- `household_entitlements`
+- `purchase_events`
 
 ## Security Model
 

--- a/src/components/AccountSettingsCard.tsx
+++ b/src/components/AccountSettingsCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { CheckCircle2, Cloud, CloudOff, LoaderCircle, LogIn, LogOut, Mail, RefreshCcw, ShieldCheck, UserRoundPlus } from 'lucide-react';
+import { CheckCircle2, Cloud, CloudOff, CreditCard, LoaderCircle, LogIn, LogOut, Mail, RefreshCcw, ShieldCheck, UserRoundPlus } from 'lucide-react';
 import { useAuth } from '@/lib/auth/use-auth';
 
 type AuthMode = 'signin' | 'signup';
@@ -11,6 +11,8 @@ export const AccountSettingsCard = () => {
     user,
     householdStatus,
     household,
+    entitlementStatus,
+    householdEntitlement,
     error,
     clearError,
     sendEmailLink,
@@ -66,7 +68,7 @@ export const AccountSettingsCard = () => {
           </div>
         </div>
       ) : status === 'signed_in' && user ? (
-        <div className="mt-6 grid gap-4 md:grid-cols-2">
+        <div className="mt-6 grid gap-4 md:grid-cols-3">
           <div className="rounded-[28px] border border-border bg-background p-5">
             <div className="flex items-center gap-2 text-foreground">
               <ShieldCheck size={18} className="text-primary" />
@@ -117,6 +119,45 @@ export const AccountSettingsCard = () => {
                   Try again
                 </button>
               </div>
+            )}
+          </div>
+
+          <div className="rounded-[28px] border border-border bg-background p-5">
+            <div className="flex items-center gap-2 text-foreground">
+              {entitlementStatus === 'loading' ? (
+                <LoaderCircle size={18} className="animate-spin text-primary" />
+              ) : (
+                <CreditCard size={18} className="text-primary" />
+              )}
+              <p className="text-sm font-black uppercase tracking-[0.18em]">Access</p>
+            </div>
+            <p className="mt-4 text-lg font-bold text-foreground">
+              {entitlementStatus === 'loading'
+                ? 'Checking access'
+                : householdEntitlement?.status === 'active'
+                  ? 'Lifetime unlock active'
+                  : householdEntitlement?.status === 'revoked'
+                    ? 'Access needs attention'
+                    : 'Not purchased yet'}
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {entitlementStatus === 'error'
+                ? 'We could not verify billing access yet. You can retry from here.'
+                : householdEntitlement?.status === 'active'
+                  ? 'This household has a verified paid unlock saved to the account.'
+                  : householdEntitlement?.status === 'revoked'
+                    ? 'This household had paid access before, but the entitlement is no longer active.'
+                    : 'This household is signed in and ready for the upcoming parent-only purchase flow.'}
+            </p>
+            {(entitlementStatus === 'error' || householdEntitlement?.status === 'revoked') && (
+              <button
+                type="button"
+                onClick={() => void retryHousehold()}
+                className="mt-5 inline-flex items-center gap-2 rounded-full border border-border px-4 py-2 text-sm font-bold text-foreground transition-colors hover:border-primary/40 hover:text-primary"
+              >
+                <RefreshCcw size={16} />
+                Refresh access
+              </button>
             )}
           </div>
         </div>

--- a/src/lib/auth/auth-context.tsx
+++ b/src/lib/auth/auth-context.tsx
@@ -1,11 +1,13 @@
 import { createContext, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
-import type { HouseholdRecord } from '@/lib/data/models';
+import type { HouseholdEntitlementRecord, HouseholdRecord } from '@/lib/data/models';
+import { SupabaseHouseholdEntitlementRepository } from '@/lib/data/supabase-household-entitlement-repository';
 import { ensureHousehold } from './household-bootstrap';
 import { getSupabaseClient, getSupabaseEmailRedirectUrl, isSupabaseConfigured } from '@/lib/supabase/client';
 
 type AuthStatus = 'unavailable' | 'loading' | 'signed_out' | 'signed_in';
 type HouseholdStatus = 'idle' | 'loading' | 'ready' | 'error';
+type EntitlementStatus = 'idle' | 'loading' | 'ready' | 'error';
 type AuthLinkMode = 'signin' | 'signup';
 
 export interface AuthContextValue {
@@ -14,6 +16,8 @@ export interface AuthContextValue {
   user: User | null;
   householdStatus: HouseholdStatus;
   household: HouseholdRecord | null;
+  entitlementStatus: EntitlementStatus;
+  householdEntitlement: HouseholdEntitlementRecord | null;
   error: string | null;
   sendEmailLink: (email: string, mode: AuthLinkMode) => Promise<boolean>;
   retryHousehold: () => Promise<void>;
@@ -31,6 +35,8 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
   const [user, setUser] = useState<User | null>(null);
   const [householdStatus, setHouseholdStatus] = useState<HouseholdStatus>('idle');
   const [household, setHousehold] = useState<HouseholdRecord | null>(null);
+  const [entitlementStatus, setEntitlementStatus] = useState<EntitlementStatus>('idle');
+  const [householdEntitlement, setHouseholdEntitlement] = useState<HouseholdEntitlementRecord | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const syncHousehold = async (nextUser: User | null) => {
@@ -39,25 +45,50 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
     if (!nextUser) {
       setHousehold(null);
       setHouseholdStatus('idle');
+      setHouseholdEntitlement(null);
+      setEntitlementStatus('idle');
       setStatus('signed_out');
       return;
     }
 
     setStatus('signed_in');
     setHouseholdStatus('loading');
+    setEntitlementStatus('loading');
 
     try {
+      const supabase = getSupabaseClient();
+      if (!supabase) {
+        throw new Error('Supabase is not configured yet.');
+      }
+
       const provisioned = await ensureHousehold(nextUser);
       setHousehold(provisioned);
       setHouseholdStatus('ready');
-      setError(null);
+
+      try {
+        const entitlementRepository = new SupabaseHouseholdEntitlementRepository(supabase);
+        const entitlement = await entitlementRepository.getByHousehold(provisioned.id);
+        setHouseholdEntitlement(entitlement);
+        setEntitlementStatus('ready');
+        setError(null);
+      } catch (entitlementError) {
+        setHouseholdEntitlement(null);
+        setEntitlementStatus('error');
+        setError(
+          entitlementError instanceof Error
+            ? entitlementError.message
+            : 'Could not load the household billing access yet.'
+        );
+      }
     } catch (bootstrapError) {
       setHousehold(null);
+      setHouseholdEntitlement(null);
       setHouseholdStatus('error');
+      setEntitlementStatus('error');
       setError(
         bootstrapError instanceof Error
           ? bootstrapError.message
-          : 'Could not prepare the family household in Supabase.'
+          : 'Could not prepare the family household and billing access in Supabase.'
       );
     }
   };
@@ -109,6 +140,8 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
       user,
       householdStatus,
       household,
+      entitlementStatus,
+      householdEntitlement,
       error,
       clearError: () => setError(null),
       sendEmailLink: async (email, mode) => {
@@ -150,7 +183,7 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
         }
       },
     }),
-    [configured, error, household, householdStatus, session, status, user]
+    [configured, entitlementStatus, error, household, householdEntitlement, householdStatus, session, status, user]
   );
 
   return <AuthContext.Provider value={authActions}>{children}</AuthContext.Provider>;

--- a/src/lib/data/models.ts
+++ b/src/lib/data/models.ts
@@ -1,6 +1,8 @@
 import type { AgeBucket, HomeScene, IconKey, RoutineType } from '@/lib/types';
 
 export type HouseholdRole = 'owner' | 'parent';
+export type BillingPlatform = 'ios' | 'android' | 'web';
+export type HouseholdEntitlementStatus = 'active' | 'revoked';
 
 export interface HouseholdRecord {
   id: string;
@@ -17,6 +19,36 @@ export interface HouseholdMemberRecord {
   householdId: string;
   userId: string;
   role: HouseholdRole;
+  createdAt: string;
+}
+
+export interface HouseholdEntitlementRecord {
+  id: string;
+  householdId: string;
+  status: HouseholdEntitlementStatus;
+  platform: BillingPlatform | null;
+  storeProductId: string | null;
+  sourceTransactionId: string | null;
+  sourceOriginalTransactionId: string | null;
+  grantedAt: string | null;
+  revokedAt: string | null;
+  verificationCheckedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PurchaseEventRecord {
+  id: string;
+  householdId: string;
+  platform: BillingPlatform;
+  eventType: string;
+  storeProductId: string | null;
+  sourceTransactionId: string | null;
+  sourceOriginalTransactionId: string | null;
+  amountMinor: number | null;
+  currency: string | null;
+  rawPayload: unknown;
+  occurredAt: string;
   createdAt: string;
 }
 

--- a/src/lib/data/repositories.ts
+++ b/src/lib/data/repositories.ts
@@ -4,7 +4,9 @@ import type {
   DailyRoutineProgressRecord,
   DailyTaskProgressRecord,
   HouseholdMemberRecord,
+  HouseholdEntitlementRecord,
   HouseholdRecord,
+  PurchaseEventRecord,
   RoutineRecord,
   RoutineTaskRecord,
 } from './models';
@@ -17,6 +19,16 @@ export interface HouseholdRepository {
   }): Promise<HouseholdRecord>;
   listMembers(householdId: string): Promise<HouseholdMemberRecord[]>;
   updateHomeScene(householdId: string, homeScene: HouseholdRecord['homeScene']): Promise<HouseholdRecord>;
+}
+
+export interface HouseholdEntitlementRepository {
+  getByHousehold(householdId: string): Promise<HouseholdEntitlementRecord | null>;
+  upsert(
+    entitlement: Omit<HouseholdEntitlementRecord, 'createdAt' | 'updatedAt'>
+  ): Promise<HouseholdEntitlementRecord>;
+  recordPurchaseEvent(
+    event: Omit<PurchaseEventRecord, 'createdAt'>
+  ): Promise<PurchaseEventRecord>;
 }
 
 export interface ChildProfileRepository {

--- a/src/lib/data/supabase-household-entitlement-repository.ts
+++ b/src/lib/data/supabase-household-entitlement-repository.ts
@@ -1,0 +1,138 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { HouseholdEntitlementRecord, PurchaseEventRecord } from './models';
+import type { HouseholdEntitlementRepository } from './repositories';
+
+const HOUSEHOLD_ENTITLEMENTS_TABLE = 'household_entitlements';
+const PURCHASE_EVENTS_TABLE = 'purchase_events';
+
+const mapHouseholdEntitlement = (row: Record<string, unknown>): HouseholdEntitlementRecord => ({
+  id: String(row.id),
+  householdId: String(row.household_id),
+  status: String(row.status) as HouseholdEntitlementRecord['status'],
+  platform:
+    row.platform === null || row.platform === undefined
+      ? null
+      : (String(row.platform) as HouseholdEntitlementRecord['platform']),
+  storeProductId:
+    row.store_product_id === null || row.store_product_id === undefined
+      ? null
+      : String(row.store_product_id),
+  sourceTransactionId:
+    row.source_transaction_id === null || row.source_transaction_id === undefined
+      ? null
+      : String(row.source_transaction_id),
+  sourceOriginalTransactionId:
+    row.source_original_transaction_id === null || row.source_original_transaction_id === undefined
+      ? null
+      : String(row.source_original_transaction_id),
+  grantedAt: row.granted_at === null || row.granted_at === undefined ? null : String(row.granted_at),
+  revokedAt: row.revoked_at === null || row.revoked_at === undefined ? null : String(row.revoked_at),
+  verificationCheckedAt:
+    row.verification_checked_at === null || row.verification_checked_at === undefined
+      ? null
+      : String(row.verification_checked_at),
+  createdAt: String(row.created_at),
+  updatedAt: String(row.updated_at),
+});
+
+const mapPurchaseEvent = (row: Record<string, unknown>): PurchaseEventRecord => ({
+  id: String(row.id),
+  householdId: String(row.household_id),
+  platform: String(row.platform) as PurchaseEventRecord['platform'],
+  eventType: String(row.event_type),
+  storeProductId:
+    row.store_product_id === null || row.store_product_id === undefined
+      ? null
+      : String(row.store_product_id),
+  sourceTransactionId:
+    row.source_transaction_id === null || row.source_transaction_id === undefined
+      ? null
+      : String(row.source_transaction_id),
+  sourceOriginalTransactionId:
+    row.source_original_transaction_id === null || row.source_original_transaction_id === undefined
+      ? null
+      : String(row.source_original_transaction_id),
+  amountMinor:
+    row.amount_minor === null || row.amount_minor === undefined ? null : Number(row.amount_minor),
+  currency: row.currency === null || row.currency === undefined ? null : String(row.currency),
+  rawPayload: row.raw_payload ?? null,
+  occurredAt: String(row.occurred_at),
+  createdAt: String(row.created_at),
+});
+
+const toEntitlementPayload = (
+  entitlement: Omit<HouseholdEntitlementRecord, 'createdAt' | 'updatedAt'>
+) => ({
+  id: entitlement.id,
+  household_id: entitlement.householdId,
+  status: entitlement.status,
+  platform: entitlement.platform,
+  store_product_id: entitlement.storeProductId,
+  source_transaction_id: entitlement.sourceTransactionId,
+  source_original_transaction_id: entitlement.sourceOriginalTransactionId,
+  granted_at: entitlement.grantedAt,
+  revoked_at: entitlement.revokedAt,
+  verification_checked_at: entitlement.verificationCheckedAt,
+});
+
+const toPurchaseEventPayload = (event: Omit<PurchaseEventRecord, 'createdAt'>) => ({
+  id: event.id,
+  household_id: event.householdId,
+  platform: event.platform,
+  event_type: event.eventType,
+  store_product_id: event.storeProductId,
+  source_transaction_id: event.sourceTransactionId,
+  source_original_transaction_id: event.sourceOriginalTransactionId,
+  amount_minor: event.amountMinor,
+  currency: event.currency,
+  raw_payload: event.rawPayload,
+  occurred_at: event.occurredAt,
+});
+
+export class SupabaseHouseholdEntitlementRepository implements HouseholdEntitlementRepository {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async getByHousehold(householdId: string) {
+    const { data, error } = await this.supabase
+      .from(HOUSEHOLD_ENTITLEMENTS_TABLE)
+      .select('*')
+      .eq('household_id', householdId)
+      .maybeSingle();
+
+    if (error) {
+      throw error;
+    }
+
+    return data ? mapHouseholdEntitlement(data) : null;
+  }
+
+  async upsert(entitlement: Omit<HouseholdEntitlementRecord, 'createdAt' | 'updatedAt'>) {
+    const { data, error } = await this.supabase
+      .from(HOUSEHOLD_ENTITLEMENTS_TABLE)
+      .upsert(toEntitlementPayload(entitlement), { onConflict: 'household_id' })
+      .select('*')
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    return mapHouseholdEntitlement(data);
+  }
+
+  async recordPurchaseEvent(event: Omit<PurchaseEventRecord, 'createdAt'>) {
+    const { data, error } = await this.supabase
+      .from(PURCHASE_EVENTS_TABLE)
+      .upsert(toPurchaseEventPayload(event), { onConflict: 'platform,event_type,source_transaction_id' })
+      .select('*')
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    return mapPurchaseEvent(data);
+  }
+}
+
+export { mapHouseholdEntitlement, mapPurchaseEvent };

--- a/src/test/accountSettingsCard.test.tsx
+++ b/src/test/accountSettingsCard.test.tsx
@@ -6,25 +6,36 @@ const sendEmailLink = vi.fn();
 const signOut = vi.fn();
 const clearError = vi.fn();
 const retryHousehold = vi.fn();
+const authState = {
+  configured: true,
+  status: 'signed_out',
+  user: null,
+  householdStatus: 'idle',
+  household: null,
+  entitlementStatus: 'idle',
+  householdEntitlement: null,
+  error: null,
+  clearError,
+  sendEmailLink,
+  retryHousehold,
+  signOut,
+};
 
 vi.mock('@/lib/auth/use-auth', () => ({
-  useAuth: () => ({
-    configured: true,
-    status: 'signed_out',
-    user: null,
-    householdStatus: 'idle',
-    household: null,
-    error: null,
-    clearError,
-    sendEmailLink,
-    retryHousehold,
-    signOut,
-  }),
+  useAuth: () => authState,
 }));
 
 describe('AccountSettingsCard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    authState.configured = true;
+    authState.status = 'signed_out';
+    authState.user = null;
+    authState.householdStatus = 'idle';
+    authState.household = null;
+    authState.entitlementStatus = 'idle';
+    authState.householdEntitlement = null;
+    authState.error = null;
     sendEmailLink.mockResolvedValue(true);
   });
 
@@ -52,5 +63,21 @@ describe('AccountSettingsCard', () => {
 
     expect(screen.getByText(/check your email/i)).toBeInTheDocument();
     expect(screen.getByText(/parent@example.com/i)).toBeInTheDocument();
+  });
+
+  it('shows unpaid access copy for a signed-in household without an entitlement yet', () => {
+    authState.status = 'signed_in';
+    authState.user = { email: 'parent@example.com' };
+    authState.householdStatus = 'ready';
+    authState.household = { name: 'Parent Family' };
+    authState.entitlementStatus = 'ready';
+    authState.householdEntitlement = null;
+
+    render(<AccountSettingsCard />);
+
+    expect(screen.getByText(/not purchased yet/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/signed in and ready for the upcoming parent-only purchase flow/i)
+    ).toBeInTheDocument();
   });
 });

--- a/src/test/supabaseHouseholdEntitlementRepository.test.ts
+++ b/src/test/supabaseHouseholdEntitlementRepository.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SupabaseHouseholdEntitlementRepository } from '@/lib/data/supabase-household-entitlement-repository';
+
+const createSupabaseClient = (responses: Record<string, unknown>) =>
+  ({
+    from: vi.fn((table: string) => responses[table]),
+  }) as never;
+
+describe('SupabaseHouseholdEntitlementRepository', () => {
+  it('loads the current household entitlement when present', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: {
+        id: 'entitlement-1',
+        household_id: 'house-1',
+        status: 'active',
+        platform: 'ios',
+        store_product_id: 'routine_stars_household_unlock',
+        source_transaction_id: 'tx-1',
+        source_original_transaction_id: 'orig-tx-1',
+        granted_at: '2026-04-20T18:00:00Z',
+        revoked_at: null,
+        verification_checked_at: '2026-04-20T18:01:00Z',
+        created_at: '2026-04-20T18:00:00Z',
+        updated_at: '2026-04-20T18:01:00Z',
+      },
+      error: null,
+    });
+    const eq = vi.fn(() => ({ maybeSingle }));
+    const repository = new SupabaseHouseholdEntitlementRepository(
+      createSupabaseClient({
+        household_entitlements: {
+          select: vi.fn(() => ({ eq })),
+        },
+      })
+    );
+
+    await expect(repository.getByHousehold('house-1')).resolves.toEqual(
+      expect.objectContaining({
+        id: 'entitlement-1',
+        householdId: 'house-1',
+        status: 'active',
+        platform: 'ios',
+      })
+    );
+  });
+
+  it('upserts household entitlement and purchase event rows using snake_case payloads', async () => {
+    const entitlementSingle = vi.fn().mockResolvedValue({
+      data: {
+        id: 'entitlement-1',
+        household_id: 'house-1',
+        status: 'active',
+        platform: 'android',
+        store_product_id: 'routine_stars_household_unlock',
+        source_transaction_id: 'tx-1',
+        source_original_transaction_id: null,
+        granted_at: '2026-04-20T18:00:00Z',
+        revoked_at: null,
+        verification_checked_at: '2026-04-20T18:01:00Z',
+        created_at: '2026-04-20T18:00:00Z',
+        updated_at: '2026-04-20T18:01:00Z',
+      },
+      error: null,
+    });
+    const entitlementSelect = vi.fn(() => ({ single: entitlementSingle }));
+    const entitlementUpsert = vi.fn(() => ({ select: entitlementSelect }));
+
+    const purchaseEventSingle = vi.fn().mockResolvedValue({
+      data: {
+        id: 'event-1',
+        household_id: 'house-1',
+        platform: 'android',
+        event_type: 'purchase_verified',
+        store_product_id: 'routine_stars_household_unlock',
+        source_transaction_id: 'tx-1',
+        source_original_transaction_id: null,
+        amount_minor: 999,
+        currency: 'EUR',
+        raw_payload: { test: true },
+        occurred_at: '2026-04-20T18:00:00Z',
+        created_at: '2026-04-20T18:01:00Z',
+      },
+      error: null,
+    });
+    const purchaseEventSelect = vi.fn(() => ({ single: purchaseEventSingle }));
+    const purchaseEventUpsert = vi.fn(() => ({ select: purchaseEventSelect }));
+
+    const repository = new SupabaseHouseholdEntitlementRepository(
+      createSupabaseClient({
+        household_entitlements: {
+          upsert: entitlementUpsert,
+        },
+        purchase_events: {
+          upsert: purchaseEventUpsert,
+        },
+      })
+    );
+
+    await expect(
+      repository.upsert({
+        id: 'entitlement-1',
+        householdId: 'house-1',
+        status: 'active',
+        platform: 'android',
+        storeProductId: 'routine_stars_household_unlock',
+        sourceTransactionId: 'tx-1',
+        sourceOriginalTransactionId: null,
+        grantedAt: '2026-04-20T18:00:00Z',
+        revokedAt: null,
+        verificationCheckedAt: '2026-04-20T18:01:00Z',
+      })
+    ).resolves.toMatchObject({
+      id: 'entitlement-1',
+      householdId: 'house-1',
+      platform: 'android',
+    });
+
+    expect(entitlementUpsert).toHaveBeenCalledWith(
+      {
+        id: 'entitlement-1',
+        household_id: 'house-1',
+        status: 'active',
+        platform: 'android',
+        store_product_id: 'routine_stars_household_unlock',
+        source_transaction_id: 'tx-1',
+        source_original_transaction_id: null,
+        granted_at: '2026-04-20T18:00:00Z',
+        revoked_at: null,
+        verification_checked_at: '2026-04-20T18:01:00Z',
+      },
+      { onConflict: 'household_id' }
+    );
+
+    await expect(
+      repository.recordPurchaseEvent({
+        id: 'event-1',
+        householdId: 'house-1',
+        platform: 'android',
+        eventType: 'purchase_verified',
+        storeProductId: 'routine_stars_household_unlock',
+        sourceTransactionId: 'tx-1',
+        sourceOriginalTransactionId: null,
+        amountMinor: 999,
+        currency: 'EUR',
+        rawPayload: { test: true },
+        occurredAt: '2026-04-20T18:00:00Z',
+      })
+    ).resolves.toMatchObject({
+      id: 'event-1',
+      householdId: 'house-1',
+      platform: 'android',
+    });
+
+    expect(purchaseEventUpsert).toHaveBeenCalledWith(
+      {
+        id: 'event-1',
+        household_id: 'house-1',
+        platform: 'android',
+        event_type: 'purchase_verified',
+        store_product_id: 'routine_stars_household_unlock',
+        source_transaction_id: 'tx-1',
+        source_original_transaction_id: null,
+        amount_minor: 999,
+        currency: 'EUR',
+        raw_payload: { test: true },
+        occurred_at: '2026-04-20T18:00:00Z',
+      },
+      { onConflict: 'platform,event_type,source_transaction_id' }
+    );
+  });
+});

--- a/supabase/migrations/20260420184000_add_household_entitlements.sql
+++ b/supabase/migrations/20260420184000_add_household_entitlements.sql
@@ -1,0 +1,63 @@
+create table if not exists public.household_entitlements (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  status text not null default 'active',
+  platform text,
+  store_product_id text,
+  source_transaction_id text,
+  source_original_transaction_id text,
+  granted_at timestamptz,
+  revoked_at timestamptz,
+  verification_checked_at timestamptz,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  unique (household_id),
+  constraint household_entitlements_status_check check (status in ('active', 'revoked')),
+  constraint household_entitlements_platform_check check (platform is null or platform in ('ios', 'android', 'web'))
+);
+
+create table if not exists public.purchase_events (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  platform text not null,
+  event_type text not null,
+  store_product_id text,
+  source_transaction_id text,
+  source_original_transaction_id text,
+  amount_minor integer,
+  currency text,
+  raw_payload jsonb not null default '{}'::jsonb,
+  occurred_at timestamptz not null default timezone('utc', now()),
+  created_at timestamptz not null default timezone('utc', now()),
+  unique (platform, event_type, source_transaction_id),
+  constraint purchase_events_platform_check check (platform in ('ios', 'android', 'web'))
+);
+
+drop trigger if exists household_entitlements_set_updated_at on public.household_entitlements;
+create trigger household_entitlements_set_updated_at
+before update on public.household_entitlements
+for each row execute procedure public.set_updated_at();
+
+alter table public.household_entitlements enable row level security;
+alter table public.purchase_events enable row level security;
+
+create policy "household members can view entitlements"
+on public.household_entitlements
+for select
+using (public.is_household_member(household_id));
+
+create policy "household members can manage entitlements"
+on public.household_entitlements
+for all
+using (public.is_household_member(household_id))
+with check (public.is_household_member(household_id));
+
+create policy "household members can view purchase events"
+on public.purchase_events
+for select
+using (public.is_household_member(household_id));
+
+create policy "household members can insert purchase events"
+on public.purchase_events
+for insert
+with check (public.is_household_member(household_id));


### PR DESCRIPTION
## Summary
Adds the first native-billing entitlement foundation so signed-in households can expose paid vs unpaid state before store verification and purchase UI are implemented.

## What changed
- adds Supabase schema support for `household_entitlements` and `purchase_events`
- adds a `SupabaseHouseholdEntitlementRepository`
- extends auth/bootstrap state to load household entitlement data
- surfaces parent-facing access state in the account settings card
- adds repository and UI tests for the new entitlement behavior

## Why
Routine Stars now has a native-first billing direction. Before we build a parent-only purchase gate or store verification, the app needs a durable place to read and display household access state.

## Validation
- `npm test`

## Related issues
- Addresses #20
- Supports #19
- Supports #18