### PR TITLE
[codex] Record billing events after native results

### DIFF
--- a/src/lib/billing/billing-context.tsx
+++ b/src/lib/billing/billing-context.tsx
@@ -1,6 +1,9 @@
 import { createContext, useContext, useMemo, useState, type PropsWithChildren } from 'react';
 import { createBillingAdapter } from './create-billing-adapter';
 import type { BillingActionResult } from './types';
+import { useAuth } from '@/lib/auth/use-auth';
+import { getSupabaseClient } from '@/lib/supabase/client';
+import { SupabaseHouseholdEntitlementRepository } from '@/lib/data/supabase-household-entitlement-repository';
 
 interface BillingContextValue {
   householdUnlockProduct: ReturnType<ReturnType<typeof createBillingAdapter>['getHouseholdUnlockProduct']>;
@@ -13,7 +16,50 @@ const BillingContext = createContext<BillingContextValue | null>(null);
 
 export const BillingProvider = ({ children }: PropsWithChildren) => {
   const adapter = useMemo(() => createBillingAdapter(), []);
+  const { household, retryHousehold, status: authStatus } = useAuth();
   const [isProcessing, setIsProcessing] = useState(false);
+
+  const persistSuccessfulBillingResult = async (
+    result: BillingActionResult,
+    eventType: string
+  ) => {
+    if (
+      result.status !== 'ready' ||
+      result.source !== 'native_bridge' ||
+      !household ||
+      authStatus !== 'signed_in'
+    ) {
+      return result;
+    }
+
+    const supabase = getSupabaseClient();
+    if (!supabase || !result.platform) {
+      return result;
+    }
+
+    const repository = new SupabaseHouseholdEntitlementRepository(supabase);
+
+    await repository.recordPurchaseEvent({
+      id: crypto.randomUUID(),
+      householdId: household.id,
+      platform: result.platform,
+      eventType,
+      storeProductId: result.storeProductId ?? null,
+      sourceTransactionId: result.sourceTransactionId ?? null,
+      sourceOriginalTransactionId: result.sourceOriginalTransactionId ?? null,
+      amountMinor: null,
+      currency: null,
+      rawPayload: result,
+      occurredAt: new Date().toISOString(),
+    });
+
+    await retryHousehold();
+
+    return {
+      ...result,
+      message: `${result.message} Household access was refreshed just now.`,
+    } satisfies BillingActionResult;
+  };
 
   const value = useMemo<BillingContextValue>(
     () => ({
@@ -22,7 +68,8 @@ export const BillingProvider = ({ children }: PropsWithChildren) => {
       purchaseHouseholdUnlock: async () => {
         setIsProcessing(true);
         try {
-          return await adapter.purchaseHouseholdUnlock();
+          const result = await adapter.purchaseHouseholdUnlock();
+          return await persistSuccessfulBillingResult(result, 'household_unlock_purchase_completed');
         } finally {
           setIsProcessing(false);
         }
@@ -30,13 +77,14 @@ export const BillingProvider = ({ children }: PropsWithChildren) => {
       restorePurchases: async () => {
         setIsProcessing(true);
         try {
-          return await adapter.restorePurchases();
+          const result = await adapter.restorePurchases();
+          return await persistSuccessfulBillingResult(result, 'household_unlock_restore_completed');
         } finally {
           setIsProcessing(false);
         }
       },
     }),
-    [adapter, isProcessing]
+    [adapter, authStatus, household, isProcessing, retryHousehold]
   );
 
   return <BillingContext.Provider value={value}>{children}</BillingContext.Provider>;

--- a/src/test/billingContext.test.tsx
+++ b/src/test/billingContext.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BillingProvider, useBilling } from '@/lib/billing/billing-context';
+
+const { purchaseHouseholdUnlock, restorePurchases, recordPurchaseEvent, getSupabaseClient } = vi.hoisted(() => ({
+  purchaseHouseholdUnlock: vi.fn(),
+  restorePurchases: vi.fn(),
+  recordPurchaseEvent: vi.fn(),
+  getSupabaseClient: vi.fn(() => ({})),
+}));
+
+const authState = {
+  status: 'signed_in',
+  household: { id: 'house-1', name: 'Family' },
+  retryHousehold: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock('@/lib/auth/use-auth', () => ({
+  useAuth: () => authState,
+}));
+
+vi.mock('@/lib/billing/create-billing-adapter', () => ({
+  createBillingAdapter: () => ({
+    getHouseholdUnlockProduct: () => ({
+      id: 'household_lifetime_unlock',
+      displayName: 'Routine Stars Household Unlock',
+      description: 'One-time lifetime unlock for one household account.',
+      priceLabel: 'EUR 9.99',
+      platformProductIds: {
+        ios: 'routine_stars_household_unlock',
+        android: 'routine_stars_household_unlock',
+      },
+    }),
+    purchaseHouseholdUnlock,
+    restorePurchases,
+  }),
+}));
+
+vi.mock('@/lib/supabase/client', () => ({
+  getSupabaseClient,
+}));
+
+vi.mock('@/lib/data/supabase-household-entitlement-repository', () => ({
+  SupabaseHouseholdEntitlementRepository: class {
+    recordPurchaseEvent = recordPurchaseEvent;
+  },
+}));
+
+const Probe = () => {
+  const billing = useBilling();
+
+  return (
+    <div>
+      <div data-testid="price">{billing.householdUnlockProduct.priceLabel}</div>
+      <button type="button" onClick={() => void billing.purchaseHouseholdUnlock()}>
+        purchase
+      </button>
+      <button type="button" onClick={() => void billing.restorePurchases()}>
+        restore
+      </button>
+    </div>
+  );
+};
+
+describe('BillingProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.status = 'signed_in';
+    authState.household = { id: 'house-1', name: 'Family' };
+    purchaseHouseholdUnlock.mockResolvedValue({
+      status: 'ready',
+      source: 'native_bridge',
+      message: 'Purchase completed.',
+      platform: 'ios',
+      storeProductId: 'routine_stars_household_unlock',
+      sourceTransactionId: 'tx-1',
+      sourceOriginalTransactionId: 'orig-1',
+    });
+    restorePurchases.mockResolvedValue({
+      status: 'unsupported',
+      source: 'fallback',
+      message: 'Restore unavailable.',
+    });
+    recordPurchaseEvent.mockResolvedValue({
+      id: 'event-1',
+    });
+  });
+
+  it('records successful native purchases and refreshes household access', async () => {
+    render(
+      <BillingProvider>
+        <Probe />
+      </BillingProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'purchase' }));
+
+    await waitFor(() => {
+      expect(recordPurchaseEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          householdId: 'house-1',
+          platform: 'ios',
+          eventType: 'household_unlock_purchase_completed',
+          sourceTransactionId: 'tx-1',
+        })
+      );
+      expect(authState.retryHousehold).toHaveBeenCalled();
+    });
+  });
+
+  it('does not record fallback restore results', async () => {
+    render(
+      <BillingProvider>
+        <Probe />
+      </BillingProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'restore' }));
+
+    await waitFor(() => {
+      expect(restorePurchases).toHaveBeenCalled();
+    });
+
+    expect(recordPurchaseEvent).not.toHaveBeenCalled();
+    expect(authState.retryHousehold).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
When a native purchase or restore result succeeds, the billing layer now records a purchase event in Supabase and refreshes household access state instead of only returning a UI message.

## What changed
- records successful native billing results into `purchase_events`
- refreshes household entitlement state after successful native purchase and restore actions
- keeps fallback browser behavior unchanged for unsupported builds
- adds focused billing provider tests for event recording and refresh behavior

## Why
The native billing bridge and adapter are in place, but successful billing actions still needed to create durable app-side movement. This slice gives us event history and an entitlement refresh loop before full receipt verification is wired.

## Validation
- `npm test`

## Related issues
- Addresses #36
- Supports #34
- Supports #20
- Stacks on #35