### PR TITLE
Fix callback error handling and current-session import recovery

### DIFF
--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -27,6 +27,26 @@ const isSupportedOtpType = (value: string | null) =>
   value === 'sms' ||
   value === 'phone_change';
 
+const describeAuthLinkError = (parsedUrl: URL) => {
+  const errorCode = parsedUrl.searchParams.get('error_code');
+  const errorDescription = parsedUrl.searchParams.get('error_description');
+  const fallbackError = parsedUrl.searchParams.get('error');
+
+  if (errorCode === 'otp_expired') {
+    return 'This sign-in link has expired. Please request a new one.';
+  }
+
+  if (errorDescription) {
+    return decodeURIComponent(errorDescription.replace(/\+/g, ' '));
+  }
+
+  if (fallbackError === 'access_denied') {
+    return 'This sign-in link could not be used. Please request a new one.';
+  }
+
+  return fallbackError;
+};
+
 export const finalizeSupabaseAuthFromUrl = async (url = window.location.href) => {
   const supabase = getSupabaseClient();
   if (!supabase) {
@@ -40,8 +60,13 @@ export const finalizeSupabaseAuthFromUrl = async (url = window.location.href) =>
   const otpType = parsedUrl.searchParams.get('type');
   const accessToken = hashParams.get('access_token');
   const refreshToken = hashParams.get('refresh_token');
+  const authLinkError = describeAuthLinkError(parsedUrl);
 
   try {
+    if (authLinkError) {
+      return { handled: true, error: authLinkError };
+    }
+
     if (code) {
       const { error } = await supabase.auth.exchangeCodeForSession(code);
       if (error) {

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -126,9 +126,9 @@ const AuthCallback = () => {
               <LoaderCircle size={28} className="animate-spin" />
             </div>
             <p className="mt-5 text-sm font-black uppercase tracking-[0.22em] text-primary">Still connecting</p>
-            <h1 className="mt-4 text-3xl font-bold text-foreground">This iPad is still opening your family account</h1>
+            <h1 className="mt-4 text-3xl font-bold text-foreground">We&apos;re still opening your family account</h1>
             <p className="mt-3 text-sm text-muted-foreground">
-              Safari can take a little longer here. If this screen stays for more than a minute, then we&apos;ll show recovery options.
+              This can take a little longer on some browsers. If this screen stays for more than a minute, we&apos;ll show recovery options.
             </p>
           </>
         ) : (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -129,6 +129,23 @@ const Index = () => {
   const lastSyncedConfigRef = useRef<string | null>(null);
   const shouldSyncFirstConfigRef = useRef(false);
   const skipLocalPersistenceRef = useRef(false);
+  const currentSessionSetupRef = useRef<{
+    children: Child[];
+    homeScene: HomeScene;
+    setupComplete: boolean;
+  }>({
+    children: createSetupChildren(),
+    homeScene: 'bike',
+    setupComplete: false,
+  });
+
+  useEffect(() => {
+    currentSessionSetupRef.current = {
+      children,
+      homeScene,
+      setupComplete,
+    };
+  }, [children, homeScene, setupComplete]);
 
   const clearLocalAndState = useCallback((nextView: AppView) => {
     skipLocalPersistenceRef.current = true;
@@ -185,6 +202,18 @@ const Index = () => {
       }
 
       const storedState = loadLocalAppState();
+      const currentSessionSetup = currentSessionSetupRef.current;
+      const recoverableLocalState =
+        storedState ??
+        (currentSessionSetup.children.length > 0
+          ? {
+              version: 1,
+              children: currentSessionSetup.children,
+              homeScene: currentSessionSetup.homeScene,
+              lastReset: new Date().toDateString(),
+              setupComplete: currentSessionSetup.setupComplete,
+            }
+          : null);
       let cloudState: Awaited<ReturnType<typeof loadCloudHouseholdState>> | null = null;
       let cloudLoadError: string | null = null;
 
@@ -198,7 +227,7 @@ const Index = () => {
         }
       }
 
-      if (storedState) {
+      if (recoverableLocalState) {
         if (authStatus === 'signed_in' && householdStatus === 'ready' && household && cloudState?.children.length) {
           if (isMounted) {
             setChildren(cloudState.children);
@@ -221,13 +250,13 @@ const Index = () => {
           authStatus === 'signed_in' &&
           householdStatus === 'ready' &&
           household &&
-          storedState.children.length > 0 &&
+          recoverableLocalState.children.length > 0 &&
           (cloudState?.children.length ?? 0) === 0
         ) {
           if (isMounted) {
-            setChildren(storedState.children);
-            setHomeScene(storedState.homeScene);
-            setSetupComplete(storedState.setupComplete);
+            setChildren(recoverableLocalState.children);
+            setHomeScene(recoverableLocalState.homeScene);
+            setSetupComplete(recoverableLocalState.setupComplete);
             setView('import');
             setIsReady(true);
           }
@@ -239,7 +268,7 @@ const Index = () => {
           authStatus === 'signed_in' &&
           householdStatus === 'ready' &&
           household &&
-          storedState.children.length === 0 &&
+          recoverableLocalState.children.length === 0 &&
           (cloudState?.children.length ?? 0) === 0
         ) {
           if (isMounted) {
@@ -247,7 +276,7 @@ const Index = () => {
             setChildren(createSetupChildren());
             setActiveChildId(null);
             setSetupComplete(false);
-            setHomeScene(storedState.homeScene);
+            setHomeScene(recoverableLocalState.homeScene);
             setView('recovery');
             setIsReady(true);
           }
@@ -255,8 +284,8 @@ const Index = () => {
         }
 
         const today = new Date().toDateString();
-        if (storedState.lastReset !== today) {
-          const reset = storedState.children.map((c: Child) => ({
+        if (recoverableLocalState.lastReset !== today) {
+          const reset = recoverableLocalState.children.map((c: Child) => ({
             ...c,
             morning: c.morning.map((t: Child['morning'][0]) => ({ ...t, completed: false })),
             evening: c.evening.map((t: Child['evening'][0]) => ({ ...t, completed: false })),
@@ -265,14 +294,14 @@ const Index = () => {
             setChildren(reset);
           }
         } else if (isMounted) {
-          setChildren(storedState.children);
+          setChildren(recoverableLocalState.children);
         }
 
         if (isMounted) {
           setBootstrapError(null);
-          setSetupComplete(storedState.setupComplete);
-          setHomeScene(storedState.homeScene);
-          setView(storedState.setupComplete ? 'home' : 'setup');
+          setSetupComplete(recoverableLocalState.setupComplete);
+          setHomeScene(recoverableLocalState.homeScene);
+          setView(recoverableLocalState.setupComplete ? 'home' : 'setup');
           setIsReady(true);
         }
         return;

--- a/src/test/authCallback.test.tsx
+++ b/src/test/authCallback.test.tsx
@@ -89,6 +89,26 @@ describe('AuthCallback', () => {
     expect(screen.getByText(/magic link expired/i)).toBeInTheDocument();
   });
 
+  it('uses device-neutral copy while a slow callback is still in progress', () => {
+    vi.useFakeTimers();
+
+    render(
+      <MemoryRouter initialEntries={['/auth/callback']}>
+        <Routes>
+          <Route path="/auth/callback" element={<AuthCallback />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(20000);
+    });
+
+    expect(screen.getByText(/still connecting/i)).toBeInTheDocument();
+    expect(screen.getByText(/we're still opening your family account/i)).toBeInTheDocument();
+    expect(screen.queryByText(/this ipad is still opening your family account/i)).not.toBeInTheDocument();
+  });
+
   it('shows a slower in-progress state before eventually showing timeout recovery', async () => {
     vi.useFakeTimers();
 
@@ -111,7 +131,7 @@ describe('AuthCallback', () => {
     });
 
     expect(screen.getByText(/still connecting/i)).toBeInTheDocument();
-    expect(screen.getByText(/this ipad is still opening your family account/i)).toBeInTheDocument();
+    expect(screen.getByText(/we're still opening your family account/i)).toBeInTheDocument();
     expect(screen.queryByText(/this device did not finish connecting/i)).not.toBeInTheDocument();
 
     act(() => {

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -772,6 +772,38 @@ describe("Index", () => {
     });
   });
 
+  it("routes back to import when the current signed-in setup has in-memory children but cloud is still empty", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [],
+    });
+
+    const view = render(<Index />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "recovery-start-fresh" }));
+    fireEvent.click(await screen.findByRole("button", { name: "sync-draft-child" }));
+
+    authState.householdStatus = "loading";
+    view.rerender(<Index />);
+
+    authState.householdStatus = "ready";
+    view.rerender(<Index />);
+
+    expect(await screen.findByTestId("import-family-setup-screen")).toBeInTheDocument();
+  });
+
   it("lets a parent start fresh instead of importing existing local setup", async () => {
     authState.status = "signed_in";
     authState.user = { id: "user-1", email: "parent@example.com" };

--- a/src/test/supabaseClient.test.ts
+++ b/src/test/supabaseClient.test.ts
@@ -66,4 +66,17 @@ describe('supabase client helpers', () => {
     });
     expect(setSession).toHaveBeenCalledWith({ access_token: 'token', refresh_token: 'refresh' });
   });
+
+  it('surfaces expired-link errors directly from callback query params', async () => {
+    const { finalizeSupabaseAuthFromUrl } = await import('@/lib/supabase/client');
+
+    await expect(
+      finalizeSupabaseAuthFromUrl(
+        'https://example.com/auth/callback?error=access_denied&error_code=otp_expired&error_description=OTP+expired'
+      )
+    ).resolves.toEqual({
+      handled: true,
+      error: 'This sign-in link has expired. Please request a new one.',
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- show expired auth-link errors immediately and remove device-specific callback copy
- treat current-session setup data as recoverable local family state during signed-in bootstrap
- add regression coverage for expired links, neutral callback copy, and returning to import when cloud is empty

## Testing
- npm test -- --run src/test/authCallback.test.tsx src/test/supabaseClient.test.ts src/test/index.test.tsx
- npm run build

Closes #106
Closes #107