### PR TITLE
[codex] Add billing verification payload plumbing

### DIFF
--- a/src/lib/billing/billing-context.tsx
+++ b/src/lib/billing/billing-context.tsx
@@ -49,7 +49,10 @@ export const BillingProvider = ({ children }: PropsWithChildren) => {
       sourceOriginalTransactionId: result.sourceOriginalTransactionId ?? null,
       amountMinor: null,
       currency: null,
-      rawPayload: result,
+      rawPayload: {
+        result,
+        verificationPayload: result.verificationPayload ?? null,
+      },
       occurredAt: new Date().toISOString(),
     });
 

--- a/src/lib/billing/default-billing-adapter.ts
+++ b/src/lib/billing/default-billing-adapter.ts
@@ -9,6 +9,7 @@ export const createDefaultBillingAdapter = (): BillingAdapter => ({
       message:
         'Native store billing is not connected in this build yet. The purchase button is wired and ready for the next integration slice.',
       source: 'fallback',
+      verificationPayload: null,
     };
   },
   restorePurchases: async () => {
@@ -17,6 +18,7 @@ export const createDefaultBillingAdapter = (): BillingAdapter => ({
       message:
         'Restore purchases is not connected in this browser build yet. The restore entry point is ready for the native billing integration slice.',
       source: 'fallback',
+      verificationPayload: null,
     };
   },
 });

--- a/src/lib/billing/native-billing-bridge.ts
+++ b/src/lib/billing/native-billing-bridge.ts
@@ -1,5 +1,5 @@
 import type { BillingPlatform } from '@/lib/data/models';
