### PR TITLE
[codex] Sync daily routine progress across devices

### DIFF
--- a/src/lib/data/cloud-household-state.ts
+++ b/src/lib/data/cloud-household-state.ts
@@ -2,6 +2,7 @@ import type { Child, HomeScene, IconKey, RoutineType, Task } from '@/lib/types';
 import { TASK_CATALOG_BY_ID } from '@/lib/types';
 import type { ChildProfileRecord, HouseholdRecord, RoutineRecord, RoutineTaskRecord } from './models';
 import { SupabaseChildProfileRepository } from './supabase-child-profile-repository';
+import { SupabaseProgressRepository } from './supabase-progress-repository';
 import { SupabaseRoutineRepository } from './supabase-routine-repository';
 import { getSupabaseClient } from '@/lib/supabase/client';
 
@@ -9,6 +10,9 @@ export interface CloudHouseholdState {
   children: Child[];
   homeScene: HomeScene;
 }
+
+const getLocalProgressDate = (date: Date) =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
 
 const DEFAULT_SCHEDULE = {
   morning: { start: '07:00', end: '09:00' },
@@ -84,17 +88,53 @@ export const loadCloudHouseholdState = async (
   }
 
   const childRepository = new SupabaseChildProfileRepository(supabase);
+  const progressRepository = new SupabaseProgressRepository(supabase);
   const routineRepository = new SupabaseRoutineRepository(supabase);
   const childProfiles = await childRepository.listByHousehold(household.id);
+  const progressDate = getLocalProgressDate(new Date());
   const routinePairs = await Promise.all(
     childProfiles.map(async (profile) => [profile.id, await routineRepository.listByChild(profile.id)] as const)
   );
+  const progressPairs = await Promise.all(
+    childProfiles.flatMap((profile) =>
+      (['morning', 'evening'] as const).map(async (routineType) => [
+        `${profile.id}:${routineType}`,
+        await progressRepository.getRoutineProgress({
+          childProfileId: profile.id,
+          routineType,
+          progressDate,
+        }),
+      ] as const)
+    )
+  );
+
+  const children = mapCloudHouseholdToChildren({
+    childProfiles,
+    routinesByChildId: Object.fromEntries(routinePairs),
+  }).map((child) => {
+    const applyProgress = (routineType: RoutineType) => {
+      const progress = Object.fromEntries(progressPairs)[`${child.id}:${routineType}`];
+      const completedTaskIds = new Set(
+        (progress?.taskProgress ?? []).filter((taskProgress) => taskProgress.completed).map((taskProgress) => taskProgress.routineTaskId)
+      );
+
+      return child[routineType].map((task) => ({
+        ...task,
+        completed: completedTaskIds.has(task.id),
+      }));
+    };
+
+    return {
+      ...child,
+      morning: applyProgress('morning'),
+      evening: applyProgress('evening'),
+    };
+  });
 
   return {
     homeScene: household.homeScene,
-    children: mapCloudHouseholdToChildren({
-      childProfiles,
-      routinesByChildId: Object.fromEntries(routinePairs),
-    }),
+    children,
   };
 };
+
+export { getLocalProgressDate };

