### PR TITLE
[codex] Harden auth callback sign-in completion

### DIFF
--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -17,6 +17,75 @@ export const getSupabaseEmailRedirectUrl = () => {
   return new URL('auth/callback', window.location.origin + (import.meta.env.BASE_URL || '/')).toString();
 };
 
+const isSupportedOtpType = (value: string | null) =>
+  value === 'signup' ||
+  value === 'invite' ||
+  value === 'magiclink' ||
+  value === 'recovery' ||
+  value === 'email' ||
+  value === 'email_change' ||
+  value === 'sms' ||
+  value === 'phone_change';
+
+export const finalizeSupabaseAuthFromUrl = async (url = window.location.href) => {
+  const supabase = getSupabaseClient();
+  if (!supabase) {
+    return { handled: false, error: 'Supabase is not configured yet.' };
+  }
+
+  const parsedUrl = new URL(url);
+  const hashParams = new URLSearchParams(parsedUrl.hash.startsWith('#') ? parsedUrl.hash.slice(1) : parsedUrl.hash);
+  const code = parsedUrl.searchParams.get('code');
+  const tokenHash = parsedUrl.searchParams.get('token_hash');
+  const otpType = parsedUrl.searchParams.get('type');
+  const accessToken = hashParams.get('access_token');
+  const refreshToken = hashParams.get('refresh_token');
+
+  try {
+    if (code) {
+      const { error } = await supabase.auth.exchangeCodeForSession(code);
+      if (error) {
+        return { handled: true, error: error.message };
+      }
+
+      return { handled: true, error: null };
+    }
+
+    if (tokenHash && isSupportedOtpType(otpType)) {
+      const { error } = await supabase.auth.verifyOtp({
+        token_hash: tokenHash,
+        type: otpType,
+      } as never);
+
+      if (error) {
+        return { handled: true, error: error.message };
+      }
+
+      return { handled: true, error: null };
+    }
+
+    if (accessToken && refreshToken) {
+      const { error } = await supabase.auth.setSession({
+        access_token: accessToken,
+        refresh_token: refreshToken,
+      });
+
+      if (error) {
+        return { handled: true, error: error.message };
+      }
+
+      return { handled: true, error: null };
+    }
+
+    return { handled: false, error: null };
+  } catch (error) {
+    return {
+      handled: true,
+      error: error instanceof Error ? error.message : 'This sign-in link did not finish cleanly.',
+    };
+  }
+};
+
 export const getSupabaseClient = () => {
   if (!isConfigured) {
     return null;

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -1,11 +1,34 @@
 import { LoaderCircle } from 'lucide-react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/lib/auth/use-auth';
+import { finalizeSupabaseAuthFromUrl } from '@/lib/supabase/client';
+
+const CALLBACK_TIMEOUT_MS = 8000;
 
 const AuthCallback = () => {
   const navigate = useNavigate();
   const { configured, status, householdStatus, error, clearError } = useAuth();
+  const [callbackError, setCallbackError] = useState<string | null>(null);
+  const [timedOut, setTimedOut] = useState(false);
+
+  useEffect(() => {
+    if (!configured) {
+      return;
+    }
+
+    let cancelled = false;
+
+    void finalizeSupabaseAuthFromUrl().then((result) => {
+      if (!cancelled && result.error) {
+        setCallbackError(result.error);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [configured]);
 
   useEffect(() => {
     if (!configured) {
@@ -17,6 +40,20 @@ const AuthCallback = () => {
     }
   }, [configured, householdStatus, navigate, status]);
 
+  useEffect(() => {
+    if (!configured || callbackError || (status === 'signed_in' && householdStatus !== 'loading')) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      setTimedOut(true);
+    }, CALLBACK_TIMEOUT_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [callbackError, configured, householdStatus, status]);
+
+  const resolvedError = callbackError ?? error;
+
   return (
     <div className="flex min-h-svh items-center justify-center px-5 py-10">
       <div className="w-full max-w-lg rounded-[32px] border border-border bg-card p-8 text-center shadow-card">
@@ -25,7 +62,7 @@ const AuthCallback = () => {
             <p className="text-sm font-black uppercase tracking-[0.22em] text-destructive">Sign-in needs one more step</p>
             <h1 className="mt-4 text-3xl font-bold text-foreground">We signed you in, but could not open the family space yet</h1>
             <p className="mt-3 text-sm text-muted-foreground">
-              {error ?? 'Please try this link again in a moment.'}
+              {resolvedError ?? 'Please try this link again in a moment.'}
             </p>
             <button
               type="button"
@@ -38,21 +75,41 @@ const AuthCallback = () => {
               Continue to Routine Stars
             </button>
           </>
-        ) : status === 'signed_out' && error ? (
+        ) : resolvedError || timedOut ? (
           <>
-            <p className="text-sm font-black uppercase tracking-[0.22em] text-destructive">Sign-in link problem</p>
-            <h1 className="mt-4 text-3xl font-bold text-foreground">This sign-in link did not finish cleanly</h1>
-            <p className="mt-3 text-sm text-muted-foreground">{error}</p>
-            <button
-              type="button"
-              onClick={() => {
-                clearError();
-                navigate('/', { replace: true });
-              }}
-              className="mt-6 rounded-full bg-primary px-5 py-3 text-sm font-bold text-primary-foreground shadow-button transition-transform active:translate-y-0.5"
-            >
-              Back to sign in
-            </button>
+            <p className="text-sm font-black uppercase tracking-[0.22em] text-destructive">
+              {timedOut ? 'Sign-in is taking too long' : 'Sign-in link problem'}
+            </p>
+            <h1 className="mt-4 text-3xl font-bold text-foreground">
+              {timedOut ? 'This device did not finish connecting' : 'This sign-in link did not finish cleanly'}
+            </h1>
+            <p className="mt-3 text-sm text-muted-foreground">
+              {resolvedError ?? 'Please refresh once, or request a new sign-in link if this keeps happening.'}
+            </p>
+            <div className="mt-6 flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+              <button
+                type="button"
+                onClick={() => {
+                  clearError();
+                  setCallbackError(null);
+                  setTimedOut(false);
+                  window.location.reload();
+                }}
+                className="rounded-full border border-border bg-background px-5 py-3 text-sm font-bold text-foreground transition-colors hover:border-primary/40 hover:text-primary"
+              >
+                Refresh and try again
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  clearError();
+                  navigate('/', { replace: true });
+                }}
+                className="rounded-full bg-primary px-5 py-3 text-sm font-bold text-primary-foreground shadow-button transition-transform active:translate-y-0.5"
+              >
+                Back to sign in
+              </button>
+            </div>
           </>
         ) : (
           <>

--- a/src/test/authCallback.test.tsx
+++ b/src/test/authCallback.test.tsx
@@ -1,9 +1,12 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import AuthCallback from '@/pages/AuthCallback';
 
 const navigate = vi.fn();
+const { finalizeSupabaseAuthFromUrl } = vi.hoisted(() => ({
+  finalizeSupabaseAuthFromUrl: vi.fn(),
+}));
 
 const authState = {
   configured: true,
@@ -25,12 +28,23 @@ vi.mock('@/lib/auth/use-auth', () => ({
   useAuth: () => authState,
 }));
 
+vi.mock('@/lib/supabase/client', () => ({
+  finalizeSupabaseAuthFromUrl,
+}));
+
 describe('AuthCallback', () => {
-  it('shows a finishing sign-in state while auth is settling', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    navigate.mockReset();
+    finalizeSupabaseAuthFromUrl.mockReset();
+    finalizeSupabaseAuthFromUrl.mockResolvedValue({ handled: false, error: null });
     authState.status = 'loading';
     authState.householdStatus = 'idle';
     authState.error = null;
+    authState.clearError.mockReset();
+  });
 
+  it('shows a finishing sign-in state while auth is settling', () => {
     render(
       <MemoryRouter initialEntries={['/auth/callback']}>
         <Routes>
@@ -59,4 +73,38 @@ describe('AuthCallback', () => {
     expect(screen.getByText(/we signed you in, but could not open the family space yet/i)).toBeInTheDocument();
     expect(screen.getByText(/could not prepare the family household/i)).toBeInTheDocument();
   });
+
+  it('shows an auth-link problem when callback finalization fails', async () => {
+    finalizeSupabaseAuthFromUrl.mockResolvedValue({ handled: true, error: 'Magic link expired.' });
+
+    render(
+      <MemoryRouter initialEntries={['/auth/callback']}>
+        <Routes>
+          <Route path="/auth/callback" element={<AuthCallback />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/this sign-in link did not finish cleanly/i)).toBeInTheDocument();
+    expect(screen.getByText(/magic link expired/i)).toBeInTheDocument();
+  });
+
+  it('shows a timeout recovery state instead of waiting forever', async () => {
+    vi.useFakeTimers();
+
+    render(
+      <MemoryRouter initialEntries={['/auth/callback']}>
+        <Routes>
+          <Route path="/auth/callback" element={<AuthCallback />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+
+    expect(screen.getByText(/this device did not finish connecting/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /refresh and try again/i })).toBeInTheDocument();
+  }, 10000);
 });

--- a/src/test/supabaseClient.test.ts
+++ b/src/test/supabaseClient.test.ts
@@ -1,11 +1,69 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-describe('getSupabaseEmailRedirectUrl', () => {
-  it('targets the dedicated auth callback route', async () => {
+const exchangeCodeForSession = vi.fn();
+const verifyOtp = vi.fn();
+const setSession = vi.fn();
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    auth: {
+      exchangeCodeForSession,
+      verifyOtp,
+      setSession,
+    },
+  }),
+}));
+
+describe('supabase client helpers', () => {
+  beforeEach(() => {
     vi.resetModules();
+    exchangeCodeForSession.mockReset();
+    verifyOtp.mockReset();
+    setSession.mockReset();
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon-key');
+  });
 
+  it('targets the dedicated auth callback route', async () => {
     const { getSupabaseEmailRedirectUrl } = await import('@/lib/supabase/client');
 
     expect(getSupabaseEmailRedirectUrl()).toBe(`${window.location.origin}/auth/callback`);
+  });
+
+  it('exchanges an auth code from the callback URL', async () => {
+    exchangeCodeForSession.mockResolvedValue({ error: null });
+    const { finalizeSupabaseAuthFromUrl } = await import('@/lib/supabase/client');
+
+    await expect(finalizeSupabaseAuthFromUrl('https://example.com/auth/callback?code=abc123')).resolves.toEqual({
+      handled: true,
+      error: null,
+    });
+    expect(exchangeCodeForSession).toHaveBeenCalledWith('abc123');
+  });
+
+  it('verifies token-hash magic links from the callback URL', async () => {
+    verifyOtp.mockResolvedValue({ error: null });
+    const { finalizeSupabaseAuthFromUrl } = await import('@/lib/supabase/client');
+
+    await expect(
+      finalizeSupabaseAuthFromUrl('https://example.com/auth/callback?token_hash=hash123&type=magiclink')
+    ).resolves.toEqual({
+      handled: true,
+      error: null,
+    });
+    expect(verifyOtp).toHaveBeenCalledWith({ token_hash: 'hash123', type: 'magiclink' });
+  });
+
+  it('sets the session from hash tokens when present', async () => {
+    setSession.mockResolvedValue({ error: null });
+    const { finalizeSupabaseAuthFromUrl } = await import('@/lib/supabase/client');
+
+    await expect(
+      finalizeSupabaseAuthFromUrl('https://example.com/auth/callback#access_token=token&refresh_token=refresh')
+    ).resolves.toEqual({
+      handled: true,
+      error: null,
+    });
+    expect(setSession).toHaveBeenCalledWith({ access_token: 'token', refresh_token: 'refresh' });
   });
 });


### PR DESCRIPTION
## Summary
Fixes the iPad/Safari auth callback getting stuck on `Opening your family account` after a magic link sign-in.

## What changed
- added explicit callback finalization for common Supabase auth URL shapes
- supports `code`, `token_hash`, and hash-token session callbacks
- added a timeout/recovery state so the callback does not spin forever
- added focused tests for callback finalization and timeout/error handling

## Why
The old callback screen only waited for auth state to settle. On iPad Safari that could leave the app spinning indefinitely if the callback URL was not actively finalized.

## Validation
- `npm test -- --run src/test/authCallback.test.tsx src/test/supabaseClient.test.ts`
- `npm run build`

## Related issues
- Closes #84