-import type { BillingActionResult, BillingAdapter } from './types';
+import type { BillingActionResult, BillingAdapter, BillingVerificationPayload } from './types';
 import { HOUSEHOLD_LIFETIME_UNLOCK } from './config';
 
 export interface NativeBillingBridgeResult {
@@ -9,6 +9,8 @@ export interface NativeBillingBridgeResult {
   storeProductId?: string | null;
   sourceTransactionId?: string | null;
   sourceOriginalTransactionId?: string | null;
+  receiptData?: string | null;
+  purchaseToken?: string | null;
 }
 
 export interface NativeBillingBridge {
@@ -38,15 +40,31 @@ declare global {
 const toBillingActionResult = (
   result: NativeBillingBridgeResult,
   fallbackMessage: string
-): BillingActionResult => ({
-  status: result.status,
-  message: result.message ?? fallbackMessage,
-  source: 'native_bridge',
-  platform: result.platform,
-  storeProductId: result.storeProductId ?? null,
-  sourceTransactionId: result.sourceTransactionId ?? null,
-  sourceOriginalTransactionId: result.sourceOriginalTransactionId ?? null,
-});
+): BillingActionResult => {
+  const verificationPayload: BillingVerificationPayload | null =
+    result.platform === 'ios' || result.platform === 'android'
+      ? {
+          platform: result.platform,
+          appProductId: HOUSEHOLD_LIFETIME_UNLOCK.id,
+          storeProductId: result.storeProductId ?? null,
+          sourceTransactionId: result.sourceTransactionId ?? null,
+          sourceOriginalTransactionId: result.sourceOriginalTransactionId ?? null,
+          receiptData: result.receiptData ?? null,
+          purchaseToken: result.purchaseToken ?? null,
+        }
+      : null;
+
+  return {
+    status: result.status,
+    message: result.message ?? fallbackMessage,
+    source: 'native_bridge',
+    platform: result.platform,
+    storeProductId: result.storeProductId ?? null,
+    sourceTransactionId: result.sourceTransactionId ?? null,
+    sourceOriginalTransactionId: result.sourceOriginalTransactionId ?? null,
+    verificationPayload,
+  };
+};
 
 export const getNativeBillingBridge = (): NativeBillingBridge | null => {
   if (typeof window === 'undefined') {

--- a/src/lib/billing/types.ts
+++ b/src/lib/billing/types.ts
@@ -1,6 +1,16 @@
 import type { BillingProduct } from './config';
 import type { BillingPlatform } from '@/lib/data/models';
 
+export interface BillingVerificationPayload {
+  platform: Extract<BillingPlatform, 'ios' | 'android'>;
+  appProductId: string;
+  storeProductId: string | null;
+  sourceTransactionId: string | null;
+  sourceOriginalTransactionId: string | null;
+  receiptData: string | null;
+  purchaseToken: string | null;
+}
+
 export interface BillingActionResult {
   status: 'ready' | 'unsupported' | 'error' | 'cancelled';
   message: string;
@@ -9,6 +19,7 @@ export interface BillingActionResult {
   storeProductId?: string | null;
   sourceTransactionId?: string | null;
   sourceOriginalTransactionId?: string | null;
+  verificationPayload?: BillingVerificationPayload | null;
 }
 
 export interface BillingAdapter {

--- a/src/test/billingContext.test.tsx
+++ b/src/test/billingContext.test.tsx
@@ -75,11 +75,21 @@ describe('BillingProvider', () => {
       storeProductId: 'routine_stars_household_unlock',
       sourceTransactionId: 'tx-1',
       sourceOriginalTransactionId: 'orig-1',
+      verificationPayload: {
+        platform: 'ios',
+        appProductId: 'household_lifetime_unlock',
+        storeProductId: 'routine_stars_household_unlock',
+        sourceTransactionId: 'tx-1',
+        sourceOriginalTransactionId: 'orig-1',
+        receiptData: 'signed-receipt',
+        purchaseToken: null,
+      },
     });
     restorePurchases.mockResolvedValue({
       status: 'unsupported',
       source: 'fallback',
       message: 'Restore unavailable.',
+      verificationPayload: null,
     });
     recordPurchaseEvent.mockResolvedValue({
       id: 'event-1',
@@ -102,6 +112,12 @@ describe('BillingProvider', () => {
           platform: 'ios',
           eventType: 'household_unlock_purchase_completed',
           sourceTransactionId: 'tx-1',
+          rawPayload: expect.objectContaining({
+            verificationPayload: expect.objectContaining({
+              platform: 'ios',
+              receiptData: 'signed-receipt',
+            }),
+          }),
         })
       );
       expect(authState.retryHousehold).toHaveBeenCalled();

--- a/src/test/defaultBillingAdapter.test.ts
+++ b/src/test/defaultBillingAdapter.test.ts
@@ -20,6 +20,7 @@ describe('createDefaultBillingAdapter', () => {
       expect.objectContaining({
         status: 'unsupported',
         source: 'fallback',
+        verificationPayload: null,
       })
     );
 
@@ -27,6 +28,7 @@ describe('createDefaultBillingAdapter', () => {
       expect.objectContaining({
         status: 'unsupported',
         source: 'fallback',
+        verificationPayload: null,
       })
     );
   });

--- a/src/test/nativeBillingBridge.test.ts
+++ b/src/test/nativeBillingBridge.test.ts
@@ -21,6 +21,7 @@ describe('native billing bridge', () => {
         storeProductId: 'routine_stars_household_unlock',
         sourceTransactionId: 'tx-1',
         sourceOriginalTransactionId: 'orig-1',
+        receiptData: 'signed-receipt',
       }),
       restorePurchases: vi.fn().mockResolvedValue({
         status: 'ready',
@@ -44,6 +45,12 @@ describe('native billing bridge', () => {
         platform: 'ios',
         storeProductId: 'routine_stars_household_unlock',
         sourceTransactionId: 'tx-1',
+        verificationPayload: expect.objectContaining({
+          platform: 'ios',
+          appProductId: 'household_lifetime_unlock',
+          receiptData: 'signed-receipt',
+          purchaseToken: null,
+        }),
       })
     );
   });
@@ -56,11 +63,13 @@ describe('native billing bridge', () => {
             status: 'cancelled',
             message: 'Purchase cancelled.',
             platform: 'android',
+            purchaseToken: 'purchase-token',
           }),
           restorePurchases: vi.fn().mockResolvedValue({
             status: 'ready',
             message: 'Restore completed.',
             platform: 'android',
+            purchaseToken: 'restore-token',
           }),
         },
       },
@@ -79,6 +88,11 @@ describe('native billing bridge', () => {
         status: 'ready',
         source: 'native_bridge',
         platform: 'android',
+        verificationPayload: expect.objectContaining({
+          platform: 'android',
+          purchaseToken: 'restore-token',
+          receiptData: null,
+        }),
       })
     );
   });


### PR DESCRIPTION
## Summary
Extends the native billing result pipeline so purchase and restore actions can carry the receipt or purchase-token evidence needed for backend verification.

## What changed
- adds a normalized `verificationPayload` shape to billing action results
- extends native bridge results with `receiptData` and `purchaseToken`
- propagates verification payloads through the native adapter and fallback adapter
- includes verification payloads in recorded purchase-event raw payloads
- adds tests covering verification payload propagation through the bridge and billing provider

## Why
Billing events and entitlement refresh are in place, but the app still needed a structured way to carry Apple and Google store evidence forward into backend verification. This keeps the next backend slice focused on verification logic instead of result-shape cleanup.

## Validation
- `npm test`

## Related issues
- Addresses #38
- Supports #36
- Supports #20
- Stacks on #37