### PR TITLE
[codex] Fix iPad magic-link auth callback flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider } from "@/lib/auth/auth-context";
 import { APP_VERSION, getRefreshUrl, getVersionManifestUrl } from "@/lib/app-version";
+import AuthCallback from "./pages/AuthCallback.tsx";
 import Index from "./pages/Index.tsx";
 import NotFound from "./pages/NotFound.tsx";
 
@@ -66,6 +67,7 @@ const AppShell = () => {
       <BrowserRouter basename={import.meta.env.BASE_URL}>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/auth/callback" element={<AuthCallback />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -14,7 +14,7 @@ export const getSupabaseEmailRedirectUrl = () => {
     return undefined;
   }
 
-  return new URL(import.meta.env.BASE_URL || '/', window.location.origin).toString();
+  return new URL('auth/callback', window.location.origin + (import.meta.env.BASE_URL || '/')).toString();
 };
 
 export const getSupabaseClient = () => {

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -1,0 +1,74 @@
+import { LoaderCircle } from 'lucide-react';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/lib/auth/use-auth';
+
+const AuthCallback = () => {
+  const navigate = useNavigate();
+  const { configured, status, householdStatus, error, clearError } = useAuth();
+
+  useEffect(() => {
+    if (!configured) {
+      return;
+    }
+
+    if (status === 'signed_in' && householdStatus !== 'loading') {
+      navigate('/', { replace: true });
+    }
+  }, [configured, householdStatus, navigate, status]);
+
+  return (
+    <div className="flex min-h-svh items-center justify-center px-5 py-10">
+      <div className="w-full max-w-lg rounded-[32px] border border-border bg-card p-8 text-center shadow-card">
+        {status === 'signed_in' && householdStatus === 'error' ? (
+          <>
+            <p className="text-sm font-black uppercase tracking-[0.22em] text-destructive">Sign-in needs one more step</p>
+            <h1 className="mt-4 text-3xl font-bold text-foreground">We signed you in, but could not open the family space yet</h1>
+            <p className="mt-3 text-sm text-muted-foreground">
+              {error ?? 'Please try this link again in a moment.'}
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                clearError();
+                navigate('/', { replace: true });
+              }}
+              className="mt-6 rounded-full bg-primary px-5 py-3 text-sm font-bold text-primary-foreground shadow-button transition-transform active:translate-y-0.5"
+            >
+              Continue to Routine Stars
+            </button>
+          </>
+        ) : status === 'signed_out' && error ? (
+          <>
+            <p className="text-sm font-black uppercase tracking-[0.22em] text-destructive">Sign-in link problem</p>
+            <h1 className="mt-4 text-3xl font-bold text-foreground">This sign-in link did not finish cleanly</h1>
+            <p className="mt-3 text-sm text-muted-foreground">{error}</p>
+            <button
+              type="button"
+              onClick={() => {
+                clearError();
+                navigate('/', { replace: true });
+              }}
+              className="mt-6 rounded-full bg-primary px-5 py-3 text-sm font-bold text-primary-foreground shadow-button transition-transform active:translate-y-0.5"
+            >
+              Back to sign in
+            </button>
+          </>
+        ) : (
+          <>
+            <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <LoaderCircle size={28} className="animate-spin" />
+            </div>
+            <p className="mt-5 text-sm font-black uppercase tracking-[0.22em] text-primary">Finishing sign-in</p>
+            <h1 className="mt-4 text-3xl font-bold text-foreground">Opening your family account</h1>
+            <p className="mt-3 text-sm text-muted-foreground">
+              Please keep this page open for a moment while we connect this device.
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AuthCallback;

--- a/src/test/authCallback.test.tsx
+++ b/src/test/authCallback.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import AuthCallback from '@/pages/AuthCallback';
+
+const navigate = vi.fn();
+
+const authState = {
+  configured: true,
+  status: 'loading',
+  householdStatus: 'idle',
+  error: null as string | null,
+  clearError: vi.fn(),
+};
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigate,
+  };
+});
+
+vi.mock('@/lib/auth/use-auth', () => ({
+  useAuth: () => authState,
+}));
+
+describe('AuthCallback', () => {
+  it('shows a finishing sign-in state while auth is settling', () => {
+    authState.status = 'loading';
+    authState.householdStatus = 'idle';
+    authState.error = null;
+
+    render(
+      <MemoryRouter initialEntries={['/auth/callback']}>
+        <Routes>
+          <Route path="/auth/callback" element={<AuthCallback />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/finishing sign-in/i)).toBeInTheDocument();
+    expect(screen.getByText(/opening your family account/i)).toBeInTheDocument();
+  });
+
+  it('shows a recovery path when the household bootstrap fails after sign-in', () => {
+    authState.status = 'signed_in';
+    authState.householdStatus = 'error';
+    authState.error = 'Could not prepare the family household in Supabase.';
+
+    render(
+      <MemoryRouter initialEntries={['/auth/callback']}>
+        <Routes>
+          <Route path="/auth/callback" element={<AuthCallback />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/we signed you in, but could not open the family space yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/could not prepare the family household/i)).toBeInTheDocument();
+  });
+});

--- a/src/test/supabaseClient.test.ts
+++ b/src/test/supabaseClient.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it, vi } from 'vitest';
+
+describe('getSupabaseEmailRedirectUrl', () => {
+  it('targets the dedicated auth callback route', async () => {
+    vi.resetModules();
+
+    const { getSupabaseEmailRedirectUrl } = await import('@/lib/supabase/client');
+
+    expect(getSupabaseEmailRedirectUrl()).toBe(`${window.location.origin}/auth/callback`);
+  });
+});


### PR DESCRIPTION
## Summary
- send Supabase email-link sign-ins to a dedicated `/auth/callback` route instead of the app root
- add an auth callback page that finishes sign-in and routes parents back into the app gracefully
- add tests for the callback screen and redirect URL generation

Closes #62

## Testing
- npm test