### PR TITLE
[codex] Harden signed-in household bootstrap

### DIFF
--- a/src/components/HouseholdLoadErrorScreen.tsx
+++ b/src/components/HouseholdLoadErrorScreen.tsx
@@ -1,0 +1,51 @@
+import { CloudOff, RefreshCw, ShieldAlert } from 'lucide-react';
+
+interface HouseholdLoadErrorScreenProps {
+  error: string;
+  onRetry: () => void;
+}
+
+export const HouseholdLoadErrorScreen = ({ error, onRetry }: HouseholdLoadErrorScreenProps) => (
+  <div className="relative min-h-svh overflow-hidden px-5 py-10 md:px-6 md:py-14">
+    <div className="absolute inset-x-0 top-0 -z-10 mx-auto h-72 w-[42rem] max-w-full rounded-full bg-primary/10 blur-3xl" />
+    <div className="absolute left-6 top-24 -z-10 h-28 w-28 rounded-full bg-warning/20 blur-2xl" />
+    <div className="absolute right-8 top-16 -z-10 h-36 w-36 rounded-full bg-destructive/10 blur-2xl" />
+
+    <div className="mx-auto max-w-4xl rounded-[36px] border border-border bg-card/95 p-7 shadow-card md:p-9">
+      <div className="inline-flex items-center gap-2 rounded-full bg-warning/10 px-4 py-2 text-sm font-black uppercase tracking-[0.22em] text-warning">
+        <CloudOff size={16} />
+        Household Sync Paused
+      </div>
+
+      <h1 className="mt-6 text-4xl font-bold text-foreground md:text-5xl">
+        We could not load this family account yet
+      </h1>
+      <p className="mt-4 max-w-2xl text-lg text-muted-foreground">
+        This device is signed in, but we could not confirm the household from the cloud right now. We are pausing here
+        so we do not accidentally treat the account like a brand-new family.
+      </p>
+
+      <div className="mt-8 rounded-[28px] border border-destructive/20 bg-destructive/5 p-5">
+        <div className="flex items-center gap-2 text-destructive">
+          <ShieldAlert size={18} />
+          <p className="text-sm font-black uppercase tracking-[0.18em]">Why we paused</p>
+        </div>
+        <p className="mt-3 text-sm text-foreground">{error}</p>
+      </div>
+
+      <div className="mt-8 rounded-[28px] border border-border bg-background/80 p-5 text-sm text-muted-foreground">
+        <p>1. We did not open a fresh setup flow because that could overwrite the wrong family data.</p>
+        <p className="mt-2">2. Retry once the connection or family sync service is available again.</p>
+      </div>
+
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-8 inline-flex items-center gap-2 rounded-full bg-primary px-5 py-3 text-sm font-bold text-primary-foreground shadow-button transition-transform active:translate-y-0.5"
+      >
+        <RefreshCw size={16} />
+        Retry loading the household
+      </button>
+    </div>
+  </div>
+);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,6 +28,6 @@ export type Child = {
   evening: Task[];
 };
 
-export type AppView = 'account' | 'import' | 'recovery' | 'setup' | 'home' | 'routine' | 'parent';
+export type AppView = 'account' | 'import' | 'recovery' | 'setup' | 'home' | 'routine' | 'parent' | 'bootstrap-error';
 
 export { AGE_BUCKETS, DEFAULT_CHILDREN, groupTasksByAge, ICON_OPTIONS, TASK_CATALOG, TASK_CATALOG_BY_ID, TASK_LIBRARY };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { ChildSelector } from '@/components/ChildSelector';
 import { AccountEntryScreen } from '@/components/AccountEntryScreen';
 import { ExistingFamilyRecoveryScreen } from '@/components/ExistingFamilyRecoveryScreen';
+import { HouseholdLoadErrorScreen } from '@/components/HouseholdLoadErrorScreen';
 import { ImportFamilySetupScreen } from '@/components/ImportFamilySetupScreen';
 import { InitialSetup } from '@/components/InitialSetup';
 import { RoutineView } from '@/components/RoutineView';