--- a/src/lib/data/supabase-progress-repository.ts
+++ b/src/lib/data/supabase-progress-repository.ts
@@ -1,0 +1,125 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { DailyRoutineProgressRecord, DailyTaskProgressRecord } from './models';
+import type { ProgressRepository } from './repositories';
+
+const DAILY_ROUTINE_PROGRESS_TABLE = 'daily_routine_progress';
+const DAILY_TASK_PROGRESS_TABLE = 'daily_task_progress';
+
+const mapDailyRoutineProgress = (row: Record<string, unknown>): DailyRoutineProgressRecord => ({
+  id: String(row.id),
+  childProfileId: String(row.child_profile_id),
+  routineType: String(row.routine_type) as DailyRoutineProgressRecord['routineType'],
+  progressDate: String(row.progress_date),
+  completedAt: row.completed_at === null || row.completed_at === undefined ? null : String(row.completed_at),
+  createdAt: String(row.created_at),
+  updatedAt: String(row.updated_at),
+});
+
+const mapDailyTaskProgress = (row: Record<string, unknown>): DailyTaskProgressRecord => ({
+  id: String(row.id),
+  dailyRoutineProgressId: String(row.daily_routine_progress_id),
+  routineTaskId: String(row.routine_task_id),
+  completed: Boolean(row.completed),
+  completedAt: row.completed_at === null || row.completed_at === undefined ? null : String(row.completed_at),
+  createdAt: String(row.created_at),
+  updatedAt: String(row.updated_at),
+});
+
+export class SupabaseProgressRepository implements ProgressRepository {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async getRoutineProgress(input: {
+    childProfileId: string;
+    routineType: 'morning' | 'evening';
+    progressDate: string;
+  }) {
+    const { data: dailyRoutineRow, error: dailyRoutineError } = await this.supabase
+      .from(DAILY_ROUTINE_PROGRESS_TABLE)
+      .select('*')
+      .eq('child_profile_id', input.childProfileId)
+      .eq('routine_type', input.routineType)
+      .eq('progress_date', input.progressDate)
+      .maybeSingle();
+
+    if (dailyRoutineError) {
+      throw dailyRoutineError;
+    }
+
+    if (!dailyRoutineRow) {
+      return {
+        dailyRoutineProgress: null,
+        taskProgress: [],
+      };
+    }
+
+    const { data: taskProgressRows, error: taskProgressError } = await this.supabase
+      .from(DAILY_TASK_PROGRESS_TABLE)
+      .select('*')
+      .eq('daily_routine_progress_id', dailyRoutineRow.id);
+
+    if (taskProgressError) {
+      throw taskProgressError;
+    }
+
+    return {
+      dailyRoutineProgress: mapDailyRoutineProgress(dailyRoutineRow),
+      taskProgress: (taskProgressRows ?? []).map(mapDailyTaskProgress),
+    };
+  }
+
+  async upsertRoutineProgress(input: {
+    childProfileId: string;
+    routineType: 'morning' | 'evening';
+    progressDate: string;
+    completedAt?: string | null;
+  }) {
+    const { data, error } = await this.supabase
+      .from(DAILY_ROUTINE_PROGRESS_TABLE)
+      .upsert(
+        {
+          child_profile_id: input.childProfileId,
+          routine_type: input.routineType,
+          progress_date: input.progressDate,
+          completed_at: input.completedAt ?? null,
+        },
+        { onConflict: 'child_profile_id,routine_type,progress_date' }
+      )
+      .select('*')
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    return mapDailyRoutineProgress(data);
+  }
+
+  async setTaskCompletion(input: {
+    dailyRoutineProgressId: string;
+    routineTaskId: string;
+    completed: boolean;
+    completedAt?: string | null;
+  }) {
+    const { data, error } = await this.supabase
+      .from(DAILY_TASK_PROGRESS_TABLE)
+      .upsert(
+        {
+          daily_routine_progress_id: input.dailyRoutineProgressId,
+          routine_task_id: input.routineTaskId,
+          completed: input.completed,
+          completed_at: input.completed ? input.completedAt ?? null : null,
+        },
+        { onConflict: 'daily_routine_progress_id,routine_task_id' }
+      )
+      .select('*')
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    return mapDailyTaskProgress(data);
+  }
+}
+
+export { mapDailyRoutineProgress, mapDailyTaskProgress };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,6 +12,8 @@ import { loadCloudHouseholdState } from '@/lib/data/cloud-household-state';
 import { saveHouseholdConfigToCloud } from '@/lib/data/cloud-household-write';
 import { deleteCloudHousehold } from '@/lib/data/delete-cloud-household';
 import { importLocalFamilyToCloud } from '@/lib/data/local-to-cloud-import';
