### PR TITLE
[codex] Fix household bootstrap when Supabase RPC is unavailable

### DIFF
--- a/src/lib/auth/household-bootstrap.ts
+++ b/src/lib/auth/household-bootstrap.ts
@@ -13,6 +13,25 @@ const getSuggestedHouseholdName = (user: User) => {
   return `${normalized}'s Family`;
 };
 
+const toBootstrapErrorMessage = (error: unknown) => {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'object' && error !== null && 'message' in error
+        ? String(error.message)
+        : '';
+
+  if (
+    message.includes('bootstrap_household') ||
+    message.includes('households') ||
+    message.includes('household_members')
+  ) {
+    return 'Could not prepare the family household in Supabase. The cloud household schema may not be deployed yet.';
+  }
+
+  return message || 'Could not prepare the family household in Supabase.';
+};
+
 export const ensureHousehold = async (user: User): Promise<HouseholdRecord> => {
   const supabase = getSupabaseClient();
   if (!supabase) {
@@ -25,8 +44,13 @@ export const ensureHousehold = async (user: User): Promise<HouseholdRecord> => {
     return currentHousehold;
   }
 
-  return repository.createInitialHousehold({
-    householdName: getSuggestedHouseholdName(user),
-    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
-  });
+  try {
+    return await repository.createInitialHousehold({
+      householdName: getSuggestedHouseholdName(user),
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC',
+      userId: user.id,
+    });
+  } catch (error) {
+    throw new Error(toBootstrapErrorMessage(error));
+  }
 };

--- a/src/lib/data/repositories.ts
+++ b/src/lib/data/repositories.ts
@@ -14,6 +14,7 @@ export interface HouseholdRepository {
   createInitialHousehold(input: {
     householdName: string;
     timezone: string;
+    userId: string;
   }): Promise<HouseholdRecord>;
   listMembers(householdId: string): Promise<HouseholdMemberRecord[]>;
   updateHomeScene(householdId: string, homeScene: HouseholdRecord['homeScene']): Promise<HouseholdRecord>;

--- a/src/lib/data/supabase-household-repository.ts
+++ b/src/lib/data/supabase-household-repository.ts
@@ -5,6 +5,19 @@ import type { HouseholdRepository } from './repositories';
 const HOUSEHOLDS_TABLE = 'households';
 const HOUSEHOLD_MEMBERS_TABLE = 'household_members';
 
+const shouldFallbackToDirectBootstrap = (error: unknown) => {
+  const message =
+    typeof error === 'object' && error !== null && 'message' in error
+      ? String(error.message).toLowerCase()
+      : '';
+
+  return (
+    message.includes('bootstrap_household') ||
+    message.includes('function') ||
+    message.includes('could not find')
+  );
+};
+
 const mapHousehold = (row: Record<string, unknown>): HouseholdRecord => ({
   id: String(row.id),
   name: String(row.name),
@@ -40,17 +53,49 @@ export class SupabaseHouseholdRepository implements HouseholdRepository {
     return data ? mapHousehold(data) : null;
   }
 
-  async createInitialHousehold(input: { householdName: string; timezone: string }) {
+  async createInitialHousehold(input: { householdName: string; timezone: string; userId: string }) {
     const { data, error } = await this.supabase.rpc('bootstrap_household', {
       p_name: input.householdName,
       p_timezone: input.timezone,
     });
 
-    if (error) {
+    if (!error && data) {
+      return mapHousehold(data);
+    }
+
+    if (error && !shouldFallbackToDirectBootstrap(error)) {
       throw error;
     }
 
-    return mapHousehold(data);
+    const { data: householdRow, error: householdError } = await this.supabase
+      .from(HOUSEHOLDS_TABLE)
+      .insert({
+        name: input.householdName,
+        timezone: input.timezone,
+        created_by_user_id: input.userId,
+      })
+      .select('*')
+      .single();
+
+    if (householdError) {
+      throw householdError;
+    }
+
+    const household = mapHousehold(householdRow);
+
+    const { error: membershipError } = await this.supabase
+      .from(HOUSEHOLD_MEMBERS_TABLE)
+      .insert({
+        household_id: household.id,
+        user_id: input.userId,
+        role: 'owner',
+      });
+
+    if (membershipError) {
+      throw membershipError;
+    }
+
+    return household;
   }
 
   async listMembers(householdId: string) {

--- a/src/test/supabaseHouseholdRepository.test.ts
+++ b/src/test/supabaseHouseholdRepository.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SupabaseHouseholdRepository } from '@/lib/data/supabase-household-repository';
+
+const createSupabaseClient = (rpcResult: { data: unknown; error: unknown }, tables: Record<string, unknown>) =>
+  ({
+    rpc: vi.fn().mockResolvedValue(rpcResult),
+    from: vi.fn((table: string) => tables[table]),
+  }) as never;
+
+describe('SupabaseHouseholdRepository', () => {
+  it('returns the RPC household when bootstrap_household succeeds', async () => {
+    const repository = new SupabaseHouseholdRepository(
+      createSupabaseClient(
+        {
+          data: {
+            id: 'house-1',
+            name: "Dora's Family",
+            timezone: 'Europe/Madrid',
+            home_scene: 'bike',
+            created_by_user_id: 'user-1',
+            created_at: '2026-05-03T12:00:00Z',
+            updated_at: '2026-05-03T12:00:00Z',
+          },
+          error: null,
+        },
+        {}
+      )
+    );
+
+    await expect(
+      repository.createInitialHousehold({
+        householdName: "Dora's Family",
+        timezone: 'Europe/Madrid',
+        userId: 'user-1',
+      })
+    ).resolves.toEqual({
+      id: 'house-1',
+      name: "Dora's Family",
+      timezone: 'Europe/Madrid',
+      homeScene: 'bike',
+      createdByUserId: 'user-1',
+      createdAt: '2026-05-03T12:00:00Z',
+      updatedAt: '2026-05-03T12:00:00Z',
+    });
+  });
+
+  it('falls back to direct inserts when the bootstrap RPC is unavailable', async () => {
+    const single = vi.fn().mockResolvedValue({
+      data: {
+        id: 'house-2',
+        name: "Dora's Family",
+        timezone: 'Europe/Madrid',
+        home_scene: 'bike',
+        created_by_user_id: 'user-1',
+        created_at: '2026-05-03T12:00:00Z',
+        updated_at: '2026-05-03T12:00:00Z',
+      },
+      error: null,
+    });
+    const householdInsert = vi.fn(() => ({ select: vi.fn(() => ({ single })) }));
+    const membershipInsert = vi.fn().mockResolvedValue({ error: null });
+
+    const repository = new SupabaseHouseholdRepository(
+      createSupabaseClient(
+        {
+          data: null,
+          error: { message: 'Could not find the function public.bootstrap_household' },
+        },
+        {
+          households: {
+            insert: householdInsert,
+          },
+          household_members: {
+            insert: membershipInsert,
+          },
+        }
+      )
+    );
+
+    await expect(
+      repository.createInitialHousehold({
+        householdName: "Dora's Family",
+        timezone: 'Europe/Madrid',
+        userId: 'user-1',
+      })
+    ).resolves.toMatchObject({
+      id: 'house-2',
+      name: "Dora's Family",
+      createdByUserId: 'user-1',
+    });
+
+    expect(householdInsert).toHaveBeenCalledWith({
+      name: "Dora's Family",
+      timezone: 'Europe/Madrid',
+      created_by_user_id: 'user-1',
+    });
+    expect(membershipInsert).toHaveBeenCalledWith({
+      household_id: 'house-2',
+      user_id: 'user-1',
+      role: 'owner',
+    });
+  });
+
+  it('does not fall back when the RPC fails for a non-bootstrap reason', async () => {
+    const repository = new SupabaseHouseholdRepository(
+      createSupabaseClient(
+        {
+          data: null,
+          error: { message: 'Not authenticated' },
+        },
+        {
+          households: {
+            insert: vi.fn(),
+          },
+          household_members: {
+            insert: vi.fn(),
+          },
+        }
+      )
+    );
+
+    await expect(
+      repository.createInitialHousehold({
+        householdName: "Dora's Family",
+        timezone: 'Europe/Madrid',
+        userId: 'user-1',
+      })
+    ).rejects.toEqual({ message: 'Not authenticated' });
+  });
+});


### PR DESCRIPTION
## Summary
- fall back to direct household and membership creation when the `bootstrap_household` RPC is missing or unavailable
- keep non-bootstrap auth errors surfacing normally instead of masking them
- add repository coverage for the RPC and fallback paths

Closes #64

## Testing
- npm test