### PR TITLE
[codex] Show parent-facing sync status for shared devices

### DIFF
--- a/src/components/ParentSettings.tsx
+++ b/src/components/ParentSettings.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Reorder } from 'framer-motion';
 import {
   Sun, Moon, Trash2, Plus, GripVertical, UserPlus, ArrowLeft, X, Check, Shuffle, Clock3, Palette, ChevronDown,
-  Users, House, Shield, CreditCard, LogOut, UserRound,
+  Users, House, Shield, CreditCard, LogOut, UserRound, Cloud, CloudOff, RefreshCw,
 } from 'lucide-react';
 import { TaskIcon } from './TaskIcon';
 import { TaskSuggestionPicker } from './TaskSuggestionPicker';
@@ -17,6 +17,7 @@ import type { TaskCatalogItem } from '@/lib/task-catalog';
 interface ParentSettingsProps {
   children: Child[];
   homeScene: HomeScene;
+  pendingCloudProgressSync?: boolean;
   onChange: (children: Child[]) => void;
   onHomeSceneChange: (scene: HomeScene) => void;
   onRestartSetup: () => void;
@@ -257,6 +258,7 @@ const HOME_SCENE_OPTIONS: { key: HomeScene; label: string; preview: string; desc
 export const ParentSettings = ({
   children,
   homeScene,
+  pendingCloudProgressSync = false,
   onChange,
   onHomeSceneChange,
   onRestartSetup,
@@ -393,6 +395,33 @@ export const ParentSettings = ({
             <p className="mt-3 text-lg font-bold text-foreground">{children.length} kids</p>
             <p className="mt-1 text-sm text-muted-foreground">
               Choose a section on the left instead of scrolling through everything at once.
+            </p>
+          </div>
+
+          <div className="mt-4 rounded-[24px] border border-border bg-background p-4">
+            <div className="flex items-center gap-2">
+              {authStatus !== 'signed_in' ? (
+                <CloudOff size={16} className="text-muted-foreground" />
+              ) : pendingCloudProgressSync ? (
+                <RefreshCw size={16} className="text-primary" />
+              ) : (
+                <Cloud size={16} className="text-primary" />
+              )}
+              <p className="text-xs font-black uppercase tracking-[0.22em] text-muted-foreground">Sync status</p>
+            </div>
+            <p className="mt-3 text-base font-bold text-foreground">
+              {authStatus !== 'signed_in'
+                ? 'This device is local-only right now.'
+                : pendingCloudProgressSync
+                  ? 'This device still has progress waiting to sync.'
+                  : 'This device is caught up.'}
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {authStatus !== 'signed_in'
+                ? 'Kids can keep using this shared device, but updates stay saved only here until a parent signs in.'
+                : pendingCloudProgressSync
+                  ? 'We will keep trying quietly in the background so the family can continue without losing today’s checkmarks.'
+                  : 'Signed-in household changes and today’s progress are ready to follow the family across devices.'}
             </p>
           </div>
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -620,6 +620,7 @@ const Index = () => {
       <ParentSettings
         children={children}
         homeScene={homeScene}
+        pendingCloudProgressSync={pendingCloudProgressSync}
         onChange={setChildren}
         onHomeSceneChange={setHomeScene}
         onRestartSetup={restartSetup}

--- a/src/test/parentSettings.test.tsx
+++ b/src/test/parentSettings.test.tsx
@@ -3,8 +3,24 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { ParentSettings } from "@/components/ParentSettings";
-import { AuthProvider } from "@/lib/auth/auth-context";
 import type { Child, HomeScene } from "@/lib/types";
+
+const authState = {
+  configured: true,
+  status: "signed_out",
+  user: null,
+  householdStatus: "idle",
+  household: null,
+  error: null,
+  clearError: vi.fn(),
+  sendEmailLink: vi.fn(),
+  retryHousehold: vi.fn(),
+  signOut: vi.fn(),
+};
+
+vi.mock("@/lib/auth/use-auth", () => ({
+  useAuth: () => authState,
+}));
 
 vi.mock("framer-motion", () => ({
   motion: new Proxy(
@@ -44,35 +60,46 @@ const initialChildren: Child[] = [
 
 const readState = () => JSON.parse(screen.getByTestId("state").textContent ?? "{}") as Child[];
 
-const Harness = ({ seedChildren = initialChildren }: { seedChildren?: Child[] }) => {
+const Harness = ({
+  seedChildren = initialChildren,
+  pendingCloudProgressSync = false,
+}: {
+  seedChildren?: Child[];
+  pendingCloudProgressSync?: boolean;
+}) => {
   const [children, setChildren] = useState(seedChildren);
   const [homeScene, setHomeScene] = useState<HomeScene>("bike");
   const [restartCount, setRestartCount] = useState(0);
   const [resetCount, setResetCount] = useState(0);
 
   return (
-    <AuthProvider>
-      <div>
-        <pre data-testid="state">{JSON.stringify(children)}</pre>
-        <div data-testid="restart-count">{restartCount}</div>
-        <div data-testid="reset-count">{resetCount}</div>
-        <ParentSettings
-          children={children}
-          homeScene={homeScene}
-          onChange={setChildren}
-          onHomeSceneChange={setHomeScene}
-          onRestartSetup={() => setRestartCount((count) => count + 1)}
-          onResetAppData={() => setResetCount((count) => count + 1)}
-          onBack={() => {}}
-        />
-      </div>
-    </AuthProvider>
+    <div>
+      <pre data-testid="state">{JSON.stringify(children)}</pre>
+      <div data-testid="restart-count">{restartCount}</div>
+      <div data-testid="reset-count">{resetCount}</div>
+      <ParentSettings
+        children={children}
+        homeScene={homeScene}
+        pendingCloudProgressSync={pendingCloudProgressSync}
+        onChange={setChildren}
+        onHomeSceneChange={setHomeScene}
+        onRestartSetup={() => setRestartCount((count) => count + 1)}
+        onResetAppData={() => setResetCount((count) => count + 1)}
+        onBack={() => {}}
+      />
+    </div>
   );
 };
 
 describe("ParentSettings", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    authState.status = "signed_out";
+    authState.user = null;
+    authState.signOut.mockReset();
+    authState.clearError.mockReset();
+    authState.sendEmailLink.mockReset();
+    authState.retryHousehold.mockReset();
   });
 
   it("renames a child in place", () => {
@@ -206,5 +233,22 @@ describe("ParentSettings", () => {
 
     expect(screen.getByTestId("restart-count")).toHaveTextContent("1");
     expect(readState()).toHaveLength(2);
+  });
+
+  it("shows a calm local-only sync status when no parent is signed in", () => {
+    render(<Harness />);
+
+    expect(screen.getByText(/this device is local-only right now/i)).toBeInTheDocument();
+  });
+
+  it("shows a pending sync status when this device still has offline progress to flush", () => {
+    authState.status = "signed_in";
+
+    render(<Harness pendingCloudProgressSync />);
+
+    expect(screen.getByText(/this device still has progress waiting to sync/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/we will keep trying quietly in the background/i)
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
Adds a simple parent-facing sync status panel so signed-in shared devices feel understandable when they are local-only, caught up, or still waiting to sync pending offline progress.

## What changed
- adds a sync status card in parent settings
- shows local-only, caught-up, and pending-sync states with calm parent-facing copy
- wires the current `pendingCloudProgressSync` state from the app shell into parent settings
- updates parent settings tests to cover the new states without relying on the full auth provider

## Why
We already preserve pending offline progress, but parents had no visible clue about whether this device was caught up or still waiting to sync. This slice makes the shared-device behavior feel intentional instead of mysterious.

## Validation
- `npm test`
- 59 tests passed on the isolated branch

## Related issues
- Addresses #58
- Builds on #57