### PR TITLE
[codex] Clarify Supabase household bootstrap setup errors

### DIFF
--- a/src/components/AccountSettingsCard.tsx
+++ b/src/components/AccountSettingsCard.tsx
@@ -102,12 +102,15 @@ export const AccountSettingsCard = () => {
               {householdStatus === 'ready'
                 ? 'Your parent account is connected to the family space in Supabase.'
                 : householdStatus === 'error'
-                  ? 'We hit a problem while setting up the family space. You can try again here.'
+                  ? 'We hit a problem while setting up the family space. If the live Supabase project is missing the household schema, retry will keep failing until that database setup is applied.'
                   : 'We are preparing the first synced family space for this parent account.'}
             </p>
             {householdStatus === 'error' && (
               <div className="mt-4 rounded-2xl border border-destructive/20 bg-destructive/5 px-4 py-3">
                 <p className="text-sm text-destructive">{error ?? 'The family space is not ready yet.'}</p>
+                <p className="mt-3 text-xs text-muted-foreground">
+                  After the Supabase household schema is applied, return here and choose <span className="font-semibold text-foreground">Try again</span>.
+                </p>
                 <button
                   type="button"
                   onClick={() => void retryHousehold()}

--- a/src/lib/auth/household-bootstrap.ts
+++ b/src/lib/auth/household-bootstrap.ts
@@ -13,7 +13,7 @@ const getSuggestedHouseholdName = (user: User) => {
   return `${normalized}'s Family`;
 };
 
-const toBootstrapErrorMessage = (error: unknown) => {
+const getBootstrapErrorMessage = (error: unknown) => {
   const message =
     error instanceof Error
       ? error.message
@@ -21,12 +21,16 @@ const toBootstrapErrorMessage = (error: unknown) => {
         ? String(error.message)
         : '';
 
+  const normalized = message.toLowerCase();
+
   if (
-    message.includes('bootstrap_household') ||
-    message.includes('households') ||
-    message.includes('household_members')
+    normalized.includes('bootstrap_household') ||
+    normalized.includes('households') ||
+    normalized.includes('household_members') ||
+    normalized.includes('relation') ||
+    normalized.includes('schema cache')
   ) {
-    return 'Could not prepare the family household in Supabase. The cloud household schema may not be deployed yet.';
+    return 'Could not prepare the family household in Supabase. The shared household schema appears to be missing in the live Supabase project. Apply the household SQL migration, then try again.';
   }
 
   return message || 'Could not prepare the family household in Supabase.';
@@ -51,6 +55,6 @@ export const ensureHousehold = async (user: User): Promise<HouseholdRecord> => {
       userId: user.id,
     });
   } catch (error) {
-    throw new Error(toBootstrapErrorMessage(error));
+    throw new Error(getBootstrapErrorMessage(error));
   }
 };

--- a/src/test/accountSettingsCard.test.tsx
+++ b/src/test/accountSettingsCard.test.tsx
@@ -6,26 +6,33 @@ const sendEmailLink = vi.fn();
 const signOut = vi.fn();
 const clearError = vi.fn();
 const retryHousehold = vi.fn();
+const authState = {
+  configured: true,
+  status: 'signed_out',
+  user: null,
+  householdStatus: 'idle',
+  household: null,
+  error: null as string | null,
+  clearError,
+  sendEmailLink,
+  retryHousehold,
+  signOut,
+};
 
 vi.mock('@/lib/auth/use-auth', () => ({
-  useAuth: () => ({
-    configured: true,
-    status: 'signed_out',
-    user: null,
-    householdStatus: 'idle',
-    household: null,
-    error: null,
-    clearError,
-    sendEmailLink,
-    retryHousehold,
-    signOut,
-  }),
+  useAuth: () => authState,
 }));
 
 describe('AccountSettingsCard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sendEmailLink.mockResolvedValue(true);
+    authState.configured = true;
+    authState.status = 'signed_out';
+    authState.user = null;
+    authState.householdStatus = 'idle';
+    authState.household = null;
+    authState.error = null;
   });
 
   it('uses email link copy instead of password fields', () => {
@@ -52,5 +59,19 @@ describe('AccountSettingsCard', () => {
 
     expect(screen.getByText(/check your email/i)).toBeInTheDocument();
     expect(screen.getByText(/parent@example.com/i)).toBeInTheDocument();
+  });
+
+  it('shows actionable guidance when household bootstrap fails', () => {
+    authState.status = 'signed_in';
+    authState.user = { email: 'parent@example.com' };
+    authState.householdStatus = 'error';
+    authState.error =
+      'Could not prepare the family household in Supabase. The shared household schema appears to be missing in the live Supabase project. Apply the household SQL migration, then try again.';
+
+    render(<AccountSettingsCard />);
+
+    expect(screen.getByText(/shared household schema appears to be missing/i)).toBeInTheDocument();
+    expect(screen.getByText(/after the supabase household schema is applied/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
   });
 });

--- a/src/test/householdBootstrap.test.ts
+++ b/src/test/householdBootstrap.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const getCurrentHousehold = vi.fn();
+const createInitialHousehold = vi.fn();
+const getSupabaseClient = vi.fn();
+
+vi.mock('@/lib/supabase/client', () => ({
+  getSupabaseClient,
+}));
+
+vi.mock('@/lib/data/supabase-household-repository', () => ({
+  SupabaseHouseholdRepository: class {
+    getCurrentHousehold = getCurrentHousehold;
+    createInitialHousehold = createInitialHousehold;
+  },
+}));
+
+describe('ensureHousehold', () => {
+  it('turns schema-missing Supabase failures into actionable setup guidance', async () => {
+    vi.resetModules();
+    getSupabaseClient.mockReturnValue({} as never);
+    getCurrentHousehold.mockResolvedValue(null);
+    createInitialHousehold.mockRejectedValue({
+      message: 'relation "public.households" does not exist',
+    });
+
+    const { ensureHousehold } = await import('@/lib/auth/household-bootstrap');
+
+    await expect(
+      ensureHousehold({
+        id: 'user-1',
+        email: 'parent@example.com',
+      } as never)
+    ).rejects.toThrow(/shared household schema appears to be missing/i);
+  });
+});


### PR DESCRIPTION
## Summary
- translate common Supabase household schema failures into a clear setup message
- explain in the Parent Account card that retry will keep failing until the live household schema is applied
- add tests for the clearer bootstrap failure guidance

Closes #66

## Testing
- npm test