### PR TITLE
Add dedicated existing-family recovery step before empty setup

### DIFF
--- a/src/components/ExistingFamilyRecoveryScreen.tsx
+++ b/src/components/ExistingFamilyRecoveryScreen.tsx
@@ -1,0 +1,87 @@
+import { ArrowRight, Clock3, LogOut, Search } from 'lucide-react';
+
+interface ExistingFamilyRecoveryScreenProps {
+  onStartFresh: () => void;
+  onSignOut: () => void;
+}
+
+export const ExistingFamilyRecoveryScreen = ({
+  onStartFresh,
+  onSignOut,
+}: ExistingFamilyRecoveryScreenProps) => (
+  <div className="relative min-h-svh overflow-hidden bg-[linear-gradient(180deg,#eef8ff_0%,#fffdf7_52%,#fff6ea_100%)] px-5 py-10 md:px-6 md:py-14">
+    <div className="absolute inset-x-0 top-0 -z-10 mx-auto h-80 w-[44rem] max-w-full rounded-full bg-amber-200/30 blur-3xl" />
+    <div className="absolute left-10 top-20 -z-10 h-36 w-36 rounded-full bg-primary/15 blur-3xl" />
+    <div className="absolute right-0 top-16 -z-10 h-44 w-44 rounded-full bg-accent/20 blur-3xl" />
+
+    <div className="mx-auto max-w-4xl rounded-[40px] border border-white/80 bg-card/95 p-7 shadow-card md:p-10">
+      <div className="inline-flex items-center gap-2 rounded-full bg-amber-100 px-4 py-2 text-sm font-black uppercase tracking-[0.22em] text-amber-800">
+        <Search size={16} />
+        Looking for your family?
+      </div>
+
+      <h1 className="mt-6 max-w-3xl text-4xl font-bold text-foreground md:text-5xl">
+        This browser looks brand new
+      </h1>
+      <p className="mt-4 max-w-3xl text-lg leading-8 text-muted-foreground">
+        You&apos;re signed in, but we didn&apos;t find any saved family routines here yet. If your kids and routines
+        were created in a different browser, laptop profile, or older tab, Routine Stars can only import them from
+        that original place.
+      </p>
+
+      <div className="mt-8 grid gap-4 md:grid-cols-2">
+        <div className="rounded-[30px] border border-primary/15 bg-primary/5 p-5">
+          <div className="flex items-center gap-3 text-foreground">
+            <Clock3 size={18} className="text-primary" />
+            <p className="text-sm font-black uppercase tracking-[0.18em]">Safest next step</p>
+          </div>
+          <h2 className="mt-3 text-2xl font-bold text-foreground">Go back to the original browser once</h2>
+          <p className="mt-2 text-sm leading-7 text-muted-foreground">
+            Open the exact browser context where the routines were first created, sign in there, and import that saved
+            family into your account. After that, this device will load the synced household normally.
+          </p>
+        </div>
+
+        <div className="rounded-[30px] border border-border bg-background/80 p-5">
+          <div className="flex items-center gap-3 text-foreground">
+            <ArrowRight size={18} className="text-accent" />
+            <p className="text-sm font-black uppercase tracking-[0.18em]">Only if this is intentional</p>
+          </div>
+          <h2 className="mt-3 text-2xl font-bold text-foreground">Start a brand-new family here</h2>
+          <p className="mt-2 text-sm leading-7 text-muted-foreground">
+            Choose this only if you really want a clean household on this account and you are not trying to recover
+            existing kids and routines.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-8 rounded-[30px] border border-border bg-background/85 p-5">
+        <p className="text-sm font-black uppercase tracking-[0.18em] text-foreground">Why this happens</p>
+        <div className="mt-4 grid gap-3 text-sm text-muted-foreground md:grid-cols-3">
+          <p>1. Older routines may still live only in the browser where they were originally created.</p>
+          <p>2. Signing in on a different browser context can look like an empty family account.</p>
+          <p>3. Once the original setup is imported, new devices can load it from the cloud.</p>
+        </div>
+      </div>
+
+      <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+        <button
+          type="button"
+          onClick={onStartFresh}
+          className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-3 text-sm font-bold text-primary-foreground shadow-button transition-transform active:translate-y-0.5"
+        >
+          <ArrowRight size={16} />
+          Start fresh on this device
+        </button>
+        <button
+          type="button"
+          onClick={onSignOut}
+          className="inline-flex items-center justify-center gap-2 rounded-full border border-border bg-background px-5 py-3 text-sm font-bold text-foreground transition-colors hover:border-primary/40 hover:text-primary"
+        >
+          <LogOut size={16} />
+          Sign out here
+        </button>
+      </div>
+    </div>
+  </div>
+);

