### PR TITLE
Reduce initial iPad load by lazy-loading app views

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RefreshCw } from "lucide-react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
@@ -7,9 +7,9 @@ import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider } from "@/lib/auth/auth-context";
 import { APP_VERSION, getRefreshUrl, getVersionManifestUrl } from "@/lib/app-version";
-import AuthCallback from "./pages/AuthCallback.tsx";
-import Index from "./pages/Index.tsx";
-import NotFound from "./pages/NotFound.tsx";
+const AuthCallback = lazy(() => import("./pages/AuthCallback.tsx"));
+const Index = lazy(() => import("./pages/Index.tsx"));
+const NotFound = lazy(() => import("./pages/NotFound.tsx"));
 
 const queryClient = new QueryClient();
 
@@ -65,12 +65,26 @@ const AppShell = () => {
       <Toaster />
       <Sonner />
       <BrowserRouter basename={import.meta.env.BASE_URL}>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/auth/callback" element={<AuthCallback />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
+        <Suspense
+          fallback={
+            <div className="flex min-h-svh items-center justify-center px-5 py-10">
+              <div className="w-full max-w-lg rounded-[32px] border border-border bg-card p-8 text-center shadow-card">
+                <p className="text-sm font-black uppercase tracking-[0.22em] text-primary">Loading Routine Stars</p>
+                <h1 className="mt-4 text-3xl font-bold text-foreground">Getting everything ready</h1>
+                <p className="mt-3 text-sm text-muted-foreground">
+                  This should only take a moment.
+                </p>
+              </div>
+            </div>
+          }
+        >
+          <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/auth/callback" element={<AuthCallback />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </Suspense>
       </BrowserRouter>
 
       {latestVersion && (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,12 +1,9 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { lazy, Suspense, useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { ChildSelector } from '@/components/ChildSelector';
 import { AccountEntryScreen } from '@/components/AccountEntryScreen';
 import { ExistingFamilyRecoveryScreen } from '@/components/ExistingFamilyRecoveryScreen';
 import { HouseholdLoadErrorScreen } from '@/components/HouseholdLoadErrorScreen';
 import { ImportFamilySetupScreen } from '@/components/ImportFamilySetupScreen';
-import { InitialSetup } from '@/components/InitialSetup';
-import { RoutineView } from '@/components/RoutineView';
-import { ParentSettings } from '@/components/ParentSettings';
 import { useAuth } from '@/lib/auth/use-auth';
 import { loadCloudHouseholdState } from '@/lib/data/cloud-household-state';
 import { saveHouseholdConfigToCloud } from '@/lib/data/cloud-household-write';
@@ -20,6 +17,10 @@ import {
   loadLocalAppState,
   saveLocalAppState,
 } from '@/lib/storage/local-app-state';
+
+const InitialSetup = lazy(() => import('@/components/InitialSetup').then((module) => ({ default: module.InitialSetup })));
+const RoutineView = lazy(() => import('@/components/RoutineView').then((module) => ({ default: module.RoutineView })));
+const ParentSettings = lazy(() => import('@/components/ParentSettings').then((module) => ({ default: module.ParentSettings })));
 
 const parseTime = (value: string) => {
   const [hours, minutes] = value.split(':').map(Number);
@@ -101,6 +102,16 @@ const serializeHouseholdConfig = (input: {
     homeScene: input.homeScene,
     setupComplete: input.setupComplete,
   });
+
+const ViewLoadingFallback = ({ title = 'Loading next step' }: { title?: string }) => (
+  <div className="flex min-h-svh items-center justify-center px-5 py-10">
+    <div className="w-full max-w-lg rounded-[32px] border border-border bg-card p-8 text-center shadow-card">
+      <p className="text-sm font-black uppercase tracking-[0.22em] text-primary">Routine Stars</p>
+      <h1 className="mt-4 text-3xl font-bold text-foreground">{title}</h1>
+      <p className="mt-3 text-sm text-muted-foreground">This should only take a moment.</p>
+    </div>
+  </div>
+);
 
 const Index = () => {
   const { status: authStatus, householdStatus, household, signOut } = useAuth();
@@ -581,40 +592,46 @@ const Index = () => {
 
   if (view === 'setup') {
     return (
-      <InitialSetup
-        children={children}
-        onChange={setChildren}
-        onComplete={(configuredChildren) => {
-          setChildren(configuredChildren);
-          setSetupComplete(true);
-          setView('home');
-        }}
-      />
+      <Suspense fallback={<ViewLoadingFallback title="Opening setup" />}>
+        <InitialSetup
+          children={children}
+          onChange={setChildren}
+          onComplete={(configuredChildren) => {
+            setChildren(configuredChildren);
+            setSetupComplete(true);
+            setView('home');
+          }}
+        />
+      </Suspense>
     );
   }
 
   if (view === 'routine' && activeChild) {
     return (
-      <RoutineView
-        child={activeChild}
-        routine={activeRoutine}
-        onToggleTask={toggleTask}
-        onBack={() => setView('home')}
-      />
+      <Suspense fallback={<ViewLoadingFallback title="Opening routine" />}>
+        <RoutineView
+          child={activeChild}
+          routine={activeRoutine}
+          onToggleTask={toggleTask}
+          onBack={() => setView('home')}
+        />
+      </Suspense>
     );
   }
 
   if (view === 'parent') {
     return (
-      <ParentSettings
-        children={children}
-        homeScene={homeScene}
-        onChange={setChildren}
-        onHomeSceneChange={setHomeScene}
-        onRestartSetup={restartSetup}
-        onResetAppData={resetToFreshSetup}
-        onBack={() => setView('home')}
-      />
+      <Suspense fallback={<ViewLoadingFallback title="Opening parent settings" />}>
+        <ParentSettings
+          children={children}
+          homeScene={homeScene}
+          onChange={setChildren}
+          onHomeSceneChange={setHomeScene}
+          onRestartSetup={restartSetup}
+          onResetAppData={resetToFreshSetup}
+          onBack={() => setView('home')}
+        />
+      </Suspense>
     );
   }
 

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -980,7 +980,7 @@ describe("Index", () => {
     render(<Index />);
 
     fireEvent.click(await screen.findByRole("button", { name: "open-settings" }));
-    fireEvent.click(screen.getByRole("button", { name: "reset-app-data" }));
+    fireEvent.click(await screen.findByRole("button", { name: "reset-app-data" }));
 
     await waitFor(() => {
       expect(deleteCloudHousehold).toHaveBeenCalledWith(authState.household);


### PR DESCRIPTION
## Summary
- lazy-load the route pages so the auth-first shell does not ship the whole app up front
- lazy-load setup, routine, and parent settings views from the main index flow
- add light loading fallbacks and update the affected test for async parent settings loading

Closes #90