### PR TITLE
[codex] Add billing verification transport

### DIFF
--- a/src/lib/billing/verification-client.ts
+++ b/src/lib/billing/verification-client.ts
@@ -1,4 +1,5 @@
 import type { BillingVerificationPayload } from './types';
+import { getSupabaseClient } from '@/lib/supabase/client';
 
 export interface BillingVerificationRequest {
   householdId: string;
@@ -15,10 +16,50 @@ export interface BillingVerificationClient {
   verifyHouseholdUnlock(request: BillingVerificationRequest): Promise<BillingVerificationResponse>;
 }
 
+export const BILLING_VERIFICATION_FUNCTION = 'verify-household-unlock';
+
 export const createBillingVerificationClient = (): BillingVerificationClient => ({
-  verifyHouseholdUnlock: async (_request) => ({
-    status: 'unsupported',
-    message:
-      'Backend verification is not connected in this build yet. The app captured the store evidence and is ready for the next server integration slice.',
-  }),
+  verifyHouseholdUnlock: async (request) => {
+    const supabase = getSupabaseClient();
+    if (!supabase) {
+      return {
+        status: 'unsupported',
+        message:
+          'Supabase is not connected in this build yet, so backend billing verification is unavailable.',
+      };
+    }
+
+    if (!('functions' in supabase) || !supabase.functions?.invoke) {
+      return {
+        status: 'unsupported',
+        message:
+          'Supabase Edge Functions are not available in this runtime yet. The verification request is ready for the next backend slice.',
+      };
+    }
+
+    const { data, error } = await supabase.functions.invoke(BILLING_VERIFICATION_FUNCTION, {
+      body: request,
+    });
+
+    if (error) {
+      return {
+        status: 'error',
+        message: error.message || 'Billing verification failed before the backend could confirm the purchase.',
+      };
+    }
+
+    return {
+      status:
+        data?.status === 'verified' ||
+        data?.status === 'pending' ||
+        data?.status === 'unsupported' ||
+        data?.status === 'error'
+          ? data.status
+          : 'error',
+      message:
+        typeof data?.message === 'string'
+          ? data.message
+          : 'Billing verification returned without a message.',
+    };
+  },
 });

--- a/src/test/billingContext.test.tsx
+++ b/src/test/billingContext.test.tsx
@@ -102,8 +102,8 @@ describe('BillingProvider', () => {
       id: 'event-1',
     });
     verifyHouseholdUnlock.mockResolvedValue({
-      status: 'unsupported',
-      message: 'Backend verification is not connected in this build yet.',
+      status: 'pending',
+      message: 'Verification queued.',
     });
   });
 
@@ -136,7 +136,7 @@ describe('BillingProvider', () => {
               householdId: 'house-1',
             }),
             verificationResponse: expect.objectContaining({
-              status: 'unsupported',
+              status: 'pending',
             }),
             verificationPayload: expect.objectContaining({
               platform: 'ios',

--- a/src/test/verificationClient.test.ts
+++ b/src/test/verificationClient.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  BILLING_VERIFICATION_FUNCTION,
+  createBillingVerificationClient,
+} from '@/lib/billing/verification-client';
+
+const { getSupabaseClient, invoke } = vi.hoisted(() => ({
+  getSupabaseClient: vi.fn(),
+  invoke: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/client', () => ({
+  getSupabaseClient,
+}));
+
+const request = {
+  householdId: 'house-1',
+  eventType: 'household_unlock_purchase_completed',
+  verificationPayload: {
+    platform: 'ios' as const,
+    appProductId: 'household_lifetime_unlock',
+    storeProductId: 'routine_stars_household_unlock',
+    sourceTransactionId: 'tx-1',
+    sourceOriginalTransactionId: 'orig-1',
+    receiptData: 'signed-receipt',
+    purchaseToken: null,
+  },
+};
+
+describe('createBillingVerificationClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns unsupported when Supabase is unavailable', async () => {
+    getSupabaseClient.mockReturnValue(null);
+
+    await expect(createBillingVerificationClient().verifyHouseholdUnlock(request)).resolves.toEqual(
+      expect.objectContaining({
+        status: 'unsupported',
+      })
+    );
+  });
+
+  it('invokes the verification edge function when available', async () => {
+    invoke.mockResolvedValue({
+      data: {
+        status: 'pending',
+        message: 'Verification queued.',
+      },
+      error: null,
+    });
+    getSupabaseClient.mockReturnValue({
+      functions: {
+        invoke,
+      },
+    });
+
+    await expect(createBillingVerificationClient().verifyHouseholdUnlock(request)).resolves.toEqual({
+      status: 'pending',
+      message: 'Verification queued.',
+    });
+
+    expect(invoke).toHaveBeenCalledWith(BILLING_VERIFICATION_FUNCTION, {
+      body: request,
+    });
+  });
+
+  it('normalizes function errors into an error response', async () => {
+    invoke.mockResolvedValue({
+      data: null,
+      error: {
+        message: 'Function not deployed.',
+      },
+    });
+    getSupabaseClient.mockReturnValue({
+      functions: {
+        invoke,
+      },
+    });
+
+    await expect(createBillingVerificationClient().verifyHouseholdUnlock(request)).resolves.toEqual({
+      status: 'error',
+      message: 'Function not deployed.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds the first concrete app-side transport for billing verification by sending verification requests to a named Supabase Edge Function boundary with graceful fallback and error handling.

## What changed
- adds a concrete verification transport in `verification-client.ts`
- sends verification requests to the `verify-household-unlock` Supabase function when available
- normalizes unsupported and error responses when Supabase or Edge Functions are unavailable
- adds focused tests for request forwarding and response handling

## Why
The billing layer already had a verification contract, but it still needed a concrete transport boundary to prepare for the real backend verification implementation. This keeps the next server slice focused on the function itself rather than client wiring.

## Validation
- `npm test`

## Related issues
- Addresses #42
- Supports #40
- Supports #20
- Stacks on #41