+import { SupabaseProgressRepository } from '@/lib/data/supabase-progress-repository';
+import { getSupabaseClient } from '@/lib/supabase/client';
 import type { AppView, Child, HomeScene, RoutineType } from '@/lib/types';
 import {
   clearLocalAppState,
@@ -68,6 +70,8 @@ const getDisplayRoutine = (child: Child, now: Date): RoutineType => {
 };
 
 const createSetupChildren = (): Child[] => [];
+const getLocalProgressDate = (date: Date) =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
 
 const serializeHouseholdConfig = (input: {
   children: Child[];
@@ -363,20 +367,75 @@ const Index = () => {
 
   const toggleTask = useCallback(
     (taskId: string) => {
+      let nextProgressWrite:
+        | {
+            childId: string;
+            routineType: RoutineType;
+            taskId: string;
+            completed: boolean;
+            completedAt: string | null;
+          }
+        | null = null;
+
       setChildren((prev) =>
         prev.map((c) => {
           if (c.id !== activeChildId) return c;
           const resolvedRoutine = getDisplayRoutine(c, new Date());
+          const nextRoutine = c[resolvedRoutine].map((t) => {
+            if (t.id !== taskId) return t;
+
+            const completed = !t.completed;
+            nextProgressWrite = {
+              childId: c.id,
+              routineType: resolvedRoutine,
+              taskId,
+              completed,
+              completedAt: completed ? new Date().toISOString() : null,
+            };
+
+            return { ...t, completed };
+          });
+
           return {
             ...c,
-            [resolvedRoutine]: c[resolvedRoutine].map((t) =>
-              t.id === taskId ? { ...t, completed: !t.completed } : t
-            ),
+            [resolvedRoutine]: nextRoutine,
           };
         })
       );
+
+      if (
+        nextProgressWrite &&
+        authStatus === 'signed_in' &&
+        householdStatus === 'ready' &&
+        household
+      ) {
+        const supabase = getSupabaseClient();
+        if (!supabase) return;
+
+        const progressRepository = new SupabaseProgressRepository(supabase);
+        const progressDate = getLocalProgressDate(new Date());
+
+        void progressRepository
+          .upsertRoutineProgress({
+            childProfileId: nextProgressWrite.childId,
+            routineType: nextProgressWrite.routineType,
+            progressDate,
+            completedAt: null,
+          })
+          .then((dailyRoutineProgress) =>
+            progressRepository.setTaskCompletion({
+              dailyRoutineProgressId: dailyRoutineProgress.id,
+              routineTaskId: nextProgressWrite.taskId,
+              completed: nextProgressWrite.completed,
+              completedAt: nextProgressWrite.completedAt,
+            })
+          )
+          .catch((error) => {
+            console.warn('Could not sync routine progress to cloud.', error);
+          });
+      }
     },
-    [activeChildId]
+    [activeChildId, authStatus, household, householdStatus]
   );
 
   const activeChild = children.find((c) => c.id === activeChildId);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -188,6 +188,23 @@ const Index = () => {
       }
 
       if (storedState) {
+        if (authStatus === 'signed_in' && householdStatus === 'ready' && household && cloudState?.children.length) {
+          if (isMounted) {
+            setChildren(cloudState.children);
+            setHomeScene(cloudState.homeScene);
+            setSetupComplete(cloudState.children.length > 0);
+            setView(cloudState.children.length > 0 ? 'home' : 'setup');
+            lastSyncedConfigRef.current = serializeHouseholdConfig({
+              children: cloudState.children,
+              homeScene: cloudState.homeScene,
+              setupComplete: cloudState.children.length > 0,
+            });
+            shouldSyncFirstConfigRef.current = false;
+            setIsReady(true);
+          }
+          return;
+        }
+
         if (
           !cloudLoadError &&
           authStatus === 'signed_in' &&
@@ -365,8 +382,15 @@ const Index = () => {
     }
   }, [authStatus, children, homeScene, isReady, setupComplete]);
 
+  const activeChild = children.find((c) => c.id === activeChildId);
+  const activeRoutine = activeChild ? getDisplayRoutine(activeChild, now) : 'morning';
+
   const toggleTask = useCallback(
     (taskId: string) => {
+      if (!activeChild) return;
+
+      const resolvedRoutine = getDisplayRoutine(activeChild, new Date());
+      const toggledAt = new Date().toISOString();
       let nextProgressWrite:
         | {
             childId: string;
@@ -374,33 +398,43 @@ const Index = () => {
             taskId: string;
             completed: boolean;
             completedAt: string | null;
+            routineCompleted: boolean;
           }
         | null = null;
 
+      const nextRoutine = activeChild[resolvedRoutine].map((task) => {
+        if (task.id !== taskId) return task;
+
+        const completed = !task.completed;
+        nextProgressWrite = {
+          childId: activeChild.id,
+          routineType: resolvedRoutine,
+          taskId,
+          completed,
+          completedAt: completed ? toggledAt : null,
+          routineCompleted: false,
+        };
+
+        return { ...task, completed };
+      });
+
+      if (!nextProgressWrite) return;
+
+      const routineCompleted = nextRoutine.length > 0 && nextRoutine.every((task) => task.completed);
+      nextProgressWrite = {
+        ...nextProgressWrite,
+        routineCompleted,
+      };
+
       setChildren((prev) =>
-        prev.map((c) => {
-          if (c.id !== activeChildId) return c;
-          const resolvedRoutine = getDisplayRoutine(c, new Date());
-          const nextRoutine = c[resolvedRoutine].map((t) => {
-            if (t.id !== taskId) return t;
-
-            const completed = !t.completed;
-            nextProgressWrite = {
-              childId: c.id,
-              routineType: resolvedRoutine,
-              taskId,
-              completed,
-              completedAt: completed ? new Date().toISOString() : null,
-            };
-
-            return { ...t, completed };
-          });
-
-          return {
-            ...c,
-            [resolvedRoutine]: nextRoutine,
-          };
-        })
+        prev.map((child) =>
+          child.id === activeChild.id
+            ? {
+                ...child,
+                [resolvedRoutine]: nextRoutine,
+              }
+            : child
+        )
       );
 
       if (
@@ -422,24 +456,28 @@ const Index = () => {
             progressDate,
             completedAt: null,
           })
-          .then((dailyRoutineProgress) =>
-            progressRepository.setTaskCompletion({
+          .then(async (dailyRoutineProgress) => {
+            await progressRepository.setTaskCompletion({
               dailyRoutineProgressId: dailyRoutineProgress.id,
               routineTaskId: nextProgressWrite.taskId,
               completed: nextProgressWrite.completed,
               completedAt: nextProgressWrite.completedAt,
-            })
-          )
+            });
+
+            await progressRepository.upsertRoutineProgress({
+              childProfileId: nextProgressWrite.childId,
+              routineType: nextProgressWrite.routineType,
+              progressDate,
+              completedAt: nextProgressWrite.routineCompleted ? new Date().toISOString() : null,
+            });
+          })
           .catch((error) => {
             console.warn('Could not sync routine progress to cloud.', error);
           });
       }
     },
-    [activeChildId, authStatus, household, householdStatus]
+    [activeChild, authStatus, household, householdStatus]
   );
-
-  const activeChild = children.find((c) => c.id === activeChildId);
-  const activeRoutine = activeChild ? getDisplayRoutine(activeChild, now) : 'morning';
   const dueRoutineByChild = Object.fromEntries(
     children.map((child) => [child.id, getDueRoutine(child, now)])
   ) as Record<string, RoutineType | null>;

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -29,6 +29,11 @@ const { saveHouseholdConfigToCloud } = vi.hoisted(() => ({
 const { deleteCloudHousehold } = vi.hoisted(() => ({
   deleteCloudHousehold: vi.fn(),
 }));
+const { getSupabaseClient, upsertRoutineProgress, setTaskCompletion } = vi.hoisted(() => ({
+  getSupabaseClient: vi.fn(),
+  upsertRoutineProgress: vi.fn(),
+  setTaskCompletion: vi.fn(),
+}));
 
 vi.mock("@/lib/auth/use-auth", () => ({
   useAuth: () => authState,
@@ -45,6 +50,15 @@ vi.mock("@/lib/data/cloud-household-write", () => ({
 }));
 vi.mock("@/lib/data/delete-cloud-household", () => ({
   deleteCloudHousehold,
+}));
+vi.mock("@/lib/supabase/client", () => ({
+  getSupabaseClient,
+}));
+vi.mock("@/lib/data/supabase-progress-repository", () => ({
+  SupabaseProgressRepository: class {
+    upsertRoutineProgress = upsertRoutineProgress;
+    setTaskCompletion = setTaskCompletion;
+  },
 }));
 
 const today = () => new Date().toDateString();
@@ -258,6 +272,13 @@ describe("Index", () => {
     importLocalFamilyToCloud.mockReset();
     saveHouseholdConfigToCloud.mockReset();
     deleteCloudHousehold.mockReset();
+    deleteCloudHousehold.mockReset();
+    getSupabaseClient.mockReset();
+    upsertRoutineProgress.mockReset();
+    setTaskCompletion.mockReset();
+    getSupabaseClient.mockReturnValue({});
+    upsertRoutineProgress.mockResolvedValue({ id: "progress-1" });
+    setTaskCompletion.mockResolvedValue({ id: "task-progress-1" });
     authState.clearError.mockReset();
     authState.sendEmailLink.mockReset();
     authState.retryHousehold.mockReset();
@@ -530,6 +551,46 @@ describe("Index", () => {
     expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
   });
 
+  it("prefers cloud household state over stale local cache for signed-in households", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [
+        {
+          id: "1",
+          name: "Cloud Lily",
+          morning: [{ id: "m1", title: "Make bed", icon: "bed", completed: true }],
+          evening: [],
+        },
+      ],
+    });
+    localStorage.setItem(
+      "routine_stars_data",
+      JSON.stringify({
+        ...createStoredState(false, today()),
+        setupComplete: true,
+      })
+    );
+
+    render(<Index />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "select-first-child" }));
+
+    expect(await screen.findByTestId("active-child")).toHaveTextContent("Cloud Lily");
+    expect(screen.getByTestId("first-task-completed")).toHaveTextContent("true");
+  });
+
   it("shows an import decision when a signed-in device has local setup and cloud is empty", async () => {
     authState.status = "signed_in";
     authState.user = { id: "user-1", email: "parent@example.com" };
@@ -682,6 +743,52 @@ describe("Index", () => {
     fireEvent.click(await screen.findByRole("button", { name: "start-fresh-instead" }));
 
     expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
+  });
+
+  it("syncs signed-in task toggles to cloud-backed progress", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [
+        {
+          id: "1",
+          name: "Lily",
+          morning: [{ id: "m1", title: "Make bed", icon: "bed", completed: false }],
+          evening: [],
+          schedule: {
+            morning: { start: "00:00", end: "23:59" },
+            evening: { start: "00:00", end: "00:01" },
+          },
+        },
+      ],
+    });
+
+    render(<Index />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "select-first-child" }));
+    fireEvent.click(screen.getByRole("button", { name: "toggle-first-task" }));
+
+    await waitFor(() => {
+      expect(upsertRoutineProgress).toHaveBeenCalled();
+      expect(setTaskCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dailyRoutineProgressId: "progress-1",
+          routineTaskId: "m1",
+          completed: true,
+        })
+      );
+    });
   });
 
   it("shows a dedicated recovery screen when a signed-in household is empty in this browser context", async () => {

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -285,7 +285,7 @@ describe("Index", () => {
     authState.signOut.mockReset();
   });
 
-  it("resets completed tasks when stored data is from a previous day", async () => {
+  it("prefers cloud progress when local storage is from a previous day", async () => {
     authState.status = "signed_in";
     authState.user = { id: "user-1", email: "parent@example.com" };
     authState.householdStatus = "ready";
@@ -322,7 +322,7 @@ describe("Index", () => {
     fireEvent.click(await screen.findByRole("button", { name: "select-first-child" }));
 
     expect(await screen.findByTestId("active-child")).toHaveTextContent("Lily");
-    expect(screen.getByTestId("first-task-completed")).toHaveTextContent("false");
+    expect(screen.getByTestId("first-task-completed")).toHaveTextContent("true");
   });
 
   it("persists task toggles back to localStorage for the current day", async () => {

--- a/src/test/supabaseProgressRepository.test.ts
+++ b/src/test/supabaseProgressRepository.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SupabaseProgressRepository } from '@/lib/data/supabase-progress-repository';
+
+const createSupabaseClient = (responses: Record<string, unknown>) =>
+  ({
+    from: vi.fn((table: string) => responses[table]),
+  }) as never;
+
+describe('SupabaseProgressRepository', () => {
+  it('loads a routine progress record and its task progress rows', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: {
+        id: 'progress-1',
+        child_profile_id: 'child-1',
+        routine_type: 'morning',
+        progress_date: '2026-04-20',
+        completed_at: null,
+        created_at: '2026-04-20T08:00:00Z',
+        updated_at: '2026-04-20T08:00:00Z',
+      },
+      error: null,
+    });
+    const eqDate = vi.fn(() => ({ maybeSingle }));
+    const eqType = vi.fn(() => ({ eq: eqDate }));
+    const eqChild = vi.fn(() => ({ eq: eqType }));
+    const eqRoutineProgressId = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: 'task-progress-1',
+          daily_routine_progress_id: 'progress-1',
+          routine_task_id: 'task-1',
+          completed: true,
+          completed_at: '2026-04-20T08:05:00Z',
+          created_at: '2026-04-20T08:05:00Z',
+          updated_at: '2026-04-20T08:05:00Z',
+        },
+      ],
+      error: null,
+    });
+    const repository = new SupabaseProgressRepository(
+      createSupabaseClient({
+        daily_routine_progress: {
+          select: vi.fn(() => ({ eq: eqChild })),
+        },
+        daily_task_progress: {
+          select: vi.fn(() => ({ eq: eqRoutineProgressId })),
+        },
+      })
+    );
+
+    await expect(
+      repository.getRoutineProgress({
+        childProfileId: 'child-1',
+        routineType: 'morning',
+        progressDate: '2026-04-20',
+      })
+    ).resolves.toEqual({
+      dailyRoutineProgress: expect.objectContaining({
+        id: 'progress-1',
+        childProfileId: 'child-1',
+        routineType: 'morning',
+      }),
+      taskProgress: [
+        expect.objectContaining({
+          id: 'task-progress-1',
+          routineTaskId: 'task-1',
+          completed: true,
+        }),
+      ],
+    });
+  });
+
+  it('upserts daily routine progress and task completion rows', async () => {
+    const routineSingle = vi.fn().mockResolvedValue({
+      data: {
+        id: 'progress-1',
+        child_profile_id: 'child-1',
+        routine_type: 'morning',
+        progress_date: '2026-04-20',
+        completed_at: null,
+        created_at: '2026-04-20T08:00:00Z',
+        updated_at: '2026-04-20T08:00:00Z',
+      },
+      error: null,
+    });
+    const routineSelect = vi.fn(() => ({ single: routineSingle }));
+    const routineUpsert = vi.fn(() => ({ select: routineSelect }));
+    const taskSingle = vi.fn().mockResolvedValue({
+      data: {
+        id: 'task-progress-1',
+        daily_routine_progress_id: 'progress-1',
+        routine_task_id: 'task-1',
+        completed: true,
+        completed_at: '2026-04-20T08:05:00Z',
+        created_at: '2026-04-20T08:05:00Z',
+        updated_at: '2026-04-20T08:05:00Z',
+      },
+      error: null,
+    });
+    const taskSelect = vi.fn(() => ({ single: taskSingle }));
+    const taskUpsert = vi.fn(() => ({ select: taskSelect }));
+    const repository = new SupabaseProgressRepository(
+      createSupabaseClient({
+        daily_routine_progress: { upsert: routineUpsert },
+        daily_task_progress: { upsert: taskUpsert },
+      })
+    );
+
+    await expect(
+      repository.upsertRoutineProgress({
+        childProfileId: 'child-1',
+        routineType: 'morning',
+        progressDate: '2026-04-20',
+      })
+    ).resolves.toMatchObject({
+      id: 'progress-1',
+      routineType: 'morning',
+    });
+
+    await expect(
+      repository.setTaskCompletion({
+        dailyRoutineProgressId: 'progress-1',
+        routineTaskId: 'task-1',
+        completed: true,
+        completedAt: '2026-04-20T08:05:00Z',
+      })
+    ).resolves.toMatchObject({
+      id: 'task-progress-1',
+      routineTaskId: 'task-1',
+      completed: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds cloud-backed daily routine progress for signed-in households so same-day task completion can follow the family across devices.

## What changed
- adds a `SupabaseProgressRepository` for `daily_routine_progress` and `daily_task_progress`
- hydrates today’s routine completion state from cloud when loading a signed-in household
- prefers cloud household state over stale local cache for signed-in households
- writes signed-in task toggles back to cloud-backed daily progress
- adds test coverage for repository reads/writes, cloud-preferring bootstrap behavior, and signed-in progress syncing

## Same-day rule
- cloud progress is loaded and written only for the current local day
- local import still does not merge same-day progress into cloud
- unsigned/local-only households keep the existing browser-local reset behavior

## Validation
- `npm test`
- 55 tests passed on the `main`-based branch

## Related issues
- Addresses #26