### PR TITLE
[codex] Add verify-household-unlock function scaffold

### DIFF
--- a/docs/supabase-schema-overview.md
+++ b/docs/supabase-schema-overview.md
@@ -41,3 +41,15 @@ Still missing:
 - typed Supabase database definitions
 - true integration between the auth shell and the real household repository
 - local-to-cloud import mapping
+
+## Edge Functions
+
+The first billing verification function scaffold now lives in:
+
+- [supabase/functions/verify-household-unlock/index.ts](/Users/doraangelov/CodexProjects/daily-star-chart/supabase/functions/verify-household-unlock/index.ts)
+
+It currently:
+
+- validates the billing verification request shape
+- returns normalized JSON responses
+- stubs real Apple and Google verification for a later backend slice

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -23,5 +23,6 @@ You can start from [.env.example](/Users/doraangelov/CodexProjects/daily-star-ch
 Still required:
 - applying the migration in `supabase/migrations/20260410194500_create_household_schema.sql` to the remote project
 - making sure the migration includes the `bootstrap_household` RPC so the first owner membership can be created safely under RLS
+- deploying the `verify-household-unlock` Edge Function once billing verification moves beyond the stub
 - cloud-backed child/routine sync
 - local-to-cloud import flow

--- a/src/test/parentSettings.test.tsx
+++ b/src/test/parentSettings.test.tsx
@@ -108,7 +108,7 @@ describe("ParentSettings", () => {
         completed: false,
       })
     );
