### PR TITLE
[codex] Clarify local-only auth state in parent settings

### DIFF
--- a/src/components/ParentSettings.tsx
+++ b/src/components/ParentSettings.tsx
@@ -264,6 +264,7 @@ export const ParentSettings = ({
   onBack,
 }: ParentSettingsProps) => {
   const { status: authStatus, signOut } = useAuth();
+  const isSignedIn = authStatus === 'signed_in';
   const [confirmReset, setConfirmReset] = useState(false);
   const [modal, setModal] = useState<{
     childId: string;
@@ -329,7 +330,7 @@ export const ParentSettings = ({
     icon: typeof Users;
   }> = [
     { key: 'kids', label: 'Kids', description: `${children.length} profile${children.length === 1 ? '' : 's'}`, icon: Users },
-    { key: 'parents', label: 'Parents', description: 'Account access', icon: UserRound },
+    { key: 'parents', label: 'Parents', description: isSignedIn ? 'Account connected' : 'Sign in for sync', icon: UserRound },
     { key: 'household', label: 'Household setup', description: 'Scenes and family home', icon: House },
     { key: 'admin', label: 'Admin', description: 'Reset and restart', icon: Shield },
     { key: 'billing', label: 'Billing', description: 'Coming soon', icon: CreditCard },
@@ -396,19 +397,32 @@ export const ParentSettings = ({
             </p>
           </div>
 
-          <button
-            type="button"
-            onClick={() => {
-              if (authStatus === 'signed_in') {
-                void signOut();
-              }
-            }}
-            disabled={authStatus !== 'signed_in'}
-            className="mt-8 flex w-full items-center justify-center gap-2 rounded-full border border-border px-4 py-3 text-sm font-bold text-foreground transition-colors hover:border-primary/40 hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <LogOut size={16} />
-            Logout
-          </button>
+          <div className="mt-8 rounded-[24px] border border-border bg-background p-4">
+            <p className="text-xs font-black uppercase tracking-[0.22em] text-muted-foreground">
+              {isSignedIn ? 'Account status' : 'Local-only setup'}
+            </p>
+            <p className="mt-3 text-base font-bold text-foreground">
+              {isSignedIn ? 'Parent account connected' : 'Kids and routines on this device'}
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {isSignedIn
+                ? 'This browser is signed in. You can manage sync from the Parents section.'
+                : 'You can edit kids and routines locally right now. Open Parents to sign in when you want cloud sync across devices.'}
+            </p>
+
+            {isSignedIn && (
+              <button
+                type="button"
+                onClick={() => {
+                  void signOut();
+                }}
+                className="mt-4 flex w-full items-center justify-center gap-2 rounded-full border border-border px-4 py-3 text-sm font-bold text-foreground transition-colors hover:border-primary/40 hover:text-primary"
+              >
+                <LogOut size={16} />
+                Logout
+              </button>
+            )}
+          </div>
         </aside>
 
         <div className="space-y-8">

--- a/src/test/parentSettings.test.tsx
+++ b/src/test/parentSettings.test.tsx
@@ -3,8 +3,17 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { ParentSettings } from "@/components/ParentSettings";
-import { AuthProvider } from "@/lib/auth/auth-context";
 import type { Child, HomeScene } from "@/lib/types";
+
+const signOut = vi.fn();
+const authState = {
+  status: "signed_out",
+  signOut,
+};
+
+vi.mock("@/lib/auth/use-auth", () => ({
+  useAuth: () => authState,
+}));
 
 vi.mock("framer-motion", () => ({
   motion: new Proxy(
@@ -51,28 +60,28 @@ const Harness = ({ seedChildren = initialChildren }: { seedChildren?: Child[] })
   const [resetCount, setResetCount] = useState(0);
 
   return (
-    <AuthProvider>
-      <div>
-        <pre data-testid="state">{JSON.stringify(children)}</pre>
-        <div data-testid="restart-count">{restartCount}</div>
-        <div data-testid="reset-count">{resetCount}</div>
-        <ParentSettings
-          children={children}
-          homeScene={homeScene}
-          onChange={setChildren}
-          onHomeSceneChange={setHomeScene}
-          onRestartSetup={() => setRestartCount((count) => count + 1)}
-          onResetAppData={() => setResetCount((count) => count + 1)}
-          onBack={() => {}}
-        />
-      </div>
-    </AuthProvider>
+    <div>
+      <pre data-testid="state">{JSON.stringify(children)}</pre>
+      <div data-testid="restart-count">{restartCount}</div>
+      <div data-testid="reset-count">{resetCount}</div>
+      <ParentSettings
+        children={children}
+        homeScene={homeScene}
+        onChange={setChildren}
+        onHomeSceneChange={setHomeScene}
+        onRestartSetup={() => setRestartCount((count) => count + 1)}
+        onResetAppData={() => setResetCount((count) => count + 1)}
+        onBack={() => {}}
+      />
+    </div>
   );
 };
 
 describe("ParentSettings", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    signOut.mockReset();
+    authState.status = "signed_out";
   });
 
   it("renames a child in place", () => {
@@ -206,5 +215,26 @@ describe("ParentSettings", () => {
 
     expect(screen.getByTestId("restart-count")).toHaveTextContent("1");
     expect(readState()).toHaveLength(2);
+  });
+
+  it("explains local-only editing when the parent account is not signed in", () => {
+    render(<Harness />);
+
+    expect(screen.getByText(/local-only setup/i)).toBeInTheDocument();
+    expect(screen.getByText(/you can edit kids and routines locally right now/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^logout$/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /parents/i })).toHaveTextContent("Sign in for sync");
+  });
+
+  it("shows logout only when the parent account is signed in", () => {
+    authState.status = "signed_in";
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^logout$/i }));
+
+    expect(signOut).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/parent account connected/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /parents/i })).toHaveTextContent("Account connected");
   });
 });


### PR DESCRIPTION
## Summary
- hide the settings-shell logout button unless a parent account is actually signed in
- explain when the device is running in local-only mode and that the Parents section is for sync sign-in
- make the Parents section label reflect whether the account is connected or still needs sign-in

Closes #68

## Testing
- npm test