### PR TITLE
[codex] Persist pending entitlement state

### DIFF
--- a/src/components/AccountSettingsCard.tsx
+++ b/src/components/AccountSettingsCard.tsx
@@ -140,6 +140,8 @@ export const AccountSettingsCard = () => {
                 ? 'Checking access'
                 : householdEntitlement?.status === 'active'
                   ? 'Lifetime unlock active'
+                  : householdEntitlement?.status === 'pending'
+                    ? 'Purchase verification in progress'
                   : householdEntitlement?.status === 'revoked'
                     ? 'Access needs attention'
                     : 'Not purchased yet'}
@@ -149,6 +151,8 @@ export const AccountSettingsCard = () => {
                 ? 'We could not verify billing access yet. You can retry from here.'
                 : householdEntitlement?.status === 'active'
                   ? 'This household has a verified paid unlock saved to the account.'
+                  : householdEntitlement?.status === 'pending'
+                    ? 'We captured the purchase evidence and the household is waiting for verification to finish.'
                   : householdEntitlement?.status === 'revoked'
                     ? 'This household had paid access before, but the entitlement is no longer active.'
                     : `This household is signed in and ready for the ${householdUnlockProduct.priceLabel} parent-only purchase flow.`}
@@ -166,7 +170,9 @@ export const AccountSettingsCard = () => {
                   className="inline-flex items-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-bold text-primary-foreground shadow-button transition-transform active:translate-y-0.5"
                 >
                   {isProcessing ? <LoaderCircle size={16} className="animate-spin" /> : <CreditCard size={16} />}
-                  Unlock Routine Stars for {householdUnlockProduct.priceLabel}
+                  {householdEntitlement?.status === 'pending'
+                    ? 'Retry purchase check'
+                    : `Unlock Routine Stars for ${householdUnlockProduct.priceLabel}`}
                 </button>
                 <button
                   type="button"

--- a/src/components/ParentSettings.tsx
+++ b/src/components/ParentSettings.tsx
@@ -863,6 +863,8 @@ export const ParentSettings = ({
                         ? 'Checking access'
                         : householdEntitlement?.status === 'active'
                           ? 'Lifetime unlock active'
+                          : householdEntitlement?.status === 'pending'
+                            ? 'Verification in progress'
                           : householdEntitlement?.status === 'revoked'
                             ? 'Access needs attention'
                             : 'Unlock this household'}
@@ -872,6 +874,8 @@ export const ParentSettings = ({
                         ? 'We are checking the latest paid access state for this family.'
                         : householdEntitlement?.status === 'active'
                           ? `Paid access is already saved for ${household?.name ?? 'this household'}.`
+                          : householdEntitlement?.status === 'pending'
+                            ? 'The household submitted purchase evidence and is waiting for verification to complete.'
                           : householdEntitlement?.status === 'revoked'
                             ? 'This household had paid access before. Use restore after we wire the store flows, or re-purchase if needed.'
                             : `This parent-only area is where the ${householdUnlockProduct.priceLabel} native store unlock and restore flows will start.`}

--- a/src/lib/data/models.ts
+++ b/src/lib/data/models.ts
@@ -2,7 +2,7 @@ import type { AgeBucket, HomeScene, IconKey, RoutineType } from '@/lib/types';
 
 export type HouseholdRole = 'owner' | 'parent';
 export type BillingPlatform = 'ios' | 'android' | 'web';
-export type HouseholdEntitlementStatus = 'active' | 'revoked';
+export type HouseholdEntitlementStatus = 'active' | 'pending' | 'revoked';
 
 export interface HouseholdRecord {
   id: string;

--- a/src/test/accountSettingsCard.test.tsx
+++ b/src/test/accountSettingsCard.test.tsx
@@ -119,6 +119,23 @@ describe('AccountSettingsCard', () => {
     expect(screen.queryByRole('button', { name: /restore purchases/i })).toBeNull();
   });
 
+  it('shows pending verification copy when the household is awaiting verification', () => {
+    authState.status = 'signed_in';
+    authState.user = { email: 'parent@example.com' };
+    authState.householdStatus = 'ready';
+    authState.household = { name: 'Parent Family' };
+    authState.entitlementStatus = 'ready';
+    authState.householdEntitlement = { status: 'pending', platform: 'ios' };
+
+    render(<AccountSettingsCard />);
+
+    expect(screen.getByText(/purchase verification in progress/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/captured the purchase evidence and the household is waiting for verification/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retry purchase check/i })).toBeInTheDocument();
+  });
+
   it('calls the billing adapter when the parent taps unlock', async () => {
     authState.status = 'signed_in';
     authState.user = { email: 'parent@example.com' };

--- a/src/test/verifyHouseholdUnlockFunction.test.ts
+++ b/src/test/verifyHouseholdUnlockFunction.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildPendingEntitlementMutation,
   handleVerificationRequest,
   parseVerificationRequest,
 } from '../../supabase/functions/verify-household-unlock/shared';
@@ -55,5 +56,78 @@ describe('verify-household-unlock function contract', () => {
         },
       })
     ).toBeNull();
+  });
+
+  it('builds a pending entitlement mutation for first-time verification requests', () => {
+    const request = parseVerificationRequest({
+      householdId: 'house-1',
+      eventType: 'household_unlock_purchase_completed',
+      verificationPayload: {
+        platform: 'ios',
+        appProductId: 'household_lifetime_unlock',
+        storeProductId: 'routine_stars_household_unlock',
+        sourceTransactionId: 'tx-1',
+        sourceOriginalTransactionId: 'orig-1',
+        receiptData: 'signed-receipt',
+        purchaseToken: null,
+      },
+    });
+
+    expect(request).not.toBeNull();
+    expect(buildPendingEntitlementMutation(request!, null, '2026-04-20T20:00:00Z')).toEqual({
+      status: 'pending',
+      platform: 'ios',
+      store_product_id: 'routine_stars_household_unlock',
+      source_transaction_id: 'tx-1',
+      source_original_transaction_id: 'orig-1',
+      granted_at: null,
+      revoked_at: null,
+      verification_checked_at: '2026-04-20T20:00:00Z',
+    });
+  });
+
+  it('preserves active access when refreshing verification evidence for an already active household', () => {
+    const request = parseVerificationRequest({
+      householdId: 'house-1',
+      eventType: 'household_unlock_restore_completed',
+      verificationPayload: {
+        platform: 'android',
+        appProductId: 'household_lifetime_unlock',
+        storeProductId: 'routine_stars_household_unlock',
+        sourceTransactionId: 'tx-2',
+        sourceOriginalTransactionId: 'orig-2',
+        receiptData: null,
+        purchaseToken: 'purchase-token',
+      },
+    });
+
+    expect(request).not.toBeNull();
+    expect(
+      buildPendingEntitlementMutation(
+        request!,
+        {
+          id: 'ent-1',
+          household_id: 'house-1',
+          status: 'active',
+          platform: 'android',
+          store_product_id: 'routine_stars_household_unlock',
+          source_transaction_id: 'old-tx',
+          source_original_transaction_id: 'old-orig',
+          granted_at: '2026-04-19T10:00:00Z',
+          revoked_at: null,
+          verification_checked_at: '2026-04-19T10:00:00Z',
+        },
+        '2026-04-20T20:00:00Z'
+      )
+    ).toEqual({
+      status: 'active',
+      platform: 'android',
+      store_product_id: 'routine_stars_household_unlock',
+      source_transaction_id: 'tx-2',
+      source_original_transaction_id: 'orig-2',
+      granted_at: '2026-04-19T10:00:00Z',
+      revoked_at: null,
+      verification_checked_at: '2026-04-20T20:00:00Z',
+    });
   });
 });

