### PR TITLE
[codex] Add platform verification decisioning

### DIFF
--- a/src/test/verifyHouseholdUnlockFunction.test.ts
+++ b/src/test/verifyHouseholdUnlockFunction.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
-  buildPendingEntitlementMutation,
+  buildEntitlementMutationFromDecision,
+  buildVerificationDecision,
   handleVerificationRequest,
   parseVerificationRequest,
 } from '../../supabase/functions/verify-household-unlock/shared';
@@ -74,7 +75,11 @@ describe('verify-household-unlock function contract', () => {
     });
 
     expect(request).not.toBeNull();
-    expect(buildPendingEntitlementMutation(request!, null, '2026-04-20T20:00:00Z')).toEqual({
+    const decision = buildVerificationDecision(request!, null, {
+      status: 'pending',
+      message: 'Verification queued.',
+    });
+    expect(buildEntitlementMutationFromDecision(decision, '2026-04-20T20:00:00Z')).toEqual({
       status: 'pending',
       platform: 'ios',
       store_product_id: 'routine_stars_household_unlock',
@@ -102,23 +107,27 @@ describe('verify-household-unlock function contract', () => {
     });
 
     expect(request).not.toBeNull();
+    const decision = buildVerificationDecision(
+      request!,
+      {
+        id: 'ent-1',
+        household_id: 'house-1',
+        status: 'active',
+        platform: 'android',
+        store_product_id: 'routine_stars_household_unlock',
+        source_transaction_id: 'old-tx',
+        source_original_transaction_id: 'old-orig',
+        granted_at: '2026-04-19T10:00:00Z',
+        revoked_at: null,
+        verification_checked_at: '2026-04-19T10:00:00Z',
+      },
+      {
+        status: 'pending',
+        message: 'Verification queued.',
+      }
+    );
     expect(
-      buildPendingEntitlementMutation(
-        request!,
-        {
-          id: 'ent-1',
-          household_id: 'house-1',
-          status: 'active',
-          platform: 'android',
-          store_product_id: 'routine_stars_household_unlock',
-          source_transaction_id: 'old-tx',
-          source_original_transaction_id: 'old-orig',
-          granted_at: '2026-04-19T10:00:00Z',
-          revoked_at: null,
-          verification_checked_at: '2026-04-19T10:00:00Z',
-        },
-        '2026-04-20T20:00:00Z'
-      )
+      buildEntitlementMutationFromDecision(decision, '2026-04-20T20:00:00Z')
     ).toEqual({
       status: 'active',
       platform: 'android',
@@ -126,6 +135,39 @@ describe('verify-household-unlock function contract', () => {
       source_transaction_id: 'tx-2',
       source_original_transaction_id: 'orig-2',
       granted_at: '2026-04-19T10:00:00Z',
+      revoked_at: null,
+      verification_checked_at: '2026-04-20T20:00:00Z',
+    });
+  });
+
+  it('promotes a new entitlement to active only when the verifier returns verified', () => {
+    const request = parseVerificationRequest({
+      householdId: 'house-1',
+      eventType: 'household_unlock_purchase_completed',
+      verificationPayload: {
+        platform: 'ios',
+        appProductId: 'household_lifetime_unlock',
+        storeProductId: 'routine_stars_household_unlock',
+        sourceTransactionId: 'tx-verified',
+        sourceOriginalTransactionId: 'orig-verified',
+        receiptData: 'verified-receipt',
+        purchaseToken: null,
+      },
+    });
+
+    expect(request).not.toBeNull();
+    const decision = buildVerificationDecision(request!, null, {
+      status: 'verified',
+      message: 'Verified purchase evidence.',
+    });
+
+    expect(buildEntitlementMutationFromDecision(decision, '2026-04-20T20:00:00Z')).toEqual({
+      status: 'active',
+      platform: 'ios',
+      store_product_id: 'routine_stars_household_unlock',
+      source_transaction_id: 'tx-verified',
+      source_original_transaction_id: 'orig-verified',
+      granted_at: '2026-04-20T20:00:00Z',
       revoked_at: null,
       verification_checked_at: '2026-04-20T20:00:00Z',
     });

--- a/supabase/functions/verify-household-unlock/apple.ts
+++ b/supabase/functions/verify-household-unlock/apple.ts
@@ -1,0 +1,10 @@
+import type { VerificationRequest, VerificationResult } from './shared.ts';
+
+export const verifyAppleHouseholdUnlock = async (
+  request: VerificationRequest
+): Promise<VerificationResult> => {
+  return {
+    status: 'pending',
+    message: `Apple verification stub accepted receipt evidence for household ${request.householdId}. App Store verification is the next backend slice.`,
+  };
+};

--- a/supabase/functions/verify-household-unlock/google.ts
+++ b/supabase/functions/verify-household-unlock/google.ts
@@ -1,0 +1,10 @@
+import type { VerificationRequest, VerificationResult } from './shared.ts';
+
+export const verifyGoogleHouseholdUnlock = async (
+  request: VerificationRequest
+): Promise<VerificationResult> => {
+  return {
+    status: 'pending',
+    message: `Google Play verification stub accepted purchase evidence for household ${request.householdId}. Play verification is the next backend slice.`,
+  };
+};

--- a/supabase/functions/verify-household-unlock/index.ts
+++ b/supabase/functions/verify-household-unlock/index.ts
@@ -1,10 +1,14 @@
 import { createClient } from 'npm:@supabase/supabase-js@2';
 import {
-  buildPendingEntitlementMutation,
+  buildEntitlementMutationFromDecision,
+  buildVerificationDecision,
   handleVerificationRequest,
   parseVerificationRequest,
   type ExistingEntitlementSnapshot,
+  type VerificationRequest,
 } from './shared.ts';
+import { verifyAppleHouseholdUnlock } from './apple.ts';
+import { verifyGoogleHouseholdUnlock } from './google.ts';
 
 const jsonHeaders = {
   'Content-Type': 'application/json',
@@ -12,6 +16,14 @@ const jsonHeaders = {
 
 const supabaseUrl = Deno.env.get('SUPABASE_URL');
 const supabaseServiceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+const verifyByPlatform = async (request: VerificationRequest) => {
+  if (request.verificationPayload.platform === 'ios') {
+    return verifyAppleHouseholdUnlock(request);
+  }
+
+  return verifyGoogleHouseholdUnlock(request);
+};
 
 Deno.serve(async (request) => {
   if (request.method !== 'POST') {
@@ -93,8 +105,10 @@ Deno.serve(async (request) => {
     );
   }
 
+  const verifierResult = await verifyByPlatform(parsed);
   const nowIso = new Date().toISOString();
-  const mutation = buildPendingEntitlementMutation(parsed, existingEntitlement ?? null, nowIso);
+  const decision = buildVerificationDecision(parsed, existingEntitlement ?? null, verifierResult);
+  const mutation = buildEntitlementMutationFromDecision(decision, nowIso);
   const { error: upsertError } = await supabase.from('household_entitlements').upsert(
     {
       household_id: parsed.householdId,
@@ -117,12 +131,18 @@ Deno.serve(async (request) => {
   }
 
   const responseBody =
-    mutation.status === 'active'
+    decision.status === 'verified'
       ? {
           status: 'verified' as const,
-          message: `Existing paid access for household ${parsed.householdId} was preserved while verification evidence was refreshed.`,
+          message:
+            existingEntitlement?.status === 'active'
+              ? `Existing paid access for household ${parsed.householdId} was preserved while verification evidence was refreshed.`
+              : decision.message,
         }
-      : result.body;
+      : {
+          status: 'pending' as const,
+          message: decision.message,
+        };
 
   return new Response(JSON.stringify(responseBody), {
     status: responseBody.status === 'verified' ? 200 : result.status,

--- a/supabase/functions/verify-household-unlock/shared.ts
+++ b/supabase/functions/verify-household-unlock/shared.ts
@@ -19,6 +19,16 @@ export interface VerificationResult {
   message: string;
 }
 
+export interface VerificationDecision {
+  status: 'verified' | 'pending';
+  message: string;
+  platform: 'ios' | 'android';
+  storeProductId: string | null;
+  sourceTransactionId: string | null;
+  sourceOriginalTransactionId: string | null;
+  grantedAt: string | null;
+}
+
 export interface ExistingEntitlementSnapshot {
   id: string;
   household_id: string;
@@ -128,17 +138,33 @@ export const handleVerificationRequest = (input: unknown): VerificationHttpRespo
   };
 };
 
-export const buildPendingEntitlementMutation = (
-  request: VerificationRequest,
-  existingEntitlement: ExistingEntitlementSnapshot | null,
+export const buildEntitlementMutationFromDecision = (
+  decision: VerificationDecision,
   nowIso: string
 ): PendingEntitlementMutation => ({
-  status: existingEntitlement?.status === 'active' ? 'active' : 'pending',
-  platform: request.verificationPayload.platform,
-  store_product_id: request.verificationPayload.storeProductId,
-  source_transaction_id: request.verificationPayload.sourceTransactionId,
-  source_original_transaction_id: request.verificationPayload.sourceOriginalTransactionId,
-  granted_at: existingEntitlement?.status === 'active' ? existingEntitlement.granted_at : null,
+  status: decision.status === 'verified' ? 'active' : 'pending',
+  platform: decision.platform,
+  store_product_id: decision.storeProductId,
+  source_transaction_id: decision.sourceTransactionId,
+  source_original_transaction_id: decision.sourceOriginalTransactionId,
+  granted_at: decision.status === 'verified' ? decision.grantedAt ?? nowIso : null,
   revoked_at: null,
   verification_checked_at: nowIso,
+});
+
+export const buildVerificationDecision = (
+  request: VerificationRequest,
+  existingEntitlement: ExistingEntitlementSnapshot | null,
+  verifierResult: Pick<VerificationResult, 'status' | 'message'>
+): VerificationDecision => ({
+  status:
+    verifierResult.status === 'verified' || existingEntitlement?.status === 'active'
+      ? 'verified'
+      : 'pending',
+  message: verifierResult.message,
+  platform: request.verificationPayload.platform,
+  storeProductId: request.verificationPayload.storeProductId,
+  sourceTransactionId: request.verificationPayload.sourceTransactionId,
+  sourceOriginalTransactionId: request.verificationPayload.sourceOriginalTransactionId,
+  grantedAt: existingEntitlement?.status === 'active' ? existingEntitlement.granted_at : null,
 });


### PR DESCRIPTION
## Summary
Splits the backend billing verification path into platform-specific Apple and Google decision handlers, and updates entitlement mutation logic so households are promoted to active only from trusted verified decisions.

## What changed
- adds separate Apple and Google verifier modules for the `verify-household-unlock` function
- introduces a normalized verification decision shape in the shared handler layer
- updates entitlement mutation logic to derive state from the verification decision instead of hardcoded pending behavior
- preserves active households while keeping unverified evidence in the safe pending path
- adds tests covering pending and verified decision outcomes

## Why
The backend can now persist pending state, but it still needed a clean structure for real verification logic. This slice gives us platform routing and trusted promotion rules before any store-specific API calls are implemented.

## Validation
- `npm test`

## Related issues
- Addresses #48
- Supports #46
- Supports #20
- Stacks on #47