### PR TITLE
Make reset everything truly destructive for signed-in households

### DIFF
--- a/src/components/ParentSettings.tsx
+++ b/src/components/ParentSettings.tsx
@@ -20,7 +20,7 @@ interface ParentSettingsProps {
   onChange: (children: Child[]) => void;
   onHomeSceneChange: (scene: HomeScene) => void;
   onRestartSetup: () => void;
-  onResetAppData: () => void;
+  onResetAppData: () => Promise<void> | void;
   onBack: () => void;
 }
 
@@ -266,6 +266,7 @@ export const ParentSettings = ({
   const { status: authStatus, signOut } = useAuth();
   const isSignedIn = authStatus === 'signed_in';
   const [confirmReset, setConfirmReset] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
   const [modal, setModal] = useState<{
     childId: string;
     routine: RoutineType;
@@ -799,25 +800,39 @@ export const ParentSettings = ({
                 <div className="rounded-[28px] border border-destructive/20 bg-destructive/5 p-5">
                   <h4 className="text-lg font-bold text-foreground">Reset app data</h4>
                   <p className="mt-2 text-sm text-muted-foreground">
-                    Remove all saved children, routines, schedules, and progress from this browser and return to a fresh start.
+                    {isSignedIn
+                      ? 'Permanently delete the signed-in household, all child profiles, routines, schedules, and progress from Supabase and this browser.'
+                      : 'Remove all saved children, routines, schedules, and progress from this browser and return to a fresh start.'}
                   </p>
                   {confirmReset ? (
                     <div className="mt-5 space-y-3">
                       <p className="text-sm font-medium text-destructive">
-                        This clears everything saved in this browser. Are you sure?
+                        {isSignedIn
+                          ? 'This permanently deletes the signed-in household everywhere and clears this browser. Are you sure?'
+                          : 'This clears everything saved in this browser. Are you sure?'}
                       </p>
                       <div className="flex flex-wrap gap-3">
                         <button
                           type="button"
-                          onClick={onResetAppData}
-                          className="rounded-full bg-destructive px-4 py-2 text-sm font-bold text-destructive-foreground transition-transform active:translate-y-0.5"
+                          disabled={isResetting}
+                          onClick={async () => {
+                            setIsResetting(true);
+                            try {
+                              await onResetAppData();
+                            } finally {
+                              setIsResetting(false);
+                              setConfirmReset(false);
+                            }
+                          }}
+                          className="rounded-full bg-destructive px-4 py-2 text-sm font-bold text-destructive-foreground transition-transform active:translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-60"
                         >
-                          Yes, reset everything
+                          {isResetting ? 'Deleting everything…' : 'Yes, reset everything'}
                         </button>
                         <button
                           type="button"
+                          disabled={isResetting}
                           onClick={() => setConfirmReset(false)}
-                          className="rounded-full border border-border px-4 py-2 text-sm font-bold text-foreground transition-colors hover:border-primary/40 hover:text-primary"
+                          className="rounded-full border border-border px-4 py-2 text-sm font-bold text-foreground transition-colors hover:border-primary/40 hover:text-primary disabled:cursor-not-allowed disabled:opacity-60"
                         >
                           Cancel
                         </button>
@@ -826,8 +841,9 @@ export const ParentSettings = ({
                   ) : (
                     <button
                       type="button"
+                      disabled={isResetting}
                       onClick={() => setConfirmReset(true)}
-                      className="mt-5 rounded-full bg-destructive px-4 py-2 text-sm font-bold text-destructive-foreground transition-transform active:translate-y-0.5"
+                      className="mt-5 rounded-full bg-destructive px-4 py-2 text-sm font-bold text-destructive-foreground transition-transform active:translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       Reset everything
                     </button>

--- a/src/lib/data/delete-cloud-household.ts
+++ b/src/lib/data/delete-cloud-household.ts
@@ -1,0 +1,13 @@
+import type { HouseholdRecord } from './models';
+import { SupabaseHouseholdRepository } from './supabase-household-repository';
+import { getSupabaseClient } from '@/lib/supabase/client';
+
+export const deleteCloudHousehold = async (household: HouseholdRecord) => {
+  const supabase = getSupabaseClient();
+  if (!supabase) {
+    throw new Error('Supabase is not configured yet.');
+  }
+
+  const householdRepository = new SupabaseHouseholdRepository(supabase);
+  await householdRepository.remove(household.id);
+};

--- a/src/lib/data/repositories.ts
+++ b/src/lib/data/repositories.ts
@@ -18,6 +18,7 @@ export interface HouseholdRepository {
   }): Promise<HouseholdRecord>;
   listMembers(householdId: string): Promise<HouseholdMemberRecord[]>;
   updateHomeScene(householdId: string, homeScene: HouseholdRecord['homeScene']): Promise<HouseholdRecord>;
+  remove(householdId: string): Promise<void>;
 }
 
 export interface ChildProfileRepository {

--- a/src/lib/data/supabase-household-repository.ts
+++ b/src/lib/data/supabase-household-repository.ts
@@ -126,4 +126,15 @@ export class SupabaseHouseholdRepository implements HouseholdRepository {
 
     return mapHousehold(data);
   }
+
+  async remove(householdId: string) {
+    const { error } = await this.supabase
+      .from(HOUSEHOLDS_TABLE)
+      .delete()
+      .eq('id', householdId);
+
+    if (error) {
+      throw error;
+    }
+  }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,6 +9,7 @@ import { ParentSettings } from '@/components/ParentSettings';
 import { useAuth } from '@/lib/auth/use-auth';
 import { loadCloudHouseholdState } from '@/lib/data/cloud-household-state';
 import { saveHouseholdConfigToCloud } from '@/lib/data/cloud-household-write';
+import { deleteCloudHousehold } from '@/lib/data/delete-cloud-household';
 import { importLocalFamilyToCloud } from '@/lib/data/local-to-cloud-import';
 import type { AppView, Child, HomeScene, RoutineType } from '@/lib/types';
 import {
@@ -109,16 +110,29 @@ const Index = () => {
   const [homeScene, setHomeScene] = useState<HomeScene>('bike');
   const lastSyncedConfigRef = useRef<string | null>(null);
   const shouldSyncFirstConfigRef = useRef(false);
+  const skipLocalPersistenceRef = useRef(false);
 
-  const resetToFreshSetup = useCallback(() => {
+  const clearLocalAndState = useCallback((nextView: AppView) => {
+    skipLocalPersistenceRef.current = true;
     clearLocalAppState();
     setChildren(createSetupChildren());
     setActiveChildId(null);
     setSetupComplete(false);
     setHomeScene('bike');
-    setView('setup');
+    setView(nextView);
     setNow(new Date());
   }, []);
+
+  const resetToFreshSetup = useCallback(async () => {
+    if (authStatus === 'signed_in' && householdStatus === 'ready' && household) {
+      await deleteCloudHousehold(household);
+      clearLocalAndState('account');
+      await signOut();
+      return;
+    }
+
+    clearLocalAndState('setup');
+  }, [authStatus, clearLocalAndState, household, householdStatus, signOut]);
 
   const restartSetup = useCallback(() => {
     setActiveChildId(null);
@@ -146,6 +160,7 @@ const Index = () => {
         setView('account');
         lastSyncedConfigRef.current = null;
         shouldSyncFirstConfigRef.current = false;
+        skipLocalPersistenceRef.current = false;
         setIsReady(true);
         return;
       }
@@ -305,6 +320,10 @@ const Index = () => {
   // Persist
   useEffect(() => {
     if (!isReady || authStatus !== 'signed_in') return;
+
+    if (skipLocalPersistenceRef.current) {
+      return;
+    }
 
     try {
       saveLocalAppState({

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -26,6 +26,9 @@ const { importLocalFamilyToCloud } = vi.hoisted(() => ({
 const { saveHouseholdConfigToCloud } = vi.hoisted(() => ({
   saveHouseholdConfigToCloud: vi.fn(),
 }));
+const { deleteCloudHousehold } = vi.hoisted(() => ({
+  deleteCloudHousehold: vi.fn(),
+}));
 
 vi.mock("@/lib/auth/use-auth", () => ({
   useAuth: () => authState,
@@ -39,6 +42,9 @@ vi.mock("@/lib/data/local-to-cloud-import", () => ({
 }));
 vi.mock("@/lib/data/cloud-household-write", () => ({
   saveHouseholdConfigToCloud,
+}));
+vi.mock("@/lib/data/delete-cloud-household", () => ({
+  deleteCloudHousehold,
 }));
 
 const today = () => new Date().toDateString();
@@ -233,6 +239,7 @@ describe("Index", () => {
     loadCloudHouseholdState.mockReset();
     importLocalFamilyToCloud.mockReset();
     saveHouseholdConfigToCloud.mockReset();
+    deleteCloudHousehold.mockReset();
     authState.clearError.mockReset();
     authState.sendEmailLink.mockReset();
     authState.retryHousehold.mockReset();
@@ -697,6 +704,28 @@ describe("Index", () => {
   it("lets a parent clear app data from Parent Settings", async () => {
     authState.status = "signed_in";
     authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    deleteCloudHousehold.mockResolvedValue(undefined);
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [
+        {
+          id: "1",
+          name: "Lily",
+          morning: [{ id: "m1", title: "Make bed", icon: "bed", completed: false }],
+          evening: [{ id: "e1", title: "Go to bed", icon: "moon-star", completed: false }],
+        },
+      ],
+    });
     localStorage.setItem(
       "routine_stars_data",
       JSON.stringify({
@@ -711,12 +740,13 @@ describe("Index", () => {
     fireEvent.click(await screen.findByRole("button", { name: "open-settings" }));
     fireEvent.click(screen.getByRole("button", { name: "reset-app-data" }));
 
-    expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
+    await waitFor(() => {
+      expect(deleteCloudHousehold).toHaveBeenCalledWith(authState.household);
+      expect(authState.signOut).toHaveBeenCalledTimes(1);
+    });
 
-    const stored = JSON.parse(localStorage.getItem("routine_stars_data") ?? "{}");
-    expect(stored.setupComplete).toBe(false);
-    expect(stored.children).toEqual([]);
-    expect(stored.homeScene).toBe("bike");
+    expect(localStorage.getItem("routine_stars_data")).toBeNull();
+    expect(await screen.findByTestId("account-entry-screen")).toBeInTheDocument();
   });
 
   it("lets a parent restart setup without manual localStorage edits", async () => {

--- a/src/test/parentSettings.test.tsx
+++ b/src/test/parentSettings.test.tsx
@@ -1,7 +1,7 @@
 import { createElement, useState } from "react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { ParentSettings } from "@/components/ParentSettings";
 import type { Child, HomeScene } from "@/lib/types";
 
@@ -193,7 +193,7 @@ describe("ParentSettings", () => {
     expect(screen.getByRole("button", { name: /^reset everything$/i })).toBeInTheDocument();
   });
 
-  it("requires confirmation before resetting all app data", () => {
+  it("requires confirmation before resetting all app data", async () => {
     render(<Harness />);
 
     fireEvent.click(screen.getByRole("button", { name: /admin/i }));
@@ -202,9 +202,28 @@ describe("ParentSettings", () => {
     expect(screen.getByText(/this clears everything saved in this browser/i)).toBeInTheDocument();
     expect(screen.getByTestId("reset-count")).toHaveTextContent("0");
 
-    fireEvent.click(screen.getByRole("button", { name: /yes, reset everything/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /yes, reset everything/i }));
+    });
 
     expect(screen.getByTestId("reset-count")).toHaveTextContent("1");
+  });
+
+  it("warns signed-in parents that reset deletes the cloud household too", () => {
+    authState.status = "signed_in";
+
+    render(<Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: /admin/i }));
+    expect(
+      screen.getByText(/permanently delete the signed-in household, all child profiles, routines, schedules, and progress/i)
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^reset everything$/i }));
+
+    expect(
+      screen.getByText(/this permanently deletes the signed-in household everywhere and clears this browser/i)
+    ).toBeInTheDocument();
   });
 
   it("fires restart setup without clearing the current children immediately", () => {

--- a/src/test/supabaseHouseholdRepository.test.ts
+++ b/src/test/supabaseHouseholdRepository.test.ts
@@ -127,4 +127,26 @@ describe('SupabaseHouseholdRepository', () => {
       })
     ).rejects.toEqual({ message: 'Not authenticated' });
   });
+
+  it('deletes the household row by id', async () => {
+    const deleteEq = vi.fn().mockResolvedValue({ error: null });
+    const repository = new SupabaseHouseholdRepository(
+      createSupabaseClient(
+        {
+          data: null,
+          error: null,
+        },
+        {
+          households: {
+            delete: vi.fn(() => ({
+              eq: deleteEq,
+            })),
+          },
+        }
+      )
+    );
+
+    await expect(repository.remove('house-1')).resolves.toBeUndefined();
+    expect(deleteEq).toHaveBeenCalledWith('id', 'house-1');
+  });
 });

--- a/supabase/migrations/20260504195000_allow_household_owner_delete.sql
+++ b/supabase/migrations/20260504195000_allow_household_owner_delete.sql
@@ -1,0 +1,12 @@
+create policy "household owners can delete households"
+on public.households
+for delete
+using (
+  exists (
+    select 1
+    from public.household_members hm
+    where hm.household_id = id
+      and hm.user_id = auth.uid()
+      and hm.role = 'owner'
+  )
+);


### PR DESCRIPTION
## Summary
- add a real cloud household delete path to the admin reset flow
- clear local state and sign the parent out after deleting the signed-in household
- add the household delete RLS policy and test coverage for the destructive reset path

## Why
- closes #77
- makes reset everything actually remove the household, child profiles, routines, tasks, and progress instead of only clearing the UI/browser state

## Validation
- `npm test -- --run src/test/index.test.tsx src/test/parentSettings.test.tsx src/test/supabaseHouseholdRepository.test.ts`
- `npm run build`
