### PR TITLE
[codex] Add billing verification client contract

### DIFF
--- a/src/lib/billing/billing-context.tsx
+++ b/src/lib/billing/billing-context.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useMemo, useState, type PropsWithChildren } from 'react';
 import { createBillingAdapter } from './create-billing-adapter';
 import type { BillingActionResult } from './types';
+import { createBillingVerificationClient } from './verification-client';
 import { useAuth } from '@/lib/auth/use-auth';
 import { getSupabaseClient } from '@/lib/supabase/client';
 import { SupabaseHouseholdEntitlementRepository } from '@/lib/data/supabase-household-entitlement-repository';
@@ -16,6 +17,7 @@ const BillingContext = createContext<BillingContextValue | null>(null);
 
 export const BillingProvider = ({ children }: PropsWithChildren) => {
   const adapter = useMemo(() => createBillingAdapter(), []);
+  const verificationClient = useMemo(() => createBillingVerificationClient(), []);
   const { household, retryHousehold, status: authStatus } = useAuth();
   const [isProcessing, setIsProcessing] = useState(false);
 
@@ -38,6 +40,16 @@ export const BillingProvider = ({ children }: PropsWithChildren) => {
     }
 
     const repository = new SupabaseHouseholdEntitlementRepository(supabase);
+    const verificationRequest = result.verificationPayload
+      ? {
+          householdId: household.id,
+          eventType,
+          verificationPayload: result.verificationPayload,
+        }
+      : null;
+    const verificationResponse = verificationRequest
+      ? await verificationClient.verifyHouseholdUnlock(verificationRequest)
+      : null;
 
     await repository.recordPurchaseEvent({
       id: crypto.randomUUID(),
@@ -52,6 +64,8 @@ export const BillingProvider = ({ children }: PropsWithChildren) => {
       rawPayload: {
         result,
         verificationPayload: result.verificationPayload ?? null,
+        verificationRequest,
+        verificationResponse,
       },
       occurredAt: new Date().toISOString(),
     });
@@ -60,7 +74,7 @@ export const BillingProvider = ({ children }: PropsWithChildren) => {
 
     return {
       ...result,
-      message: `${result.message} Household access was refreshed just now.`,
+      message: `${result.message} ${verificationResponse?.message ? `${verificationResponse.message} ` : ''}Household access was refreshed just now.`,
     } satisfies BillingActionResult;
   };
 
@@ -87,7 +101,7 @@ export const BillingProvider = ({ children }: PropsWithChildren) => {
         }
       },
     }),
-    [adapter, authStatus, household, isProcessing, retryHousehold]
+    [adapter, authStatus, household, isProcessing, retryHousehold, verificationClient]
   );
 
   return <BillingContext.Provider value={value}>{children}</BillingContext.Provider>;

--- a/src/lib/billing/verification-client.ts
+++ b/src/lib/billing/verification-client.ts
@@ -1,0 +1,24 @@
+import type { BillingVerificationPayload } from './types';
+
+export interface BillingVerificationRequest {
+  householdId: string;
+  eventType: string;
+  verificationPayload: BillingVerificationPayload;
+}
+
+export interface BillingVerificationResponse {
+  status: 'verified' | 'pending' | 'unsupported' | 'error';
+  message: string;
+}
+
+export interface BillingVerificationClient {
+  verifyHouseholdUnlock(request: BillingVerificationRequest): Promise<BillingVerificationResponse>;
+}
+
+export const createBillingVerificationClient = (): BillingVerificationClient => ({
+  verifyHouseholdUnlock: async (_request) => ({
+    status: 'unsupported',
+    message:
+      'Backend verification is not connected in this build yet. The app captured the store evidence and is ready for the next server integration slice.',
+  }),
+});

--- a/src/test/billingContext.test.tsx
+++ b/src/test/billingContext.test.tsx
@@ -2,11 +2,12 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BillingProvider, useBilling } from '@/lib/billing/billing-context';
 
-const { purchaseHouseholdUnlock, restorePurchases, recordPurchaseEvent, getSupabaseClient } = vi.hoisted(() => ({
+const { purchaseHouseholdUnlock, restorePurchases, recordPurchaseEvent, getSupabaseClient, verifyHouseholdUnlock } = vi.hoisted(() => ({
   purchaseHouseholdUnlock: vi.fn(),
   restorePurchases: vi.fn(),
   recordPurchaseEvent: vi.fn(),
   getSupabaseClient: vi.fn(() => ({})),
+  verifyHouseholdUnlock: vi.fn(),
 }));
 
 const authState = {
@@ -44,6 +45,12 @@ vi.mock('@/lib/data/supabase-household-entitlement-repository', () => ({
   SupabaseHouseholdEntitlementRepository: class {
     recordPurchaseEvent = recordPurchaseEvent;
   },
+}));
+
+vi.mock('@/lib/billing/verification-client', () => ({
+  createBillingVerificationClient: () => ({
+    verifyHouseholdUnlock,
+  }),
 }));
 
 const Probe = () => {
@@ -94,6 +101,10 @@ describe('BillingProvider', () => {
     recordPurchaseEvent.mockResolvedValue({
       id: 'event-1',
     });
+    verifyHouseholdUnlock.mockResolvedValue({
+      status: 'unsupported',
+      message: 'Backend verification is not connected in this build yet.',
+    });
   });
 
   it('records successful native purchases and refreshes household access', async () => {
@@ -106,6 +117,14 @@ describe('BillingProvider', () => {
     fireEvent.click(screen.getByRole('button', { name: 'purchase' }));
 
     await waitFor(() => {
+      expect(verifyHouseholdUnlock).toHaveBeenCalledWith({
+        householdId: 'house-1',
+        eventType: 'household_unlock_purchase_completed',
+        verificationPayload: expect.objectContaining({
+          platform: 'ios',
+          receiptData: 'signed-receipt',
+        }),
+      });
       expect(recordPurchaseEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           householdId: 'house-1',
@@ -113,6 +132,12 @@ describe('BillingProvider', () => {
           eventType: 'household_unlock_purchase_completed',
           sourceTransactionId: 'tx-1',
           rawPayload: expect.objectContaining({
+            verificationRequest: expect.objectContaining({
+              householdId: 'house-1',
+            }),
+            verificationResponse: expect.objectContaining({
+              status: 'unsupported',
+            }),
             verificationPayload: expect.objectContaining({
               platform: 'ios',
               receiptData: 'signed-receipt',
@@ -138,6 +163,7 @@ describe('BillingProvider', () => {
     });
 
     expect(recordPurchaseEvent).not.toHaveBeenCalled();
+    expect(verifyHouseholdUnlock).not.toHaveBeenCalled();
     expect(authState.retryHousehold).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
Adds an app-side verification client contract so successful native billing results are handed to a dedicated verification seam before the current entitlement refresh path runs.

## What changed
- adds billing verification request and response types plus a default verification client stub
- routes successful native billing results through the verification client
- records verification request/response details alongside purchase events
- keeps unsupported browser behavior graceful while the backend endpoint is still missing
- adds focused tests covering verification handoff behavior

## Why
The billing layer can now carry store evidence, but it still needed a stable app-to-backend verification contract before the real server-side verification logic is implemented. This keeps the next backend slice focused on the server boundary instead of UI plumbing.

## Validation
- `npm test`

## Related issues
- Addresses #40
- Supports #38
- Supports #20
- Stacks on #39