### PR TITLE
Make auth-first entry warmer and explain empty setup recovery

### DIFF
--- a/src/components/AccountEntryScreen.tsx
+++ b/src/components/AccountEntryScreen.tsx
@@ -1,50 +1,86 @@
-import { Cloud, Sparkles } from 'lucide-react';
+import { Cloud, Sparkles, Star, Wand2 } from 'lucide-react';
 import { AccountSettingsCard } from './AccountSettingsCard';
 
 export const AccountEntryScreen = () => (
-    <div className="relative min-h-svh overflow-hidden px-5 py-10 md:px-6 md:py-14">
-      <div className="absolute inset-x-0 top-0 -z-10 mx-auto h-72 w-[42rem] max-w-full rounded-full bg-primary/10 blur-3xl" />
-      <div className="absolute left-6 top-24 -z-10 h-28 w-28 rounded-full bg-accent/20 blur-2xl" />
-      <div className="absolute right-8 top-16 -z-10 h-36 w-36 rounded-full bg-success/15 blur-2xl" />
+  <div className="relative min-h-svh overflow-hidden bg-[linear-gradient(180deg,#eef8ff_0%,#fffdf7_52%,#fff6ea_100%)] px-5 py-10 md:px-6 md:py-14">
+    <div className="absolute inset-x-0 top-0 -z-10 mx-auto h-80 w-[48rem] max-w-full rounded-full bg-primary/15 blur-3xl" />
+    <div className="absolute -left-10 top-24 -z-10 h-44 w-44 rounded-full bg-accent/25 blur-3xl" />
+    <div className="absolute right-0 top-8 -z-10 h-52 w-52 rounded-full bg-success/20 blur-3xl" />
+    <div className="absolute left-[12%] top-28 -z-10 rotate-[-10deg] text-accent/70">
+      <Star size={34} fill="currentColor" />
+    </div>
+    <div className="absolute right-[16%] top-32 -z-10 rotate-[12deg] text-primary/60">
+      <Sparkles size={42} />
+    </div>
+    <div className="absolute bottom-24 left-[8%] -z-10 text-success/60">
+      <Wand2 size={36} />
+    </div>
 
-      <div className="mx-auto grid max-w-6xl gap-8 xl:grid-cols-[minmax(0,1.1fr)_440px] xl:items-start">
-        <section className="rounded-[36px] border border-border bg-card/95 p-7 shadow-card md:p-9">
-          <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 text-sm font-black uppercase tracking-[0.22em] text-primary">
-            <Cloud size={16} />
-            New Device Setup
-          </div>
+    <div className="mx-auto grid max-w-6xl gap-8 xl:grid-cols-[minmax(0,1.1fr)_440px] xl:items-start">
+      <section className="relative overflow-hidden rounded-[40px] border border-white/70 bg-card/95 p-7 shadow-card md:p-9">
+        <div className="absolute right-6 top-6 hidden rounded-full bg-accent/15 px-4 py-2 text-xs font-black uppercase tracking-[0.28em] text-accent md:inline-flex">
+          Kids open their stars after parent sign-in
+        </div>
 
-          <h1 className="mt-6 text-4xl font-bold text-foreground md:text-5xl">
-            Sign in to open your family routines
-          </h1>
-          <p className="mt-4 max-w-2xl text-lg text-muted-foreground">
-            Routine Stars now works as an account-based app. Sign in or create a parent account to load your
-            household, set up routines, and keep data synced across devices.
-          </p>
+        <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 text-sm font-black uppercase tracking-[0.22em] text-primary">
+          <Cloud size={16} />
+          Family Launch Pad
+        </div>
 
-          <div className="mt-8 rounded-[28px] bg-primary/8 p-5">
-            <p className="text-sm font-black uppercase tracking-[0.2em] text-primary">Required</p>
+        <h1 className="mt-6 max-w-3xl text-4xl font-bold text-foreground md:text-6xl">
+          Open your family&apos;s routine world
+        </h1>
+        <p className="mt-4 max-w-2xl text-lg leading-8 text-muted-foreground">
+          Parents sign in first, then Routine Stars brings back the family&apos;s profiles, routines, and progress so
+          kids can jump straight into their playful check-in screen.
+        </p>
+
+        <div className="mt-8 grid gap-4 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+          <div className="rounded-[30px] bg-[linear-gradient(135deg,rgba(14,165,233,0.10),rgba(251,191,36,0.16),rgba(34,197,94,0.10))] p-5">
+            <p className="text-sm font-black uppercase tracking-[0.2em] text-primary">Parent step first</p>
             <h2 className="mt-3 text-2xl font-bold text-foreground">Use your parent account to continue</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              After you sign in, Routine Stars will load the household saved to your account and guide you through
-              setup if this is a brand-new family space.
+            <p className="mt-2 text-sm leading-7 text-muted-foreground">
+              We&apos;ll send a magic link by email. After that, this device opens the household saved to your account
+              and brings the kid-facing home screen back into view.
             </p>
           </div>
 
-          <div className="mt-8 rounded-[28px] border border-border bg-background/80 p-5">
+          <div className="rounded-[30px] border border-primary/15 bg-white/80 p-5">
             <div className="flex items-center gap-2 text-foreground">
               <Sparkles size={18} className="text-primary" />
-              <p className="text-sm font-black uppercase tracking-[0.18em]">What happens next</p>
+              <p className="text-sm font-black uppercase tracking-[0.18em]">When it feels right</p>
             </div>
-            <div className="mt-4 grid gap-3 text-sm text-muted-foreground md:grid-cols-3">
-              <p>1. Parent signs in or creates an account with an email link.</p>
-              <p>2. Routine Stars loads the synced household or starts first-time setup.</p>
-              <p>3. Kids return here later and just tap their profile to begin.</p>
+            <div className="mt-4 space-y-3 text-sm text-muted-foreground">
+              <p>Kids should mostly see their profiles, not a grown-up login wall.</p>
+              <p>This screen only appears on a new device or when a parent needs to reconnect the family account.</p>
+              <p>Once signed in, the app returns to the warm child-friendly routine flow.</p>
             </div>
           </div>
-        </section>
+        </div>
 
-        <AccountSettingsCard />
-      </div>
+        <div className="mt-8 rounded-[30px] border border-border bg-background/85 p-5">
+          <div className="flex items-center gap-2 text-foreground">
+            <Star size={18} className="fill-accent text-accent" />
+            <p className="text-sm font-black uppercase tracking-[0.18em]">What happens next</p>
+          </div>
+          <div className="mt-4 grid gap-4 text-sm md:grid-cols-3">
+            <div className="rounded-2xl bg-primary/6 p-4">
+              <p className="font-black text-foreground">1. Parent signs in</p>
+              <p className="mt-2 leading-6 text-muted-foreground">Use the email link to unlock the family account on this device.</p>
+            </div>
+            <div className="rounded-2xl bg-accent/8 p-4">
+              <p className="font-black text-foreground">2. Routine Stars loads the family</p>
+              <p className="mt-2 leading-6 text-muted-foreground">Saved kids, routines, and sync setup come back into place automatically.</p>
+            </div>
+            <div className="rounded-2xl bg-success/8 p-4">
+              <p className="font-black text-foreground">3. Kids tap their profile</p>
+              <p className="mt-2 leading-6 text-muted-foreground">The shared device goes back to the fun, simple child flow for daily routines.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <AccountSettingsCard />
     </div>
+  </div>
 );

