### PR TITLE
[codex] Preserve pending offline progress on signed-in devices

### DIFF
--- a/src/lib/storage/local-app-state.ts
+++ b/src/lib/storage/local-app-state.ts
@@ -9,6 +9,7 @@ export interface LocalAppState {
   homeScene: HomeScene;
   lastReset: string;
   setupComplete: boolean;
+  pendingCloudProgressSync: boolean;
 }
 
 type LegacyLocalAppState = Partial<Omit<LocalAppState, 'version'>> & {
@@ -34,6 +35,8 @@ const normalizeLocalAppState = (value: unknown): LocalAppState | null => {
     homeScene: legacy.homeScene ?? 'bike',
     lastReset: legacy.lastReset ?? new Date().toDateString(),
     setupComplete: legacy.setupComplete ?? true,
+    pendingCloudProgressSync:
+      typeof value.pendingCloudProgressSync === 'boolean' ? value.pendingCloudProgressSync : false,
   };
 };
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -70,6 +70,62 @@ const createSetupChildren = (): Child[] => [];
 const getLocalProgressDate = (date: Date) =>
   `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
 
+const mergeLocalProgressIntoChildren = (cloudChildren: Child[], localChildren: Child[]) =>
+  cloudChildren.map((cloudChild) => {
+    const localChild = localChildren.find((candidate) => candidate.id === cloudChild.id);
+    if (!localChild) {
+      return cloudChild;
+    }
+
+    const mergeRoutine = (routineType: RoutineType) =>
+      cloudChild[routineType].map((cloudTask) => {
+        const localTask = localChild[routineType].find((candidate) => candidate.id === cloudTask.id);
+        return localTask ? { ...cloudTask, completed: localTask.completed } : cloudTask;
+      });
+
+    return {
+      ...cloudChild,
+      morning: mergeRoutine('morning'),
+      evening: mergeRoutine('evening'),
+    };
+  });
+
+const syncPendingProgressToCloud = async (input: { children: Child[] }) => {
+  const supabase = getSupabaseClient();
+  if (!supabase) {
+    throw new Error('Supabase is not configured yet.');
+  }
+
+  const progressRepository = new SupabaseProgressRepository(supabase);
+  const progressDate = getLocalProgressDate(new Date());
+
+  await Promise.all(
+    input.children.flatMap((child) =>
+      (['morning', 'evening'] as const).map(async (routineType) => {
+        const tasks = child[routineType];
+        const completedTasks = tasks.filter((task) => task.completed);
+        const dailyRoutineProgress = await progressRepository.upsertRoutineProgress({
+          childProfileId: child.id,
+          routineType,
+          progressDate,
+          completedAt: completedTasks.length === tasks.length && tasks.length > 0 ? new Date().toISOString() : null,
+        });
+
+        await Promise.all(
+          tasks.map((task) =>
+            progressRepository.setTaskCompletion({
+              dailyRoutineProgressId: dailyRoutineProgress.id,
+              routineTaskId: task.id,
+              completed: task.completed,
+              completedAt: task.completed ? new Date().toISOString() : null,
+            })
+          )
+        );
+      })
+    )
+  );
+};
+
 const serializeHouseholdConfig = (input: {
   children: Child[];
   homeScene: HomeScene;
@@ -110,6 +166,7 @@ const Index = () => {
   const [isImporting, setIsImporting] = useState(false);
   const [now, setNow] = useState(() => new Date());
   const [homeScene, setHomeScene] = useState<HomeScene>('bike');
+  const [pendingCloudProgressSync, setPendingCloudProgressSync] = useState(false);
   const lastSyncedConfigRef = useRef<string | null>(null);
   const shouldSyncFirstConfigRef = useRef(false);
 
@@ -119,6 +176,7 @@ const Index = () => {
     setActiveChildId(null);
     setSetupComplete(false);
     setHomeScene('bike');
+    setPendingCloudProgressSync(false);
     setView('setup');
     setNow(new Date());
   }, []);
@@ -126,6 +184,7 @@ const Index = () => {
   const restartSetup = useCallback(() => {
     setActiveChildId(null);
     setSetupComplete(false);
+    setPendingCloudProgressSync(false);
     setView('setup');
     setNow(new Date());
   }, []);
@@ -151,14 +210,21 @@ const Index = () => {
       }
 
       if (storedState) {
+        const storedStateIsToday = storedState.lastReset === new Date().toDateString();
+
         if (authStatus === 'signed_in' && householdStatus === 'ready' && household && cloudState?.children.length) {
           if (isMounted) {
-            setChildren(cloudState.children);
+            const nextChildren =
+              storedStateIsToday && storedState.pendingCloudProgressSync
+                ? mergeLocalProgressIntoChildren(cloudState.children, storedState.children)
+                : cloudState.children;
+            setChildren(nextChildren);
             setHomeScene(cloudState.homeScene);
             setSetupComplete(cloudState.children.length > 0);
+            setPendingCloudProgressSync(storedStateIsToday && storedState.pendingCloudProgressSync);
             setView(cloudState.children.length > 0 ? 'home' : 'setup');
             lastSyncedConfigRef.current = serializeHouseholdConfig({
-              children: cloudState.children,
+              children: nextChildren,
               homeScene: cloudState.homeScene,
               setupComplete: cloudState.children.length > 0,
             });
@@ -179,6 +245,7 @@ const Index = () => {
             setChildren(storedState.children);
             setHomeScene(storedState.homeScene);
             setSetupComplete(storedState.setupComplete);
+            setPendingCloudProgressSync(storedStateIsToday && storedState.pendingCloudProgressSync);
             setView('import');
             setIsReady(true);
           }
@@ -202,6 +269,7 @@ const Index = () => {
         if (isMounted) {
           setSetupComplete(storedState.setupComplete);
           setHomeScene(storedState.homeScene);
+          setPendingCloudProgressSync(storedState.lastReset === today ? storedState.pendingCloudProgressSync : false);
           setView(
             storedState.setupComplete
               ? 'home'
@@ -220,6 +288,7 @@ const Index = () => {
         setChildren(cloudState.children);
         setHomeScene(cloudState.homeScene);
         setSetupComplete(cloudState.children.length > 0);
+        setPendingCloudProgressSync(false);
         setView(cloudState.children.length > 0 ? 'home' : 'setup');
         if (cloudState.children.length > 0) {
           lastSyncedConfigRef.current = serializeHouseholdConfig({
@@ -239,6 +308,7 @@ const Index = () => {
         setChildren(createSetupChildren());
         setSetupComplete(false);
         setHomeScene('bike');
+        setPendingCloudProgressSync(false);
         setView(authStatus === 'signed_in' ? 'setup' : 'account');
         shouldSyncFirstConfigRef.current = authStatus === 'signed_in';
         setIsReady(true);
@@ -317,11 +387,41 @@ const Index = () => {
         homeScene,
         lastReset: new Date().toDateString(),
         setupComplete,
+        pendingCloudProgressSync,
       });
     } catch (error) {
       console.warn('Could not save app state to local storage.', error);
     }
-  }, [children, homeScene, isReady, setupComplete]);
+  }, [children, homeScene, isReady, pendingCloudProgressSync, setupComplete]);
+
+  useEffect(() => {
+    if (
+      !isReady ||
+      !pendingCloudProgressSync ||
+      authStatus !== 'signed_in' ||
+      householdStatus !== 'ready' ||
+      !household ||
+      !setupComplete
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+
+    void syncPendingProgressToCloud({ children })
+      .then(() => {
+        if (!cancelled) {
+          setPendingCloudProgressSync(false);
+        }
+      })
+      .catch((error) => {
+        console.warn('Could not flush pending local progress to cloud.', error);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authStatus, children, household, householdStatus, isReady, pendingCloudProgressSync, setupComplete]);
 
   const activeChild = children.find((c) => c.id === activeChildId);
   const activeRoutine = activeChild ? getDisplayRoutine(activeChild, now) : 'morning';
@@ -389,6 +489,7 @@ const Index = () => {
 
         const progressRepository = new SupabaseProgressRepository(supabase);
         const progressDate = getLocalProgressDate(new Date());
+        setPendingCloudProgressSync(true);
 
         void progressRepository
           .upsertRoutineProgress({
@@ -411,6 +512,7 @@ const Index = () => {
               progressDate,
               completedAt: nextProgressWrite.routineCompleted ? new Date().toISOString() : null,
             });
+            setPendingCloudProgressSync(false);
           })
           .catch((error) => {
             console.warn('Could not sync routine progress to cloud.', error);
@@ -457,6 +559,7 @@ const Index = () => {
               setChildren(cloudState.children);
               setHomeScene(cloudState.homeScene);
               setSetupComplete(cloudState.children.length > 0);
+              setPendingCloudProgressSync(false);
               setView(cloudState.children.length > 0 ? 'home' : 'setup');
               lastSyncedConfigRef.current = serializeHouseholdConfig({
                 children: cloudState.children,
@@ -479,6 +582,7 @@ const Index = () => {
           setChildren(createSetupChildren());
           setSetupComplete(false);
           setHomeScene('bike');
+          setPendingCloudProgressSync(false);
           setView('setup');
           setImportError(null);
           shouldSyncFirstConfigRef.current = true;

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -395,6 +395,48 @@ describe("Index", () => {
       JSON.stringify({
         ...createStoredState(false, today()),
         setupComplete: true,
+        pendingCloudProgressSync: false,
+      })
+    );
+
+    render(<Index />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "select-first-child" }));
+
+    expect(await screen.findByTestId("active-child")).toHaveTextContent("Cloud Lily");
+    expect(screen.getByTestId("first-task-completed")).toHaveTextContent("true");
+  });
+
+  it("preserves same-day local progress over cloud state when a signed-in device has pending offline sync", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [
+        {
+          id: "1",
+          name: "Cloud Lily",
+          morning: [{ id: "m1", title: "Make bed", icon: "bed", completed: false }],
+          evening: [],
+        },
+      ],
+    });
+    localStorage.setItem(
+      "routine_stars_data",
+      JSON.stringify({
+        ...createStoredState(true, today()),
+        setupComplete: true,
+        pendingCloudProgressSync: true,
       })
     );
 
@@ -592,6 +634,53 @@ describe("Index", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "select-first-child" }));
     fireEvent.click(screen.getByRole("button", { name: "toggle-first-task" }));
+
+    await waitFor(() => {
+      expect(upsertRoutineProgress).toHaveBeenCalled();
+      expect(setTaskCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dailyRoutineProgressId: "progress-1",
+          routineTaskId: "m1",
+          completed: true,
+        })
+      );
+    });
+  });
+
+  it("retries pending local progress sync after signed-in bootstrap", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [
+        {
+          id: "1",
+          name: "Cloud Lily",
+          morning: [{ id: "m1", title: "Make bed", icon: "bed", completed: false }],
+          evening: [],
+        },
+      ],
+    });
+    localStorage.setItem(
+      "routine_stars_data",
+      JSON.stringify({
+        ...createStoredState(true, today()),
+        setupComplete: true,
+        pendingCloudProgressSync: true,
+      })
+    );
+
+    render(<Index />);
 
     await waitFor(() => {
       expect(upsertRoutineProgress).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
Builds on the daily progress sync foundation by preserving same-day local progress when a signed-in shared device has pending offline progress that has not reached the cloud yet.

## What changed
- adds `pendingCloudProgressSync` to the local app cache shape
- marks signed-in local progress as pending before cloud writes complete
- preserves same-day local task completion over cloud state only when this device has known pending offline progress
- retries pending progress sync in the background after signed-in bootstrap
- adds test coverage for pending offline preservation and retry sync behavior

## Why
After adding cross-device daily progress sync, the next trust risk was silent loss of same-day checkmarks made offline on a shared device. This slice keeps cloud as the normal source of truth, while preserving local progress only for the narrow case where this device knows it still has unsynced changes.

## Validation
- `npm test`
- 57 tests passed on the stacked branch

## Related issues
- Addresses #53
- Builds on #52