### PR TITLE
Prevent duplicate household creation during sign-in bootstrap

### DIFF
--- a/src/lib/data/supabase-household-repository.ts
+++ b/src/lib/data/supabase-household-repository.ts
@@ -18,6 +18,19 @@ const shouldFallbackToDirectBootstrap = (error: unknown) => {
   );
 };
 
+const isDuplicateHouseholdError = (error: unknown) => {
+  const message =
+    typeof error === 'object' && error !== null && 'message' in error
+      ? String(error.message).toLowerCase()
+      : '';
+  const code =
+    typeof error === 'object' && error !== null && 'code' in error
+      ? String(error.code)
+      : '';
+
+  return code === '23505' || message.includes('duplicate key') || message.includes('unique constraint');
+};
+
 const mapHousehold = (row: Record<string, unknown>): HouseholdRecord => ({
   id: String(row.id),
   name: String(row.name),
@@ -65,6 +78,13 @@ export class SupabaseHouseholdRepository implements HouseholdRepository {
       return mapHousehold(data);
     }
 
+    if (error && isDuplicateHouseholdError(error)) {
+      const existingHousehold = await this.getCurrentHousehold();
+      if (existingHousehold) {
+        return existingHousehold;
+      }
+    }
+
     if (error && !shouldFallbackToDirectBootstrap(error)) {
       throw error;
     }
@@ -80,6 +100,13 @@ export class SupabaseHouseholdRepository implements HouseholdRepository {
       .single();
 
     if (householdError) {
+      if (isDuplicateHouseholdError(householdError)) {
+        const existingHousehold = await this.getCurrentHousehold();
+        if (existingHousehold) {
+          return existingHousehold;
+        }
+      }
+
       throw householdError;
     }
 
@@ -94,6 +121,13 @@ export class SupabaseHouseholdRepository implements HouseholdRepository {
       });
 
     if (membershipError) {
+      if (isDuplicateHouseholdError(membershipError)) {
+        const existingHousehold = await this.getCurrentHousehold();
+        if (existingHousehold) {
+          return existingHousehold;
+        }
+      }
+
       throw membershipError;
     }
 

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -4,12 +4,14 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/lib/auth/use-auth';
 import { finalizeSupabaseAuthFromUrl } from '@/lib/supabase/client';
 
-const CALLBACK_TIMEOUT_MS = 20000;
+const CALLBACK_SLOW_MS = 20000;
+const CALLBACK_FAILURE_MS = 60000;
 
 const AuthCallback = () => {
   const navigate = useNavigate();
   const { configured, status, householdStatus, error, clearError } = useAuth();
   const [callbackError, setCallbackError] = useState<string | null>(null);
+  const [takingLongerThanExpected, setTakingLongerThanExpected] = useState(false);
   const [timedOut, setTimedOut] = useState(false);
 
   useEffect(() => {
@@ -45,11 +47,18 @@ const AuthCallback = () => {
       return;
     }
 
-    const timer = window.setTimeout(() => {
-      setTimedOut(true);
-    }, CALLBACK_TIMEOUT_MS);
+    const slowTimer = window.setTimeout(() => {
+      setTakingLongerThanExpected(true);
+    }, CALLBACK_SLOW_MS);
 
-    return () => window.clearTimeout(timer);
+    const failureTimer = window.setTimeout(() => {
+      setTimedOut(true);
+    }, CALLBACK_FAILURE_MS);
+
+    return () => {
+      window.clearTimeout(slowTimer);
+      window.clearTimeout(failureTimer);
+    };
   }, [callbackError, configured, householdStatus, status]);
 
   const resolvedError = callbackError ?? error;
@@ -110,6 +119,17 @@ const AuthCallback = () => {
                 Back to sign in
               </button>
             </div>
+          </>
+        ) : takingLongerThanExpected ? (
+          <>
+            <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <LoaderCircle size={28} className="animate-spin" />
+            </div>
+            <p className="mt-5 text-sm font-black uppercase tracking-[0.22em] text-primary">Still connecting</p>
+            <h1 className="mt-4 text-3xl font-bold text-foreground">This iPad is still opening your family account</h1>
+            <p className="mt-3 text-sm text-muted-foreground">
+              Safari can take a little longer here. If this screen stays for more than a minute, then we&apos;ll show recovery options.
+            </p>
           </>
         ) : (
           <>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -234,6 +234,26 @@ const Index = () => {
           return;
         }
 
+        if (
+          !cloudLoadError &&
+          authStatus === 'signed_in' &&
+          householdStatus === 'ready' &&
+          household &&
+          storedState.children.length === 0 &&
+          (cloudState?.children.length ?? 0) === 0
+        ) {
+          if (isMounted) {
+            setBootstrapError(null);
+            setChildren(createSetupChildren());
+            setActiveChildId(null);
+            setSetupComplete(false);
+            setHomeScene(storedState.homeScene);
+            setView('recovery');
+            setIsReady(true);
+          }
+          return;
+        }
+
         const today = new Date().toDateString();
         if (storedState.lastReset !== today) {
           const reset = storedState.children.map((c: Child) => ({

--- a/src/test/authCallback.test.tsx
+++ b/src/test/authCallback.test.tsx
@@ -89,7 +89,7 @@ describe('AuthCallback', () => {
     expect(screen.getByText(/magic link expired/i)).toBeInTheDocument();
   });
 
-  it('waits longer before showing a timeout recovery state', async () => {
+  it('shows a slower in-progress state before eventually showing timeout recovery', async () => {
     vi.useFakeTimers();
 
     render(
@@ -108,6 +108,14 @@ describe('AuthCallback', () => {
 
     act(() => {
       vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText(/still connecting/i)).toBeInTheDocument();
+    expect(screen.getByText(/this ipad is still opening your family account/i)).toBeInTheDocument();
+    expect(screen.queryByText(/this device did not finish connecting/i)).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(40000);
     });
 
     expect(screen.getByText(/this device did not finish connecting/i)).toBeInTheDocument();

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -539,7 +539,7 @@ describe("Index", () => {
     expect(screen.queryByTestId("household-load-error-screen")).not.toBeInTheDocument();
   });
 
-  it("shows a retryable bootstrap error instead of setup when signed-in cloud loading fails with no local cache", async () => {
+  it("shows the recovery screen after retry when signed-in cloud loading fails and no local family data exists", async () => {
     authState.status = "signed_in";
     authState.user = { id: "user-1", email: "parent@example.com" };
     authState.householdStatus = "ready";
@@ -566,7 +566,8 @@ describe("Index", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "retry-household-load" }));
 
-    expect(await screen.findByTestId("setup-child-count")).toHaveTextContent("0");
+    expect(await screen.findByTestId("existing-family-recovery-screen")).toBeInTheDocument();
+    expect(screen.queryByTestId("setup-child-count")).not.toBeInTheDocument();
   });
 
   it("prefers cloud household state over stale local cache for signed-in households", async () => {
@@ -870,6 +871,40 @@ describe("Index", () => {
     render(<Index />);
 
     expect(await screen.findByTestId("existing-family-recovery-screen")).toBeInTheDocument();
+  });
+
+  it("shows the recovery screen instead of setup when a signed-in browser only has an empty local shell", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [],
+    });
+    localStorage.setItem(
+      "routine_stars_data",
+      JSON.stringify({
+        version: CURRENT_LOCAL_APP_STATE_VERSION,
+        children: [],
+        homeScene: "bike",
+        lastReset: today(),
+        setupComplete: false,
+      })
+    );
+
+    render(<Index />);
+
+    expect(await screen.findByTestId("existing-family-recovery-screen")).toBeInTheDocument();
+    expect(screen.queryByTestId("setup-child-count")).toBeNull();
   });
 
   it("lets a parent intentionally continue into fresh setup from the recovery screen", async () => {

--- a/src/test/supabaseHouseholdRepository.test.ts
+++ b/src/test/supabaseHouseholdRepository.test.ts
@@ -174,6 +174,64 @@ describe('SupabaseHouseholdRepository', () => {
     ).rejects.toEqual({ message: 'Not authenticated' });
   });
 
+  it('returns the existing household when bootstrap collides with a duplicate-account create', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: {
+        id: 'house-existing',
+        name: "Dora's Family",
+        timezone: 'Europe/Madrid',
+        home_scene: 'bike',
+        created_by_user_id: 'user-1',
+        created_at: '2026-05-06T12:00:00Z',
+        updated_at: '2026-05-06T12:05:00Z',
+      },
+      error: null,
+    });
+    const limit = vi.fn(() => ({
+      maybeSingle,
+    }));
+    const orderCreatedAt = vi.fn(() => ({
+      limit,
+    }));
+    const orderUpdatedAt = vi.fn(() => ({
+      order: orderCreatedAt,
+    }));
+
+    const repository = new SupabaseHouseholdRepository({
+      rpc: vi.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'duplicate key value violates unique constraint', code: '23505' },
+      }),
+      from: vi.fn((table: string) => {
+        if (table === 'households') {
+          return {
+            select: vi.fn(() => ({
+              order: orderUpdatedAt,
+            })),
+          };
+        }
+
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    } as never);
+
+    await expect(
+      repository.createInitialHousehold({
+        householdName: "Dora's Family",
+        timezone: 'Europe/Madrid',
+        userId: 'user-1',
+      })
+    ).resolves.toEqual({
+      id: 'house-existing',
+      name: "Dora's Family",
+      timezone: 'Europe/Madrid',
+      homeScene: 'bike',
+      createdByUserId: 'user-1',
+      createdAt: '2026-05-06T12:00:00Z',
+      updatedAt: '2026-05-06T12:05:00Z',
+    });
+  });
+
   it('deletes the household row by id', async () => {
     const deleteEq = vi.fn().mockResolvedValue({ error: null });
     const repository = new SupabaseHouseholdRepository(

--- a/supabase/migrations/20260506143000_enforce_one_household_per_account.sql
+++ b/supabase/migrations/20260506143000_enforce_one_household_per_account.sql
@@ -1,0 +1,9 @@
+-- Routine Stars is designed around one household per parent account.
+-- These constraints prevent concurrent sign-in/bootstrap flows from creating
+-- duplicate empty households for the same authenticated user.
+
+create unique index if not exists households_created_by_user_id_unique
+on public.households (created_by_user_id);
+
+create unique index if not exists household_members_user_id_unique
+on public.household_members (user_id);


### PR DESCRIPTION
## Summary
- recover gracefully when concurrent bootstrap requests race to create the same household
- return the existing household on duplicate-key collisions instead of failing or creating more empties
- add a migration that enforces one household per account at the database level
- add repository coverage for the duplicate-account race

Closes #104