@@ -105,9 +106,11 @@ const Index = () => {
   const [setupComplete, setSetupComplete] = useState(false);
   const [isReady, setIsReady] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
+  const [bootstrapError, setBootstrapError] = useState<string | null>(null);
   const [isImporting, setIsImporting] = useState(false);
   const [now, setNow] = useState(() => new Date());
   const [homeScene, setHomeScene] = useState<HomeScene>('bike');
+  const [bootstrapAttempt, setBootstrapAttempt] = useState(0);
   const lastSyncedConfigRef = useRef<string | null>(null);
   const shouldSyncFirstConfigRef = useRef(false);
   const skipLocalPersistenceRef = useRef(false);
@@ -153,6 +156,7 @@ const Index = () => {
       if (authStatus === 'signed_out' || authStatus === 'unavailable') {
         if (!isMounted) return;
 
+        setBootstrapError(null);
         setChildren(createSetupChildren());
         setActiveChildId(null);
         setSetupComplete(false);
@@ -167,17 +171,21 @@ const Index = () => {
 
       const storedState = loadLocalAppState();
       let cloudState: Awaited<ReturnType<typeof loadCloudHouseholdState>> | null = null;
+      let cloudLoadError: string | null = null;
 
       if (authStatus === 'signed_in' && householdStatus === 'ready' && household) {
         try {
           cloudState = await loadCloudHouseholdState(household);
         } catch (error) {
           console.warn('Could not load cloud household state.', error);
+          cloudLoadError =
+            error instanceof Error ? error.message : 'Could not load this household from the cloud right now.';
         }
       }
 
       if (storedState) {
         if (
+          !cloudLoadError &&
           authStatus === 'signed_in' &&
           householdStatus === 'ready' &&
           household &&
@@ -209,6 +217,7 @@ const Index = () => {
         }
 
         if (isMounted) {
+          setBootstrapError(null);
           setSetupComplete(storedState.setupComplete);
           setHomeScene(storedState.homeScene);
           setView(storedState.setupComplete ? 'home' : 'setup');
@@ -220,6 +229,7 @@ const Index = () => {
       if (cloudState) {
         if (!isMounted) return;
 
+        setBootstrapError(null);
         setChildren(cloudState.children);
         setHomeScene(cloudState.homeScene);
         setSetupComplete(cloudState.children.length > 0);
@@ -238,7 +248,21 @@ const Index = () => {
         return;
       }
 
+      if (cloudLoadError && authStatus === 'signed_in' && householdStatus === 'ready' && household) {
+        if (!isMounted) return;
+
+        setActiveChildId(null);
+        setChildren(createSetupChildren());
+        setSetupComplete(false);
+        setHomeScene('bike');
+        setBootstrapError(cloudLoadError);
+        setView('bootstrap-error');
+        setIsReady(true);
+        return;
+      }
+
       if (isMounted) {
+        setBootstrapError(null);
         setChildren(createSetupChildren());
         setActiveChildId(null);
         setSetupComplete(false);
@@ -260,7 +284,7 @@ const Index = () => {
     return () => {
       isMounted = false;
     };
-  }, [authStatus, household, householdStatus]);
+  }, [authStatus, bootstrapAttempt, household, householdStatus]);
 
   const householdConfigSignature = useMemo(
     () => serializeHouseholdConfig({ children, homeScene, setupComplete }),
@@ -374,6 +398,19 @@ const Index = () => {
     return <AccountEntryScreen />;
   }
 
+  if (view === 'bootstrap-error') {
+    return (
+      <HouseholdLoadErrorScreen
+        error={bootstrapError ?? 'Could not load this household right now.'}
+        onRetry={() => {
+          setBootstrapError(null);
+          setIsReady(false);
+          setBootstrapAttempt((count) => count + 1);
+        }}
+      />
+    );
+  }
+
   if (view === 'import') {
     return (
       <ImportFamilySetupScreen
@@ -414,6 +451,7 @@ const Index = () => {
         }}
         onStartFresh={() => {
           clearLocalAppState();
+          setActiveChildId(null);
           setChildren(createSetupChildren());
           setSetupComplete(false);
           setHomeScene('bike');

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -186,6 +186,24 @@ vi.mock("@/components/AccountEntryScreen", () => ({
   ),
 }));
 
+vi.mock("@/components/HouseholdLoadErrorScreen", () => ({
+  HouseholdLoadErrorScreen: ({
+    error,
+    onRetry,
+  }: {
+    error: string;
+    onRetry: () => void;
+  }) => (
+    <div>
+      <div data-testid="household-load-error-screen">household-load-error</div>
+      <div data-testid="household-load-error">{error}</div>
+      <button type="button" onClick={onRetry}>
+        retry-household-load
+      </button>
+    </div>
+  ),
+}));
+
 vi.mock("@/components/ImportFamilySetupScreen", () => ({
   ImportFamilySetupScreen: ({
     onImport,
@@ -451,6 +469,65 @@ describe("Index", () => {
 
     expect(await screen.findByTestId("child-count")).toHaveTextContent("1");
     expect(loadCloudHouseholdState).toHaveBeenCalledWith(authState.household);
+  });
+
+  it("falls back to cached local household data when signed-in cloud loading fails", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockRejectedValue(new Error("Network offline"));
+    localStorage.setItem(
+      "routine_stars_data",
+      JSON.stringify({
+        ...createStoredState(false, today()),
+        setupComplete: true,
+        homeScene: "school",
+      })
+    );
+
+    render(<Index />);
+
+    expect(await screen.findByTestId("child-count")).toHaveTextContent("1");
+    expect(screen.queryByTestId("household-load-error-screen")).not.toBeInTheDocument();
+  });
+
+  it("shows a retryable bootstrap error instead of setup when signed-in cloud loading fails with no local cache", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState
+      .mockRejectedValueOnce(new Error("Supabase timeout"))
+      .mockResolvedValueOnce({
+        homeScene: "kite",
+        children: [],
+      });
+
+    render(<Index />);
+
+    expect(await screen.findByTestId("household-load-error-screen")).toBeInTheDocument();
+    expect(screen.getByTestId("household-load-error")).toHaveTextContent("Supabase timeout");
+
+    fireEvent.click(screen.getByRole("button", { name: "retry-household-load" }));
+
+    expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
   });
 
   it("shows an import decision when a signed-in device has local setup and cloud is empty", async () => {


### PR DESCRIPTION
## Summary
Prevents signed-in devices from falling into a misleading fresh-setup path when cloud household loading fails.

## What changed
- adds a dedicated household-load error screen for signed-in bootstrap failures with no safe local cache
- falls back to cached local household data when the cloud load fails on a shared device that already has synced local state
- avoids showing the import flow when the cloud household could not be loaded at all
- adds test coverage for offline fallback and retryable blocking behavior

## Why
A transient network or Supabase failure should not look like an empty household. That was a risky path because it could steer a real family into setup or import decisions based on missing data rather than confirmed state.

## Validation
- `npm test`
- 53 tests passed on the `main`-based branch

## Related issues
- Closes #50