-  }, 10000);
+  }, 40000);
 
   it("edits an existing task title and preserves its icon", () => {
     render(<Harness />);
@@ -128,7 +128,7 @@ describe("ParentSettings", () => {
         completed: false,
       })
     );
-  });
+  }, 20000);
 
   it("adds a task from the other-tasks bucket without opening the modal", () => {
     render(<Harness />);

--- a/src/test/routineView.test.tsx
+++ b/src/test/routineView.test.tsx
@@ -51,7 +51,7 @@ describe("RoutineView child-facing copy", () => {
     expect(screen.getByText("Tap the cards")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Use the toilet/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Brush teeth/i })).toBeInTheDocument();
-  });
+  }, 10000);
 
   it("shows a simple evening routine heading and bedtime copy", () => {
     render(<RoutineView child={child} routine="evening" onToggleTask={() => {}} onBack={() => {}} />);

--- a/src/test/verifyHouseholdUnlockFunction.test.ts
+++ b/src/test/verifyHouseholdUnlockFunction.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  handleVerificationRequest,
+  parseVerificationRequest,
+} from '../../supabase/functions/verify-household-unlock/shared';
+
+describe('verify-household-unlock function contract', () => {
+  it('accepts a valid iOS verification request', () => {
+    const request = {
+      householdId: 'house-1',
+      eventType: 'household_unlock_purchase_completed',
+      verificationPayload: {
+        platform: 'ios',
+        appProductId: 'household_lifetime_unlock',
+        storeProductId: 'routine_stars_household_unlock',
+        sourceTransactionId: 'tx-1',
+        sourceOriginalTransactionId: 'orig-1',
+        receiptData: 'signed-receipt',
+        purchaseToken: null,
+      },
+    };
+
+    expect(parseVerificationRequest(request)).toEqual(request);
+    expect(handleVerificationRequest(request)).toEqual({
+      status: 200,
+      body: expect.objectContaining({
+        status: 'pending',
+      }),
+    });
+  });
+
+  it('rejects invalid payloads with a structured error response', () => {
+    expect(handleVerificationRequest({ foo: 'bar' })).toEqual({
+      status: 400,
+      body: {
+        status: 'error',
+        message: 'Invalid billing verification request payload.',
+      },
+    });
+  });
+
+  it('requires Android requests to carry purchase evidence', () => {
+    expect(
+      parseVerificationRequest({
+        householdId: 'house-1',
+        eventType: 'household_unlock_restore_completed',
+        verificationPayload: {
+          platform: 'android',
+          appProductId: 'household_lifetime_unlock',
+          storeProductId: 'routine_stars_household_unlock',
+          sourceTransactionId: null,
+          sourceOriginalTransactionId: null,
+          receiptData: null,
+          purchaseToken: null,
+        },
+      })
+    ).toBeNull();
+  });
+});

--- a/supabase/functions/verify-household-unlock/index.ts
+++ b/supabase/functions/verify-household-unlock/index.ts
@@ -1,0 +1,44 @@
+import { handleVerificationRequest } from './shared.ts';
+
+const jsonHeaders = {
+  'Content-Type': 'application/json',
+};
+
+Deno.serve(async (request) => {
+  if (request.method !== 'POST') {
+    return new Response(
+      JSON.stringify({
+        status: 'error',
+        message: 'Method not allowed.',
+      }),
+      {
+        status: 405,
+        headers: jsonHeaders,
+      }
+    );
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch {
+    return new Response(
+      JSON.stringify({
+        status: 'error',
+        message: 'Request body must be valid JSON.',
+      }),
+      {
+        status: 400,
+        headers: jsonHeaders,
+      }
+    );
+  }
+
+  const result = handleVerificationRequest(payload);
+
+  return new Response(JSON.stringify(result.body), {
+    status: result.status,
+    headers: jsonHeaders,
+  });
+});

--- a/supabase/functions/verify-household-unlock/shared.ts
+++ b/supabase/functions/verify-household-unlock/shared.ts
@@ -1,0 +1,105 @@
+export interface VerificationPayload {
+  platform: 'ios' | 'android';
+  appProductId: string;
+  storeProductId: string | null;
+  sourceTransactionId: string | null;
+  sourceOriginalTransactionId: string | null;
+  receiptData: string | null;
+  purchaseToken: string | null;
+}
+
+export interface VerificationRequest {
+  householdId: string;
+  eventType: string;
+  verificationPayload: VerificationPayload;
+}
+
+export interface VerificationResult {
+  status: 'verified' | 'pending' | 'unsupported' | 'error';
+  message: string;
+}
+
+export interface VerificationHttpResponse {
+  status: number;
+  body: VerificationResult;
+}
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+const isVerificationPayload = (value: unknown): value is VerificationPayload => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const payload = value as Record<string, unknown>;
+  const platform = payload.platform;
+
+  if (platform !== 'ios' && platform !== 'android') {
+    return false;
+  }
+
+  if (!isNonEmptyString(payload.appProductId)) {
+    return false;
+  }
+
+  if (
+    platform === 'ios' &&
+    !isNonEmptyString(payload.receiptData) &&
+    !isNonEmptyString(payload.sourceTransactionId)
+  ) {
+    return false;
+  }
+
+  if (
+    platform === 'android' &&
+    !isNonEmptyString(payload.purchaseToken) &&
+    !isNonEmptyString(payload.sourceTransactionId)
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
+export const parseVerificationRequest = (input: unknown): VerificationRequest | null => {
+  if (!input || typeof input !== 'object') {
+    return null;
+  }
+
+  const request = input as Record<string, unknown>;
+  if (!isNonEmptyString(request.householdId) || !isNonEmptyString(request.eventType)) {
+    return null;
+  }
+
+  if (!isVerificationPayload(request.verificationPayload)) {
+    return null;
+  }
+
+  return {
+    householdId: request.householdId,
+    eventType: request.eventType,
+    verificationPayload: request.verificationPayload,
+  };
+};
+
+export const handleVerificationRequest = (input: unknown): VerificationHttpResponse => {
+  const request = parseVerificationRequest(input);
+  if (!request) {
+    return {
+      status: 400,
+      body: {
+        status: 'error',
+        message: 'Invalid billing verification request payload.',
+      },
+    };
+  }
+
+  return {
+    status: 200,
+    body: {
+      status: 'pending',
+      message: `Verification stub accepted ${request.verificationPayload.platform} evidence for household ${request.householdId}. Real store verification is the next backend slice.`,
+    },
+  };
+};


### PR DESCRIPTION
## Summary
Adds the first Supabase Edge Function scaffold for `verify-household-unlock`, giving the billing verification transport a concrete backend target with normalized request validation and response handling.

## What changed
- adds `supabase/functions/verify-household-unlock/index.ts` as the Edge Function entrypoint
- adds a pure shared handler for request parsing and normalized verification responses
- adds contract tests for valid and invalid verification payloads
- updates Supabase docs to mention the new function scaffold
- stabilizes slow UI test timeouts so the full suite remains green as coverage grows

## Why
The app-side verification transport is now wired, but it still needed a real backend function boundary to target. This scaffold makes the client/server contract concrete while keeping real Apple and Google verification logic for the next backend slice.

## Validation
- `npm test`

## Related issues
- Addresses #44
- Supports #42
- Supports #20
- Stacks on #43