### PR TITLE
[codex] Switch Routine Stars to auth-first app flow

### DIFF
--- a/src/components/AccountEntryScreen.tsx
+++ b/src/components/AccountEntryScreen.tsx
@@ -1,15 +1,7 @@
-import { ArrowRight, Cloud, Sparkles } from 'lucide-react';
+import { Cloud, Sparkles } from 'lucide-react';
 import { AccountSettingsCard } from './AccountSettingsCard';
-import { useAuth } from '@/lib/auth/use-auth';
 
-interface AccountEntryScreenProps {
-  onContinueLocalSetup: () => void;
-}
-
-export const AccountEntryScreen = ({ onContinueLocalSetup }: AccountEntryScreenProps) => {
-  const { configured } = useAuth();
-
-  return (
+export const AccountEntryScreen = () => (
     <div className="relative min-h-svh overflow-hidden px-5 py-10 md:px-6 md:py-14">
       <div className="absolute inset-x-0 top-0 -z-10 mx-auto h-72 w-[42rem] max-w-full rounded-full bg-primary/10 blur-3xl" />
       <div className="absolute left-6 top-24 -z-10 h-28 w-28 rounded-full bg-accent/20 blur-2xl" />
@@ -23,29 +15,20 @@ export const AccountEntryScreen = ({ onContinueLocalSetup }: AccountEntryScreenP
           </div>
 
           <h1 className="mt-6 text-4xl font-bold text-foreground md:text-5xl">
-            Bring your family routines onto this device
+            Sign in to open your family routines
           </h1>
           <p className="mt-4 max-w-2xl text-lg text-muted-foreground">
-            Parents can sign in to connect this iPad to the household, while kids still get the same quick tap-and-go
-            routine flow once setup is finished.
+            Routine Stars now works as an account-based app. Sign in or create a parent account to load your
+            household, set up routines, and keep data synced across devices.
           </p>
 
-          <div className="mt-8 grid gap-4 md:grid-cols-2">
-            <div className="rounded-[28px] bg-primary/8 p-5">
-              <p className="text-sm font-black uppercase tracking-[0.2em] text-primary">Recommended</p>
-              <h2 className="mt-3 text-2xl font-bold text-foreground">Sign in or create a parent account</h2>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Best for shared households and future sync across phones, tablets, and family devices.
-              </p>
-            </div>
-
-            <div className="rounded-[28px] bg-muted/55 p-5">
-              <p className="text-sm font-black uppercase tracking-[0.2em] text-muted-foreground">Local option</p>
-              <h2 className="mt-3 text-2xl font-bold text-foreground">Set up only this device for now</h2>
-              <p className="mt-2 text-sm text-muted-foreground">
-                You can stay local today and come back to the parent account flow later from Parent Settings.
-              </p>
-            </div>
+          <div className="mt-8 rounded-[28px] bg-primary/8 p-5">
+            <p className="text-sm font-black uppercase tracking-[0.2em] text-primary">Required</p>
+            <h2 className="mt-3 text-2xl font-bold text-foreground">Use your parent account to continue</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              After you sign in, Routine Stars will load the household saved to your account and guide you through
+              setup if this is a brand-new family space.
+            </p>
           </div>
 
           <div className="mt-8 rounded-[28px] border border-border bg-background/80 p-5">
@@ -54,24 +37,14 @@ export const AccountEntryScreen = ({ onContinueLocalSetup }: AccountEntryScreenP
               <p className="text-sm font-black uppercase tracking-[0.18em]">What happens next</p>
             </div>
             <div className="mt-4 grid gap-3 text-sm text-muted-foreground md:grid-cols-3">
-              <p>1. Parent signs in with an email link or chooses local-only setup.</p>
-              <p>2. Household setup stays parent-led and child-friendly.</p>
+              <p>1. Parent signs in or creates an account with an email link.</p>
+              <p>2. Routine Stars loads the synced household or starts first-time setup.</p>
               <p>3. Kids return here later and just tap their profile to begin.</p>
             </div>
           </div>
-
-          <button
-            type="button"
-            onClick={onContinueLocalSetup}
-            className="mt-8 inline-flex items-center gap-2 rounded-full border border-border bg-background px-5 py-3 text-sm font-bold text-foreground transition-colors hover:border-primary/40 hover:text-primary"
-          >
-            <ArrowRight size={16} />
-            {configured ? 'Continue with local-only setup' : 'Set up this device locally'}
-          </button>
         </section>
 
         <AccountSettingsCard />
       </div>
     </div>
-  );
-};
+);

--- a/src/components/AccountSettingsCard.tsx
+++ b/src/components/AccountSettingsCard.tsx
@@ -43,7 +43,7 @@ export const AccountSettingsCard = () => {
         <div>
           <h3 className="text-2xl font-bold text-foreground">Parent Account</h3>
           <p className="text-sm text-muted-foreground">
-            Sign in to prepare household sync without interrupting the child flow on a shared device.
+            Sign in to load and manage the household saved to this account.
           </p>
         </div>
       </div>
@@ -60,7 +60,7 @@ export const AccountSettingsCard = () => {
                 Add <code>VITE_SUPABASE_URL</code> and <code>VITE_SUPABASE_ANON_KEY</code> to enable real parent sign in.
               </p>
               <p className="mt-2 text-sm text-muted-foreground">
-                The shared-device child experience will keep working locally until those keys are in place.
+                Routine Stars needs these keys before account-based household access can work.
               </p>
             </div>
           </div>
@@ -74,7 +74,7 @@ export const AccountSettingsCard = () => {
             </div>
             <p className="mt-4 text-lg font-bold text-foreground">{user.email}</p>
             <p className="mt-2 text-sm text-muted-foreground">
-              This shared device can keep showing child profiles while the parent account handles sync and setup.
+              This browser is connected to the household saved under this parent account.
             </p>
             <button
               type="button"
@@ -165,7 +165,7 @@ export const AccountSettingsCard = () => {
 
           <p className="mt-4 text-sm text-muted-foreground">
             {mode === 'signin'
-              ? 'We will email a sign-in link to this address so the shared device can connect safely.'
+              ? 'We will email a sign-in link to this address so this device can open the household saved to your account.'
               : 'We will email a one-time sign-up link. After you confirm it, the household bootstrap will run automatically.'}
           </p>
 

--- a/src/components/ParentSettings.tsx
+++ b/src/components/ParentSettings.tsx
@@ -399,15 +399,15 @@ export const ParentSettings = ({
 
           <div className="mt-8 rounded-[24px] border border-border bg-background p-4">
             <p className="text-xs font-black uppercase tracking-[0.22em] text-muted-foreground">
-              {isSignedIn ? 'Account status' : 'Local-only setup'}
+              {isSignedIn ? 'Account status' : 'Sign-in required'}
             </p>
             <p className="mt-3 text-base font-bold text-foreground">
-              {isSignedIn ? 'Parent account connected' : 'Kids and routines on this device'}
+              {isSignedIn ? 'Parent account connected' : 'Parent account not connected'}
             </p>
             <p className="mt-1 text-sm text-muted-foreground">
               {isSignedIn
                 ? 'This browser is signed in. You can manage sync from the Parents section.'
-                : 'You can edit kids and routines locally right now. Open Parents to sign in when you want cloud sync across devices.'}
+                : 'Sign in from the Parents section to load and manage the household saved to this account.'}
             </p>
 
             {isSignedIn && (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -126,7 +126,7 @@ const Index = () => {
     setNow(new Date());
   }, []);
 
-  // Load from localStorage once auth has settled so startup can be account-aware.
+  // Startup is auth-first: signed-out users always land on account entry.
   useEffect(() => {
     if (authStatus === 'loading' || (authStatus === 'signed_in' && householdStatus === 'loading')) {
       return;
@@ -135,6 +135,20 @@ const Index = () => {
     let isMounted = true;
 
     const bootstrap = async () => {
+      if (authStatus === 'signed_out' || authStatus === 'unavailable') {
+        if (!isMounted) return;
+
+        setChildren(createSetupChildren());
+        setActiveChildId(null);
+        setSetupComplete(false);
+        setHomeScene('bike');
+        setView('account');
+        lastSyncedConfigRef.current = null;
+        shouldSyncFirstConfigRef.current = false;
+        setIsReady(true);
+        return;
+      }
+
       const storedState = loadLocalAppState();
       let cloudState: Awaited<ReturnType<typeof loadCloudHouseholdState>> | null = null;
 
@@ -181,13 +195,7 @@ const Index = () => {
         if (isMounted) {
           setSetupComplete(storedState.setupComplete);
           setHomeScene(storedState.homeScene);
-          setView(
-            storedState.setupComplete
-              ? 'home'
-              : storedState.children.length > 0 || authStatus === 'signed_in'
-                ? 'setup'
-                : 'account'
-          );
+          setView(storedState.setupComplete ? 'home' : 'setup');
           setIsReady(true);
         }
         return;
@@ -216,10 +224,11 @@ const Index = () => {
 
       if (isMounted) {
         setChildren(createSetupChildren());
+        setActiveChildId(null);
         setSetupComplete(false);
         setHomeScene('bike');
-        setView(authStatus === 'signed_in' ? 'setup' : 'account');
-        shouldSyncFirstConfigRef.current = authStatus === 'signed_in';
+        setView(authStatus === 'signed_in' && householdStatus !== 'error' ? 'setup' : 'account');
+        shouldSyncFirstConfigRef.current = authStatus === 'signed_in' && householdStatus !== 'error';
         setIsReady(true);
       }
     };
@@ -288,7 +297,7 @@ const Index = () => {
 
   // Persist
   useEffect(() => {
-    if (!isReady) return;
+    if (!isReady || authStatus !== 'signed_in') return;
 
     try {
       saveLocalAppState({
@@ -300,7 +309,7 @@ const Index = () => {
     } catch (error) {
       console.warn('Could not save app state to local storage.', error);
     }
-  }, [children, homeScene, isReady, setupComplete]);
+  }, [authStatus, children, homeScene, isReady, setupComplete]);
 
   const toggleTask = useCallback(
     (taskId: string) => {
@@ -336,7 +345,7 @@ const Index = () => {
   }
 
   if (view === 'account') {
-    return <AccountEntryScreen onContinueLocalSetup={() => setView('setup')} />;
+    return <AccountEntryScreen />;
   }
 
   if (view === 'import') {

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -153,16 +153,9 @@ vi.mock("@/components/InitialSetup", () => ({
 }));
 
 vi.mock("@/components/AccountEntryScreen", () => ({
-  AccountEntryScreen: ({
-    onContinueLocalSetup,
-  }: {
-    onContinueLocalSetup: () => void;
-  }) => (
+  AccountEntryScreen: () => (
     <div>
       <div data-testid="account-entry-screen">account-entry</div>
-      <button type="button" onClick={onContinueLocalSetup}>
-        continue-local-setup
-      </button>
     </div>
   ),
 }));
@@ -227,6 +220,32 @@ describe("Index", () => {
   });
 
   it("resets completed tasks when stored data is from a previous day", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [
+        {
+          id: "1",
+          name: "Lily",
+          morning: [
+            { id: "m1", title: "Make bed", icon: "bed", completed: true },
+            { id: "m2", title: "Brush teeth", icon: "brush", completed: false },
+          ],
+          evening: [],
+        },
+      ],
+    });
     localStorage.setItem(
       "routine_stars_data",
       JSON.stringify(createStoredState(true, yesterday()))
@@ -234,13 +253,39 @@ describe("Index", () => {
 
     render(<Index />);
 
-    fireEvent.click(screen.getByRole("button", { name: "select-first-child" }));
+    fireEvent.click(await screen.findByRole("button", { name: "select-first-child" }));
 
     expect(await screen.findByTestId("active-child")).toHaveTextContent("Lily");
     expect(screen.getByTestId("first-task-completed")).toHaveTextContent("false");
   });
 
   it("persists task toggles back to localStorage for the current day", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [
+        {
+          id: "1",
+          name: "Lily",
+          morning: [
+            { id: "m1", title: "Make bed", icon: "bed", completed: false },
+            { id: "m2", title: "Brush teeth", icon: "brush", completed: false },
+          ],
+          evening: [],
+        },
+      ],
+    });
     localStorage.setItem(
       "routine_stars_data",
       JSON.stringify(createStoredState(false, today()))
@@ -248,7 +293,7 @@ describe("Index", () => {
 
     render(<Index />);
 
-    fireEvent.click(screen.getByRole("button", { name: "select-first-child" }));
+    fireEvent.click(await screen.findByRole("button", { name: "select-first-child" }));
     fireEvent.click(screen.getByRole("button", { name: "toggle-first-task" }));
 
     await waitFor(() => {
@@ -261,7 +306,19 @@ describe("Index", () => {
     expect(stored.children[0].morning[0].completed).toBe(true);
   });
 
-  it("opens the due routine for the active child view", () => {
+  it("opens the due routine for the active child view", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
     localStorage.setItem(
       "routine_stars_data",
       JSON.stringify({
@@ -284,10 +341,25 @@ describe("Index", () => {
         ],
       })
     );
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [
+        {
+          id: "1",
+          name: "Lily",
+          morning: [{ id: "m1", title: "Make bed", icon: "bed", completed: false }],
+          evening: [{ id: "e1", title: "Go to bed", icon: "moon-star", completed: false }],
+          schedule: {
+            morning: { start: "00:00", end: "00:01" },
+            evening: { start: "00:02", end: "23:59" },
+          },
+        },
+      ],
+    });
 
     render(<Index />);
 
-    fireEvent.click(screen.getByRole("button", { name: "select-first-child" }));
+    fireEvent.click(await screen.findByRole("button", { name: "select-first-child" }));
 
     expect(screen.getByTestId("active-routine")).toHaveTextContent("evening");
   });
@@ -298,12 +370,20 @@ describe("Index", () => {
     expect(await screen.findByTestId("account-entry-screen")).toBeInTheDocument();
   });
 
-  it("lets a parent continue into local-only setup from the account entry flow", async () => {
+  it("keeps signed-out users on the account entry flow even when stale local data exists", async () => {
+    localStorage.setItem(
+      "routine_stars_data",
+      JSON.stringify({
+        ...createStoredState(false, today()),
+        setupComplete: true,
+        homeScene: "school",
+      })
+    );
+
     render(<Index />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "continue-local-setup" }));
-
-    expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
+    expect(await screen.findByTestId("account-entry-screen")).toBeInTheDocument();
+    expect(screen.queryByTestId("child-count")).toBeNull();
   });
 
   it("opens setup immediately on a fresh device when the parent is already signed in", async () => {
@@ -500,6 +580,8 @@ describe("Index", () => {
   });
 
   it("re-opens setup when saved data is marked incomplete", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
     localStorage.setItem(
       "routine_stars_data",
       JSON.stringify({
@@ -514,6 +596,8 @@ describe("Index", () => {
   });
 
   it("hydrates legacy unversioned local data", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
     localStorage.setItem(
       "routine_stars_data",
       JSON.stringify(createStoredState(false, today()))
@@ -527,9 +611,10 @@ describe("Index", () => {
   });
 
   it("completes first-run setup and persists the configured routines", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
     render(<Index />);
 
-    fireEvent.click(await screen.findByRole("button", { name: "continue-local-setup" }));
     fireEvent.click(await screen.findByRole("button", { name: "finish-setup" }));
 
     expect(await screen.findByTestId("child-count")).toHaveTextContent("1");
@@ -541,6 +626,8 @@ describe("Index", () => {
   });
 
   it("lets a parent clear app data from Parent Settings", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
     localStorage.setItem(
       "routine_stars_data",
       JSON.stringify({
@@ -552,7 +639,7 @@ describe("Index", () => {
 
     render(<Index />);
 
-    fireEvent.click(screen.getByRole("button", { name: "open-settings" }));
+    fireEvent.click(await screen.findByRole("button", { name: "open-settings" }));
     fireEvent.click(screen.getByRole("button", { name: "reset-app-data" }));
 
     expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
@@ -564,6 +651,8 @@ describe("Index", () => {
   });
 
   it("lets a parent restart setup without manual localStorage edits", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
     localStorage.setItem(
       "routine_stars_data",
       JSON.stringify({
@@ -574,7 +663,7 @@ describe("Index", () => {
 
     render(<Index />);
 
-    fireEvent.click(screen.getByRole("button", { name: "open-settings" }));
+    fireEvent.click(await screen.findByRole("button", { name: "open-settings" }));
     fireEvent.click(screen.getByRole("button", { name: "restart-setup" }));
 
     expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("1");

--- a/src/test/parentSettings.test.tsx
+++ b/src/test/parentSettings.test.tsx
@@ -217,11 +217,11 @@ describe("ParentSettings", () => {
     expect(readState()).toHaveLength(2);
   });
 
-  it("explains local-only editing when the parent account is not signed in", () => {
+  it("explains sign-in requirements when the parent account is not connected", () => {
     render(<Harness />);
 
-    expect(screen.getByText(/local-only setup/i)).toBeInTheDocument();
-    expect(screen.getByText(/you can edit kids and routines locally right now/i)).toBeInTheDocument();
+    expect(screen.getByText(/sign-in required/i)).toBeInTheDocument();
+    expect(screen.getByText(/sign in from the parents section/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /^logout$/i })).toBeNull();
     expect(screen.getByRole("button", { name: /parents/i })).toHaveTextContent("Sign in for sync");
   });


### PR DESCRIPTION
## Summary
- remove the signed-out local-only startup branch and force signed-out users to the account entry screen
- keep signed-in users on cloud-backed household setup, home, or import paths only
- update the account and parent-settings copy to match the new account-based product model

Closes #70

## Testing
- npm test