### PR TITLE
Fix iPad auth timing and sync setup drafts across devices

### DIFF
--- a/src/components/InitialSetup.tsx
+++ b/src/components/InitialSetup.tsx
@@ -8,6 +8,7 @@ import { ANIMAL_AVATARS } from './animal-avatars';
 
 interface InitialSetupProps {
   children: Child[];
+  onChange?: (children: Child[]) => void;
   onComplete: (children: Child[]) => void;
 }
 
@@ -72,7 +73,7 @@ const buildRoutineTasks = (childId: string, routine: RoutineType, selectedTitles
       completed: false,
     }));
 
-export const InitialSetup = ({ children, onComplete }: InitialSetupProps) => {
+export const InitialSetup = ({ children, onChange, onComplete }: InitialSetupProps) => {
   const [draftChildren, setDraftChildren] = useState(children);
   const [selectionState, setSelectionState] = useState<SelectionState>(() => buildSelectionState(children));
   const [activeChildId, setActiveChildId] = useState<string | null>(children[0]?.id ?? null);
@@ -156,14 +157,22 @@ export const InitialSetup = ({ children, onComplete }: InitialSetupProps) => {
     });
   };
 
-  const handleComplete = () => {
-    const configuredChildren = draftChildren.map((child) => ({
+  const configuredChildren = useMemo(
+    () =>
+      draftChildren.map((child) => ({
       ...child,
       name: child.name.trim() || 'Child',
       morning: buildRoutineTasks(child.id, 'morning', selectionState[child.id]?.morning ?? []),
       evening: buildRoutineTasks(child.id, 'evening', selectionState[child.id]?.evening ?? []),
-    }));
+    })),
+    [draftChildren, selectionState]
+  );
 
+  useEffect(() => {
+    onChange?.(configuredChildren);
+  }, [configuredChildren, onChange]);
+
+  const handleComplete = () => {
     onComplete(configuredChildren);
   };
 

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/lib/auth/use-auth';
 import { finalizeSupabaseAuthFromUrl } from '@/lib/supabase/client';
 
-const CALLBACK_TIMEOUT_MS = 8000;
+const CALLBACK_TIMEOUT_MS = 20000;
 
 const AuthCallback = () => {
   const navigate = useNavigate();

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -313,7 +313,7 @@ const Index = () => {
   );
 
   useEffect(() => {
-    if (!isReady || authStatus !== 'signed_in' || householdStatus !== 'ready' || !household || !setupComplete) {
+    if (!isReady || authStatus !== 'signed_in' || householdStatus !== 'ready' || !household) {
       lastSyncedConfigRef.current = null;
       return;
     }
@@ -332,12 +332,14 @@ const Index = () => {
     shouldSyncFirstConfigRef.current = false;
     lastSyncedConfigRef.current = householdConfigSignature;
 
-    void saveHouseholdConfigToCloud({
-      household,
-      children,
-      homeScene,
-      removeMissingChildren: true,
-    }).catch((error) => {
+    void Promise.resolve(
+      saveHouseholdConfigToCloud({
+        household,
+        children,
+        homeScene,
+        removeMissingChildren: true,
+      })
+    ).catch((error) => {
       console.warn('Could not sync household configuration to cloud.', error);
     });
   }, [authStatus, children, homeScene, household, householdConfigSignature, householdStatus, isReady, setupComplete]);
@@ -581,6 +583,7 @@ const Index = () => {
     return (
       <InitialSetup
         children={children}
+        onChange={setChildren}
         onComplete={(configuredChildren) => {
           setChildren(configuredChildren);
           setSetupComplete(true);

--- a/src/test/authCallback.test.tsx
+++ b/src/test/authCallback.test.tsx
@@ -89,7 +89,7 @@ describe('AuthCallback', () => {
     expect(screen.getByText(/magic link expired/i)).toBeInTheDocument();
   });
 
-  it('shows a timeout recovery state instead of waiting forever', async () => {
+  it('waits longer before showing a timeout recovery state', async () => {
     vi.useFakeTimers();
 
     render(
@@ -101,7 +101,13 @@ describe('AuthCallback', () => {
     );
 
     act(() => {
-      vi.advanceTimersByTime(8000);
+      vi.advanceTimersByTime(19000);
+    });
+
+    expect(screen.queryByText(/this device did not finish connecting/i)).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
     });
 
     expect(screen.getByText(/this device did not finish connecting/i)).toBeInTheDocument();

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -146,13 +146,30 @@ vi.mock("@/components/ParentSettings", () => ({
 vi.mock("@/components/InitialSetup", () => ({
   InitialSetup: ({
     children,
+    onChange,
     onComplete,
   }: {
     children: Child[];
+    onChange?: (children: Child[]) => void;
     onComplete: (children: Child[]) => void;
   }) => (
     <div>
       <div data-testid="setup-child-count">{children.length}</div>
+      <button
+        type="button"
+        onClick={() =>
+          onChange?.([
+            {
+              id: "draft-1",
+              name: "Elie",
+              morning: [{ id: "m1", title: "Brush teeth", icon: "tooth", completed: false }],
+              evening: [{ id: "e1", title: "Put on pajamas", icon: "shirt", completed: false }],
+            },
+          ])
+        }
+      >
+        sync-draft-child
+      </button>
       <button
         type="button"
         onClick={() =>
@@ -271,6 +288,7 @@ describe("Index", () => {
     loadCloudHouseholdState.mockReset();
     importLocalFamilyToCloud.mockReset();
     saveHouseholdConfigToCloud.mockReset();
+    saveHouseholdConfigToCloud.mockResolvedValue(undefined);
     deleteCloudHousehold.mockReset();
     deleteCloudHousehold.mockReset();
     getSupabaseClient.mockReset();
@@ -707,6 +725,46 @@ describe("Index", () => {
       expect(saveHouseholdConfigToCloud).toHaveBeenCalledWith(
         expect.objectContaining({
           household: authState.household,
+          removeMissingChildren: true,
+        })
+      );
+    });
+  });
+
+  it("syncs signed-in draft child creation to cloud before setup is completed", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [],
+    });
+    saveHouseholdConfigToCloud.mockResolvedValue(undefined);
+
+    render(<Index />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "recovery-start-fresh" }));
+    fireEvent.click(await screen.findByRole("button", { name: "sync-draft-child" }));
+
+    await waitFor(() => {
+      expect(saveHouseholdConfigToCloud).toHaveBeenCalledWith(
+        expect.objectContaining({
+          household: authState.household,
+          children: [
+            expect.objectContaining({
+              id: "draft-1",
+              name: "Elie",
+            }),
+          ],
           removeMissingChildren: true,
         })
       );


### PR DESCRIPTION
## Summary
- wait longer before showing the auth callback timeout state on slow iPad Safari handoffs
- propagate signed-in setup edits up from InitialSetup as they happen instead of waiting for final completion
- allow signed-in cloud config sync to persist those in-progress setup profiles so they appear on a second device
- add regression coverage for both behaviors

Closes #87
Closes #88