### PR TITLE
[codex] Fix Initial Setup go-to-routines crash

### DIFF
--- a/src/components/InitialSetup.tsx
+++ b/src/components/InitialSetup.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Check, Moon, Plus, Sparkles, Sun, UserRound } from 'lucide-react';
+import { Check, Clock3, Moon, Plus, Sparkles, Sun, UserRound } from 'lucide-react';
 import type { Child, RoutineType, Task } from '@/lib/types';
 import { AGE_BUCKETS, groupTasksByAge, TASK_CATALOG } from '@/lib/types';
 import { TaskIcon } from './TaskIcon';

--- a/src/test/initialSetup.test.tsx
+++ b/src/test/initialSetup.test.tsx
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { InitialSetup } from "@/components/InitialSetup";
+import type { Child } from "@/lib/types";
+
+vi.mock("@/components/ChildProfileAvatar", () => ({
+  ChildProfileAvatar: ({ name }: { name?: string }) => <div>{name ?? "avatar"}</div>,
+}));
+
+const initialChildren: Child[] = [
+  {
+    id: "child-1",
+    name: "Elie",
+    age: 8,
+    ageBucket: "6-8",
+    avatarAnimal: "rabbit",
+    avatarSeed: "seed-1",
+    schedule: {
+      morning: { start: "07:00", end: "09:00" },
+      evening: { start: "17:00", end: "20:00" },
+    },
+    morning: [],
+    evening: [],
+  },
+];
+
+describe("InitialSetup", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("switches cleanly into the routines tab from the profile CTA", () => {
+    render(<InitialSetup children={initialChildren} onComplete={() => {}} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /go to routines/i }));
+
+    expect(screen.getByText(/choose active routine tasks/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /morning/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /evening/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the Initial Setup `Go to routines` CTA leaving the app on a blank page.

## What changed
- restores the missing `Clock3` icon import used by the routines pane in `InitialSetup`
- adds a regression test for the exact `profile -> Go to routines` transition

## Why
The CTA itself was fine, but switching into the routines tab crashed at runtime because `Clock3` was referenced without being imported. That left the screen blank until refresh.

## Validation
- `npm test -- --run src/test/initialSetup.test.tsx`
- `npm run build`

## Related issues
- Closes #80