### PR TITLE
[codex] Add native billing bridge selection

### DIFF
--- a/src/lib/billing/billing-context.tsx
+++ b/src/lib/billing/billing-context.tsx
@@ -1,9 +1,9 @@
 import { createContext, useContext, useMemo, useState, type PropsWithChildren } from 'react';
-import { createDefaultBillingAdapter } from './default-billing-adapter';
+import { createBillingAdapter } from './create-billing-adapter';
 import type { BillingActionResult } from './types';
 
 interface BillingContextValue {
-  householdUnlockProduct: ReturnType<ReturnType<typeof createDefaultBillingAdapter>['getHouseholdUnlockProduct']>;
+  householdUnlockProduct: ReturnType<ReturnType<typeof createBillingAdapter>['getHouseholdUnlockProduct']>;
   isProcessing: boolean;
   purchaseHouseholdUnlock: () => Promise<BillingActionResult>;
   restorePurchases: () => Promise<BillingActionResult>;
@@ -12,7 +12,7 @@ interface BillingContextValue {
 const BillingContext = createContext<BillingContextValue | null>(null);
 
 export const BillingProvider = ({ children }: PropsWithChildren) => {
-  const adapter = useMemo(() => createDefaultBillingAdapter(), []);
+  const adapter = useMemo(() => createBillingAdapter(), []);
   const [isProcessing, setIsProcessing] = useState(false);
 
   const value = useMemo<BillingContextValue>(

--- a/src/lib/billing/create-billing-adapter.ts
+++ b/src/lib/billing/create-billing-adapter.ts
@@ -1,0 +1,12 @@
+import type { BillingAdapter } from './types';
+import { createDefaultBillingAdapter } from './default-billing-adapter';
+import { createNativeBillingAdapter, getNativeBillingBridge } from './native-billing-bridge';
+
+export const createBillingAdapter = (): BillingAdapter => {
+  const nativeBridge = getNativeBillingBridge();
+  if (nativeBridge) {
+    return createNativeBillingAdapter(nativeBridge);
+  }
+
+  return createDefaultBillingAdapter();
+};

--- a/src/lib/billing/default-billing-adapter.ts
+++ b/src/lib/billing/default-billing-adapter.ts
@@ -1,40 +1,22 @@
 import { HOUSEHOLD_LIFETIME_UNLOCK } from './config';
 import type { BillingAdapter } from './types';
 
-const isNativeStoreRuntimeAvailable = () =>
-  typeof window !== 'undefined' &&
-  'Capacitor' in window;
-
 export const createDefaultBillingAdapter = (): BillingAdapter => ({
   getHouseholdUnlockProduct: () => HOUSEHOLD_LIFETIME_UNLOCK,
   purchaseHouseholdUnlock: async () => {
-    if (!isNativeStoreRuntimeAvailable()) {
-      return {
-        status: 'unsupported',
-        message:
-          'Native store billing is not connected in this build yet. The purchase button is wired and ready for the next integration slice.',
-      };
-    }
-
     return {
-      status: 'ready',
+      status: 'unsupported',
       message:
-        'Native billing runtime detected. The next slice will connect this button to the Apple and Google purchase SDKs.',
+        'Native store billing is not connected in this build yet. The purchase button is wired and ready for the next integration slice.',
+      source: 'fallback',
     };
   },
   restorePurchases: async () => {
-    if (!isNativeStoreRuntimeAvailable()) {
-      return {
-        status: 'unsupported',
-        message:
-          'Restore purchases is not connected in this browser build yet. The restore entry point is ready for the native billing integration slice.',
-      };
-    }
-
     return {
-      status: 'ready',
+      status: 'unsupported',
       message:
-        'Native billing runtime detected. The next slice will connect this restore flow to Apple and Google purchase restoration.',
+        'Restore purchases is not connected in this browser build yet. The restore entry point is ready for the native billing integration slice.',
+      source: 'fallback',
     };
   },
 });

--- a/src/lib/billing/native-billing-bridge.ts
+++ b/src/lib/billing/native-billing-bridge.ts
@@ -1,0 +1,83 @@
+import type { BillingPlatform } from '@/lib/data/models';
+import type { BillingActionResult, BillingAdapter } from './types';
+import { HOUSEHOLD_LIFETIME_UNLOCK } from './config';
+
+export interface NativeBillingBridgeResult {
+  status: 'ready' | 'error' | 'cancelled';
+  message?: string;
+  platform?: BillingPlatform;
+  storeProductId?: string | null;
+  sourceTransactionId?: string | null;
+  sourceOriginalTransactionId?: string | null;
+}
+
+export interface NativeBillingBridge {
+  purchaseHouseholdUnlock(input: {
+    appProductId: string;
+    iosProductId: string;
+    androidProductId: string;
+  }): Promise<NativeBillingBridgeResult>;
+  restorePurchases(input: {
+    appProductId: string;
+    iosProductId: string;
+    androidProductId: string;
+  }): Promise<NativeBillingBridgeResult>;
+}
+
+declare global {
+  interface Window {
+    RoutineStarsBilling?: NativeBillingBridge;
+    Capacitor?: {
+      Plugins?: {
+        RoutineStarsBilling?: NativeBillingBridge;
+      };
+    };
+  }
+}
+
+const toBillingActionResult = (
+  result: NativeBillingBridgeResult,
+  fallbackMessage: string
+): BillingActionResult => ({
+  status: result.status,
+  message: result.message ?? fallbackMessage,
+  source: 'native_bridge',
+  platform: result.platform,
+  storeProductId: result.storeProductId ?? null,
+  sourceTransactionId: result.sourceTransactionId ?? null,
+  sourceOriginalTransactionId: result.sourceOriginalTransactionId ?? null,
+});
+
+export const getNativeBillingBridge = (): NativeBillingBridge | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  return (
+    window.RoutineStarsBilling ??
+    window.Capacitor?.Plugins?.RoutineStarsBilling ??
+    null
+  );
+};
+
+export const createNativeBillingAdapter = (bridge: NativeBillingBridge): BillingAdapter => ({
+  getHouseholdUnlockProduct: () => HOUSEHOLD_LIFETIME_UNLOCK,
+  purchaseHouseholdUnlock: async () =>
+    toBillingActionResult(
+      await bridge.purchaseHouseholdUnlock({
+        appProductId: HOUSEHOLD_LIFETIME_UNLOCK.id,
+        iosProductId: HOUSEHOLD_LIFETIME_UNLOCK.platformProductIds.ios,
+        androidProductId: HOUSEHOLD_LIFETIME_UNLOCK.platformProductIds.android,
+      }),
+      'The native purchase flow returned without a message.'
+    ),
+  restorePurchases: async () =>
+    toBillingActionResult(
+      await bridge.restorePurchases({
+        appProductId: HOUSEHOLD_LIFETIME_UNLOCK.id,
+        iosProductId: HOUSEHOLD_LIFETIME_UNLOCK.platformProductIds.ios,
+        androidProductId: HOUSEHOLD_LIFETIME_UNLOCK.platformProductIds.android,
+      }),
+      'The native restore flow returned without a message.'
+    ),
+});

--- a/src/lib/billing/types.ts
+++ b/src/lib/billing/types.ts
@@ -1,8 +1,14 @@
 import type { BillingProduct } from './config';
+import type { BillingPlatform } from '@/lib/data/models';
 
 export interface BillingActionResult {
-  status: 'ready' | 'unsupported' | 'error';
+  status: 'ready' | 'unsupported' | 'error' | 'cancelled';
   message: string;
+  source: 'native_bridge' | 'fallback';
+  platform?: BillingPlatform;
+  storeProductId?: string | null;
+  sourceTransactionId?: string | null;
+  sourceOriginalTransactionId?: string | null;
 }
 
 export interface BillingAdapter {

--- a/src/test/defaultBillingAdapter.test.ts
+++ b/src/test/defaultBillingAdapter.test.ts
@@ -19,12 +19,14 @@ describe('createDefaultBillingAdapter', () => {
     await expect(adapter.purchaseHouseholdUnlock()).resolves.toEqual(
       expect.objectContaining({
         status: 'unsupported',
+        source: 'fallback',
       })
     );
 
     await expect(adapter.restorePurchases()).resolves.toEqual(
       expect.objectContaining({
         status: 'unsupported',
+        source: 'fallback',
       })
     );
   });

--- a/src/test/nativeBillingBridge.test.ts
+++ b/src/test/nativeBillingBridge.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createBillingAdapter } from '@/lib/billing/create-billing-adapter';
+import { getNativeBillingBridge } from '@/lib/billing/native-billing-bridge';
+
+describe('native billing bridge', () => {
+  afterEach(() => {
+    delete window.RoutineStarsBilling;
+    delete window.Capacitor;
+  });
+
+  it('returns null when no native billing bridge is present', () => {
+    expect(getNativeBillingBridge()).toBeNull();
+  });
+
+  it('selects the window bridge when present and normalizes purchase results', async () => {
+    window.RoutineStarsBilling = {
+      purchaseHouseholdUnlock: vi.fn().mockResolvedValue({
+        status: 'ready',
+        message: 'Purchase completed.',
+        platform: 'ios',
+        storeProductId: 'routine_stars_household_unlock',
+        sourceTransactionId: 'tx-1',
+        sourceOriginalTransactionId: 'orig-1',
+      }),
+      restorePurchases: vi.fn().mockResolvedValue({
+        status: 'ready',
+        message: 'Purchases restored.',
+        platform: 'ios',
+      }),
+    };
+
+    const adapter = createBillingAdapter();
+    const result = await adapter.purchaseHouseholdUnlock();
+
+    expect(window.RoutineStarsBilling.purchaseHouseholdUnlock).toHaveBeenCalledWith({
+      appProductId: 'household_lifetime_unlock',
+      iosProductId: 'routine_stars_household_unlock',
+      androidProductId: 'routine_stars_household_unlock',
+    });
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: 'ready',
+        source: 'native_bridge',
+        platform: 'ios',
+        storeProductId: 'routine_stars_household_unlock',
+        sourceTransactionId: 'tx-1',
+      })
+    );
+  });
+
+  it('falls back to the Capacitor plugin bridge when present', async () => {
+    window.Capacitor = {
+      Plugins: {
+        RoutineStarsBilling: {
+          purchaseHouseholdUnlock: vi.fn().mockResolvedValue({
+            status: 'cancelled',
+            message: 'Purchase cancelled.',
+            platform: 'android',
+          }),
+          restorePurchases: vi.fn().mockResolvedValue({
+            status: 'ready',
+            message: 'Restore completed.',
+            platform: 'android',
+          }),
+        },
+      },
+    };
+
+    const adapter = createBillingAdapter();
+    const result = await adapter.restorePurchases();
+
+    expect(window.Capacitor.Plugins.RoutineStarsBilling.restorePurchases).toHaveBeenCalledWith({
+      appProductId: 'household_lifetime_unlock',
+      iosProductId: 'routine_stars_household_unlock',
+      androidProductId: 'routine_stars_household_unlock',
+    });
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: 'ready',
+        source: 'native_bridge',
+        platform: 'android',
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Adds a native billing bridge contract and adapter selection so the billing layer can use a real runtime bridge when one is present, while keeping the current browser fallback intact.

## What changed
- adds a typed native billing bridge contract for purchase and restore flows
- adds runtime bridge detection for `window.RoutineStarsBilling` and `window.Capacitor?.Plugins?.RoutineStarsBilling`
- adds adapter selection between native bridge and browser fallback
- normalizes purchase and restore results into the shared billing action shape
- adds tests for bridge detection, native normalization, and fallback behavior

## Why
The billing adapter foundation is in place, but the app still needed a clean seam for an actual native runtime. This lets us plug in Apple and Google store wiring without rewriting the parent purchase UI again.

## Validation
- `npm test`

## Related issues
- Addresses #34
- Supports #32
- Supports #20
- Stacks on #33