--- a/src/components/InitialSetup.tsx
+++ b/src/components/InitialSetup.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Check, Clock3, Moon, Plus, Sparkles, Sun, UserRound } from 'lucide-react';
+import { Check, Moon, Plus, Sparkles, Sun, UserRound } from 'lucide-react';
 import type { Child, RoutineType, Task } from '@/lib/types';
 import { AGE_BUCKETS, groupTasksByAge, TASK_CATALOG } from '@/lib/types';
 import { TaskIcon } from './TaskIcon';
@@ -9,7 +9,6 @@ import { ANIMAL_AVATARS } from './animal-avatars';
 interface InitialSetupProps {
   children: Child[];
   onComplete: (children: Child[]) => void;
-  showEmptyHouseholdRecoveryHint?: boolean;
 }
 
 type SelectionState = Record<string, Record<RoutineType, string[]>>;
@@ -73,11 +72,7 @@ const buildRoutineTasks = (childId: string, routine: RoutineType, selectedTitles
       completed: false,
     }));
 
-export const InitialSetup = ({
-  children,
-  onComplete,
-  showEmptyHouseholdRecoveryHint = false,
-}: InitialSetupProps) => {
+export const InitialSetup = ({ children, onComplete }: InitialSetupProps) => {
   const [draftChildren, setDraftChildren] = useState(children);
   const [selectionState, setSelectionState] = useState<SelectionState>(() => buildSelectionState(children));
   const [activeChildId, setActiveChildId] = useState<string | null>(children[0]?.id ?? null);
@@ -186,25 +181,6 @@ export const InitialSetup = ({
             Start with each child&apos;s profile, then switch to routines when you&apos;re ready to choose tasks.
           </p>
         </header>
-
-        {showEmptyHouseholdRecoveryHint && draftChildren.length === 0 && (
-          <section className="mx-auto mt-8 max-w-4xl rounded-[30px] border border-amber-300/60 bg-amber-50/90 p-5 text-left shadow-sm">
-            <div className="flex items-start gap-3">
-              <div className="mt-0.5 flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-amber-200/70 text-amber-700">
-                <Clock3 size={22} />
-              </div>
-              <div>
-                <p className="text-sm font-black uppercase tracking-[0.24em] text-amber-700">Already had routines?</p>
-                <h2 className="mt-2 text-2xl font-bold text-foreground">This account is signed in, but this browser looks brand new.</h2>
-                <p className="mt-3 text-sm leading-7 text-muted-foreground">
-                  If your kids and routines were created somewhere else, go back to that exact browser, laptop profile,
-                  or old tab and sign in there once. Routine Stars can only import the saved family setup from the place
-                  where it was originally stored.
-                </p>
-              </div>
-            </div>
-          </section>
-        )}
 
         <div className="mt-10 grid gap-8 xl:grid-cols-[320px_minmax(0,1fr)]">
           <aside className="rounded-[32px] border border-border bg-card p-6 shadow-card">

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,6 +28,6 @@ export type Child = {
   evening: Task[];
 };
 
-export type AppView = 'account' | 'import' | 'setup' | 'home' | 'routine' | 'parent';
+export type AppView = 'account' | 'import' | 'recovery' | 'setup' | 'home' | 'routine' | 'parent';
 
 export { AGE_BUCKETS, DEFAULT_CHILDREN, groupTasksByAge, ICON_OPTIONS, TASK_CATALOG, TASK_CATALOG_BY_ID, TASK_LIBRARY };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { ChildSelector } from '@/components/ChildSelector';
 import { AccountEntryScreen } from '@/components/AccountEntryScreen';
+import { ExistingFamilyRecoveryScreen } from '@/components/ExistingFamilyRecoveryScreen';
 import { ImportFamilySetupScreen } from '@/components/ImportFamilySetupScreen';
 import { InitialSetup } from '@/components/InitialSetup';
 import { RoutineView } from '@/components/RoutineView';
@@ -96,7 +97,7 @@ const serializeHouseholdConfig = (input: {
   });
 
 const Index = () => {
-  const { status: authStatus, householdStatus, household } = useAuth();
+  const { status: authStatus, householdStatus, household, signOut } = useAuth();
   const [view, setView] = useState<AppView>('setup');
   const [children, setChildren] = useState<Child[]>(createSetupChildren);
   const [activeChildId, setActiveChildId] = useState<string | null>(null);
@@ -106,7 +107,6 @@ const Index = () => {
   const [isImporting, setIsImporting] = useState(false);
   const [now, setNow] = useState(() => new Date());
   const [homeScene, setHomeScene] = useState<HomeScene>('bike');
-  const [showEmptyHouseholdRecoveryHint, setShowEmptyHouseholdRecoveryHint] = useState(false);
   const lastSyncedConfigRef = useRef<string | null>(null);
   const shouldSyncFirstConfigRef = useRef(false);
 
@@ -116,7 +116,6 @@ const Index = () => {
     setActiveChildId(null);
     setSetupComplete(false);
     setHomeScene('bike');
-    setShowEmptyHouseholdRecoveryHint(false);
     setView('setup');
     setNow(new Date());
   }, []);
@@ -124,7 +123,6 @@ const Index = () => {
   const restartSetup = useCallback(() => {
     setActiveChildId(null);
     setSetupComplete(false);
-    setShowEmptyHouseholdRecoveryHint(false);
     setView('setup');
     setNow(new Date());
   }, []);
@@ -145,7 +143,6 @@ const Index = () => {
         setActiveChildId(null);
         setSetupComplete(false);
         setHomeScene('bike');
-        setShowEmptyHouseholdRecoveryHint(false);
         setView('account');
         lastSyncedConfigRef.current = null;
         shouldSyncFirstConfigRef.current = false;
@@ -176,7 +173,6 @@ const Index = () => {
             setChildren(storedState.children);
             setHomeScene(storedState.homeScene);
             setSetupComplete(storedState.setupComplete);
-            setShowEmptyHouseholdRecoveryHint(false);
             setView('import');
             setIsReady(true);
           }
@@ -200,7 +196,6 @@ const Index = () => {
         if (isMounted) {
           setSetupComplete(storedState.setupComplete);
           setHomeScene(storedState.homeScene);
-          setShowEmptyHouseholdRecoveryHint(false);
           setView(storedState.setupComplete ? 'home' : 'setup');
           setIsReady(true);
         }
@@ -213,8 +208,7 @@ const Index = () => {
         setChildren(cloudState.children);
         setHomeScene(cloudState.homeScene);
         setSetupComplete(cloudState.children.length > 0);
-        setShowEmptyHouseholdRecoveryHint(cloudState.children.length === 0);
-        setView(cloudState.children.length > 0 ? 'home' : 'setup');
+        setView(cloudState.children.length > 0 ? 'home' : 'recovery');
         if (cloudState.children.length > 0) {
           lastSyncedConfigRef.current = serializeHouseholdConfig({
             children: cloudState.children,
@@ -234,8 +228,13 @@ const Index = () => {
         setActiveChildId(null);
         setSetupComplete(false);
         setHomeScene('bike');
-        setShowEmptyHouseholdRecoveryHint(authStatus === 'signed_in' && householdStatus === 'ready');
-        setView(authStatus === 'signed_in' && householdStatus !== 'error' ? 'setup' : 'account');
+        const nextView: AppView =
+          authStatus === 'signed_in' && householdStatus === 'ready'
+            ? 'recovery'
+            : authStatus === 'signed_in' && householdStatus !== 'error'
+              ? 'setup'
+              : 'account';
+        setView(nextView);
         shouldSyncFirstConfigRef.current = authStatus === 'signed_in' && householdStatus !== 'error';
         setIsReady(true);
       }
@@ -399,10 +398,26 @@ const Index = () => {
           setChildren(createSetupChildren());
           setSetupComplete(false);
           setHomeScene('bike');
-          setShowEmptyHouseholdRecoveryHint(false);
           setView('setup');
           setImportError(null);
           shouldSyncFirstConfigRef.current = true;
+        }}
+      />
+    );
+  }
+
+  if (view === 'recovery') {
+    return (
+      <ExistingFamilyRecoveryScreen
+        onStartFresh={() => {
+          setChildren(createSetupChildren());
+          setSetupComplete(false);
+          setHomeScene('bike');
+          setView('setup');
+          shouldSyncFirstConfigRef.current = true;
+        }}
+        onSignOut={() => {
+          void signOut();
         }}
       />
     );
@@ -412,11 +427,9 @@ const Index = () => {
     return (
       <InitialSetup
         children={children}
-        showEmptyHouseholdRecoveryHint={showEmptyHouseholdRecoveryHint}
         onComplete={(configuredChildren) => {
           setChildren(configuredChildren);
           setSetupComplete(true);
-          setShowEmptyHouseholdRecoveryHint(false);
           setView('home');
         }}
       />

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -127,15 +127,12 @@ vi.mock("@/components/InitialSetup", () => ({
   InitialSetup: ({
     children,
     onComplete,
-    showEmptyHouseholdRecoveryHint,
   }: {
     children: Child[];
     onComplete: (children: Child[]) => void;
-    showEmptyHouseholdRecoveryHint?: boolean;
   }) => (
     <div>
       <div data-testid="setup-child-count">{children.length}</div>
-      <div data-testid="setup-recovery-hint">{String(Boolean(showEmptyHouseholdRecoveryHint))}</div>
       <button
         type="button"
         onClick={() =>
@@ -150,6 +147,26 @@ vi.mock("@/components/InitialSetup", () => ({
         }
       >
         finish-setup
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ExistingFamilyRecoveryScreen", () => ({
+  ExistingFamilyRecoveryScreen: ({
+    onStartFresh,
+    onSignOut,
+  }: {
+    onStartFresh: () => void;
+    onSignOut: () => void;
+  }) => (
+    <div>
+      <div data-testid="existing-family-recovery-screen">existing-family-recovery</div>
+      <button type="button" onClick={onStartFresh}>
+        recovery-start-fresh
+      </button>
+      <button type="button" onClick={onSignOut}>
+        recovery-sign-out
       </button>
     </div>
   ),
@@ -396,7 +413,6 @@ describe("Index", () => {
     render(<Index />);
 
     expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
-    expect(screen.getByTestId("setup-recovery-hint")).toHaveTextContent("false");
   });
 
   it("hydrates cloud household data on a fresh signed-in device", async () => {
@@ -539,6 +555,7 @@ describe("Index", () => {
 
     render(<Index />);
 
+    fireEvent.click(await screen.findByRole("button", { name: "recovery-start-fresh" }));
     fireEvent.click(await screen.findByRole("button", { name: "finish-setup" }));
 
     await waitFor(() => {
@@ -581,10 +598,9 @@ describe("Index", () => {
     fireEvent.click(await screen.findByRole("button", { name: "start-fresh-instead" }));
 
     expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
-    expect(screen.getByTestId("setup-recovery-hint")).toHaveTextContent("false");
   });
 
-  it("shows a recovery hint when a signed-in household is empty in this browser context", async () => {
+  it("shows a dedicated recovery screen when a signed-in household is empty in this browser context", async () => {
     authState.status = "signed_in";
     authState.user = { id: "user-1", email: "parent@example.com" };
     authState.householdStatus = "ready";
@@ -604,8 +620,32 @@ describe("Index", () => {
 
     render(<Index />);
 
+    expect(await screen.findByTestId("existing-family-recovery-screen")).toBeInTheDocument();
+  });
+
+  it("lets a parent intentionally continue into fresh setup from the recovery screen", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [],
+    });
+
+    render(<Index />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "recovery-start-fresh" }));
+
     expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
-    expect(screen.getByTestId("setup-recovery-hint")).toHaveTextContent("true");
   });
 
   it("re-opens setup when saved data is marked incomplete", async () => {


### PR DESCRIPTION
## Summary
- add a dedicated recovery screen for signed-in parents when the current browser context has no saved family setup
- require an explicit choice before continuing into fresh setup on that device
- update startup tests for the new recovery checkpoint

## Why
- closes #75
- builds on #74 by turning the warning into a proper recovery branch instead of dropping parents directly into empty setup

## Validation
- `npm test -- --run src/test/index.test.tsx src/test/accountSettingsCard.test.tsx src/test/parentSettings.test.tsx`
- `npm run build`