--- a/src/components/InitialSetup.tsx
+++ b/src/components/InitialSetup.tsx
@@ -9,6 +9,7 @@ import { ANIMAL_AVATARS } from './animal-avatars';
 interface InitialSetupProps {
   children: Child[];
   onComplete: (children: Child[]) => void;
+  showEmptyHouseholdRecoveryHint?: boolean;
 }
 
 type SelectionState = Record<string, Record<RoutineType, string[]>>;
@@ -72,7 +73,11 @@ const buildRoutineTasks = (childId: string, routine: RoutineType, selectedTitles
       completed: false,
     }));
 
-export const InitialSetup = ({ children, onComplete }: InitialSetupProps) => {
+export const InitialSetup = ({
+  children,
+  onComplete,
+  showEmptyHouseholdRecoveryHint = false,
+}: InitialSetupProps) => {
   const [draftChildren, setDraftChildren] = useState(children);
   const [selectionState, setSelectionState] = useState<SelectionState>(() => buildSelectionState(children));
   const [activeChildId, setActiveChildId] = useState<string | null>(children[0]?.id ?? null);
@@ -181,6 +186,25 @@ export const InitialSetup = ({ children, onComplete }: InitialSetupProps) => {
             Start with each child&apos;s profile, then switch to routines when you&apos;re ready to choose tasks.
           </p>
         </header>
+
+        {showEmptyHouseholdRecoveryHint && draftChildren.length === 0 && (
+          <section className="mx-auto mt-8 max-w-4xl rounded-[30px] border border-amber-300/60 bg-amber-50/90 p-5 text-left shadow-sm">
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-amber-200/70 text-amber-700">
+                <Clock3 size={22} />
+              </div>
+              <div>
+                <p className="text-sm font-black uppercase tracking-[0.24em] text-amber-700">Already had routines?</p>
+                <h2 className="mt-2 text-2xl font-bold text-foreground">This account is signed in, but this browser looks brand new.</h2>
+                <p className="mt-3 text-sm leading-7 text-muted-foreground">
+                  If your kids and routines were created somewhere else, go back to that exact browser, laptop profile,
+                  or old tab and sign in there once. Routine Stars can only import the saved family setup from the place
+                  where it was originally stored.
+                </p>
+              </div>
+            </div>
+          </section>
+        )}
 
         <div className="mt-10 grid gap-8 xl:grid-cols-[320px_minmax(0,1fr)]">
           <aside className="rounded-[32px] border border-border bg-card p-6 shadow-card">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -106,6 +106,7 @@ const Index = () => {
   const [isImporting, setIsImporting] = useState(false);
   const [now, setNow] = useState(() => new Date());
   const [homeScene, setHomeScene] = useState<HomeScene>('bike');
+  const [showEmptyHouseholdRecoveryHint, setShowEmptyHouseholdRecoveryHint] = useState(false);
   const lastSyncedConfigRef = useRef<string | null>(null);
   const shouldSyncFirstConfigRef = useRef(false);
 
@@ -115,6 +116,7 @@ const Index = () => {
     setActiveChildId(null);
     setSetupComplete(false);
     setHomeScene('bike');
+    setShowEmptyHouseholdRecoveryHint(false);
     setView('setup');
     setNow(new Date());
   }, []);
@@ -122,6 +124,7 @@ const Index = () => {
   const restartSetup = useCallback(() => {
     setActiveChildId(null);
     setSetupComplete(false);
+    setShowEmptyHouseholdRecoveryHint(false);
     setView('setup');
     setNow(new Date());
   }, []);
@@ -142,6 +145,7 @@ const Index = () => {
         setActiveChildId(null);
         setSetupComplete(false);
         setHomeScene('bike');
+        setShowEmptyHouseholdRecoveryHint(false);
         setView('account');
         lastSyncedConfigRef.current = null;
         shouldSyncFirstConfigRef.current = false;
@@ -172,6 +176,7 @@ const Index = () => {
             setChildren(storedState.children);
             setHomeScene(storedState.homeScene);
             setSetupComplete(storedState.setupComplete);
+            setShowEmptyHouseholdRecoveryHint(false);
             setView('import');
             setIsReady(true);
           }
@@ -195,6 +200,7 @@ const Index = () => {
         if (isMounted) {
           setSetupComplete(storedState.setupComplete);
           setHomeScene(storedState.homeScene);
+          setShowEmptyHouseholdRecoveryHint(false);
           setView(storedState.setupComplete ? 'home' : 'setup');
           setIsReady(true);
         }
@@ -207,6 +213,7 @@ const Index = () => {
         setChildren(cloudState.children);
         setHomeScene(cloudState.homeScene);
         setSetupComplete(cloudState.children.length > 0);
+        setShowEmptyHouseholdRecoveryHint(cloudState.children.length === 0);
         setView(cloudState.children.length > 0 ? 'home' : 'setup');
         if (cloudState.children.length > 0) {
           lastSyncedConfigRef.current = serializeHouseholdConfig({
@@ -227,6 +234,7 @@ const Index = () => {
         setActiveChildId(null);
         setSetupComplete(false);
         setHomeScene('bike');
+        setShowEmptyHouseholdRecoveryHint(authStatus === 'signed_in' && householdStatus === 'ready');
         setView(authStatus === 'signed_in' && householdStatus !== 'error' ? 'setup' : 'account');
         shouldSyncFirstConfigRef.current = authStatus === 'signed_in' && householdStatus !== 'error';
         setIsReady(true);
@@ -391,6 +399,7 @@ const Index = () => {
           setChildren(createSetupChildren());
           setSetupComplete(false);
           setHomeScene('bike');
+          setShowEmptyHouseholdRecoveryHint(false);
           setView('setup');
           setImportError(null);
           shouldSyncFirstConfigRef.current = true;
@@ -403,9 +412,11 @@ const Index = () => {
     return (
       <InitialSetup
         children={children}
+        showEmptyHouseholdRecoveryHint={showEmptyHouseholdRecoveryHint}
         onComplete={(configuredChildren) => {
           setChildren(configuredChildren);
           setSetupComplete(true);
+          setShowEmptyHouseholdRecoveryHint(false);
           setView('home');
         }}
       />

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -127,12 +127,15 @@ vi.mock("@/components/InitialSetup", () => ({
   InitialSetup: ({
     children,
     onComplete,
+    showEmptyHouseholdRecoveryHint,
   }: {
     children: Child[];
     onComplete: (children: Child[]) => void;
+    showEmptyHouseholdRecoveryHint?: boolean;
   }) => (
     <div>
       <div data-testid="setup-child-count">{children.length}</div>
+      <div data-testid="setup-recovery-hint">{String(Boolean(showEmptyHouseholdRecoveryHint))}</div>
       <button
         type="button"
         onClick={() =>
@@ -393,6 +396,7 @@ describe("Index", () => {
     render(<Index />);
 
     expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
+    expect(screen.getByTestId("setup-recovery-hint")).toHaveTextContent("false");
   });
 
   it("hydrates cloud household data on a fresh signed-in device", async () => {
@@ -577,6 +581,31 @@ describe("Index", () => {
     fireEvent.click(await screen.findByRole("button", { name: "start-fresh-instead" }));
 
     expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
+    expect(screen.getByTestId("setup-recovery-hint")).toHaveTextContent("false");
+  });
+
+  it("shows a recovery hint when a signed-in household is empty in this browser context", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [],
+    });
+
+    render(<Index />);
+
+    expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
+    expect(screen.getByTestId("setup-recovery-hint")).toHaveTextContent("true");
   });
 
   it("re-opens setup when saved data is marked incomplete", async () => {


### PR DESCRIPTION
## Summary
- redesign the auth-first entry screen so it feels more playful and kid-friendly
- add a clear recovery hint when a signed-in household is empty in the current browser context
- cover the empty-household recovery hint in the startup tests

## Why
- closes #72
- addresses #73 by explaining the real recovery path when routines were created in a different browser/tab/profile and are not available to import from the current context

## Validation
- `npm test -- --run src/test/index.test.tsx src/test/accountSettingsCard.test.tsx src/test/parentSettings.test.tsx`
- `npm run build`