--- a/supabase/functions/verify-household-unlock/index.ts
+++ b/supabase/functions/verify-household-unlock/index.ts
@@ -1,8 +1,17 @@
-import { handleVerificationRequest } from './shared.ts';
+import { createClient } from 'npm:@supabase/supabase-js@2';
+import {
+  buildPendingEntitlementMutation,
+  handleVerificationRequest,
+  parseVerificationRequest,
+  type ExistingEntitlementSnapshot,
+} from './shared.ts';
 
 const jsonHeaders = {
   'Content-Type': 'application/json',
 };
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL');
+const supabaseServiceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
 
 Deno.serve(async (request) => {
   if (request.method !== 'POST') {
@@ -35,10 +44,88 @@ Deno.serve(async (request) => {
     );
   }
 
+  const parsed = parseVerificationRequest(payload);
   const result = handleVerificationRequest(payload);
 
-  return new Response(JSON.stringify(result.body), {
-    status: result.status,
+  if (!parsed) {
+    return new Response(JSON.stringify(result.body), {
+      status: result.status,
+      headers: jsonHeaders,
+    });
+  }
+
+  if (!supabaseUrl || !supabaseServiceRoleKey) {
+    return new Response(
+      JSON.stringify({
+        status: 'unsupported',
+        message: 'Server verification is not configured yet. Missing Supabase service role environment.',
+      }),
+      {
+        status: 200,
+        headers: jsonHeaders,
+      }
+    );
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+
+  const { data: existingEntitlement, error: loadError } = await supabase
+    .from('household_entitlements')
+    .select('*')
+    .eq('household_id', parsed.householdId)
+    .maybeSingle<ExistingEntitlementSnapshot>();
+
+  if (loadError) {
+    return new Response(
+      JSON.stringify({
+        status: 'error',
+        message: loadError.message || 'Could not load the current household entitlement.',
+      }),
+      {
+        status: 500,
+        headers: jsonHeaders,
+      }
+    );
+  }
+
+  const nowIso = new Date().toISOString();
+  const mutation = buildPendingEntitlementMutation(parsed, existingEntitlement ?? null, nowIso);
+  const { error: upsertError } = await supabase.from('household_entitlements').upsert(
+    {
+      household_id: parsed.householdId,
+      ...mutation,
+    },
+    { onConflict: 'household_id' }
+  );
+
+  if (upsertError) {
+    return new Response(
+      JSON.stringify({
+        status: 'error',
+        message: upsertError.message || 'Could not persist the household entitlement state.',
+      }),
+      {
+        status: 500,
+        headers: jsonHeaders,
+      }
+    );
+  }
+
+  const responseBody =
+    mutation.status === 'active'
+      ? {
+          status: 'verified' as const,
+          message: `Existing paid access for household ${parsed.householdId} was preserved while verification evidence was refreshed.`,
+        }
+      : result.body;
+
+  return new Response(JSON.stringify(responseBody), {
+    status: responseBody.status === 'verified' ? 200 : result.status,
     headers: jsonHeaders,
   });
 });

--- a/supabase/functions/verify-household-unlock/shared.ts
+++ b/supabase/functions/verify-household-unlock/shared.ts
@@ -19,6 +19,30 @@ export interface VerificationResult {
   message: string;
 }
 
+export interface ExistingEntitlementSnapshot {
+  id: string;
+  household_id: string;
+  status: 'active' | 'pending' | 'revoked';
+  platform: 'ios' | 'android' | 'web' | null;
+  store_product_id: string | null;
+  source_transaction_id: string | null;
+  source_original_transaction_id: string | null;
+  granted_at: string | null;
+  revoked_at: string | null;
+  verification_checked_at: string | null;
+}
+
+export interface PendingEntitlementMutation {
+  status: 'active' | 'pending';
+  platform: 'ios' | 'android';
+  store_product_id: string | null;
+  source_transaction_id: string | null;
+  source_original_transaction_id: string | null;
+  granted_at: string | null;
+  revoked_at: null;
+  verification_checked_at: string;
+}
+
 export interface VerificationHttpResponse {
   status: number;
   body: VerificationResult;
@@ -103,3 +127,18 @@ export const handleVerificationRequest = (input: unknown): VerificationHttpRespo
     },
   };
 };
+
+export const buildPendingEntitlementMutation = (
+  request: VerificationRequest,
+  existingEntitlement: ExistingEntitlementSnapshot | null,
+  nowIso: string
+): PendingEntitlementMutation => ({
+  status: existingEntitlement?.status === 'active' ? 'active' : 'pending',
+  platform: request.verificationPayload.platform,
+  store_product_id: request.verificationPayload.storeProductId,
+  source_transaction_id: request.verificationPayload.sourceTransactionId,
+  source_original_transaction_id: request.verificationPayload.sourceOriginalTransactionId,
+  granted_at: existingEntitlement?.status === 'active' ? existingEntitlement.granted_at : null,
+  revoked_at: null,
+  verification_checked_at: nowIso,
+});

--- a/supabase/migrations/20260420195500_add_pending_entitlement_status.sql
+++ b/supabase/migrations/20260420195500_add_pending_entitlement_status.sql
@@ -1,0 +1,6 @@
+alter table public.household_entitlements
+  drop constraint if exists household_entitlements_status_check;
+
+alter table public.household_entitlements
+  add constraint household_entitlements_status_check
+  check (status in ('active', 'pending', 'revoked'));


### PR DESCRIPTION
## Summary
Extends the billing verification backend path so valid verification requests can persist a safe `pending` household entitlement state instead of only returning a stub response.

## What changed
- adds `pending` to the household entitlement status model and migration path
- updates the verification function to upsert pending entitlement records for valid requests
- preserves already-active access instead of downgrading verified households
- updates parent-facing account and billing copy for the new pending state
- adds tests for pending entitlement mutation behavior and pending UI copy

## Why
The verification function scaffold gave the app a backend target, but the backend still needed to persist meaningful state. This slice lets us represent 'verification in progress' honestly without granting paid access too early.

## Validation
- `npm test`

## Related issues
- Addresses #46
- Supports #44
- Supports #20
- Stacks on #45