### PR TITLE
Surface and retry failed cloud saves during setup

### DIFF
--- a/src/components/InitialSetup.tsx
+++ b/src/components/InitialSetup.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Check, Clock3, LogOut, Moon, Plus, Sparkles, Sun, UserRound } from 'lucide-react';
+import { AlertCircle, Check, Clock3, LogOut, Moon, Plus, RefreshCw, Sparkles, Sun, UserRound } from 'lucide-react';
 import type { Child, RoutineType, Task } from '@/lib/types';
 import { AGE_BUCKETS, groupTasksByAge, TASK_CATALOG } from '@/lib/types';
 import { TaskIcon } from './TaskIcon';
@@ -10,6 +10,8 @@ interface InitialSetupProps {
   children: Child[];
   signedInEmail?: string | null;
   onSignOut?: () => void;
+  cloudSyncError?: string | null;
+  onRetryCloudSync?: () => void;
   onChange?: (children: Child[]) => void;
   onComplete: (children: Child[]) => void;
 }
@@ -75,7 +77,15 @@ const buildRoutineTasks = (childId: string, routine: RoutineType, selectedTitles
       completed: false,
     }));
 
-export const InitialSetup = ({ children, signedInEmail, onSignOut, onChange, onComplete }: InitialSetupProps) => {
+export const InitialSetup = ({
+  children,
+  signedInEmail,
+  onSignOut,
+  cloudSyncError,
+  onRetryCloudSync,
+  onChange,
+  onComplete,
+}: InitialSetupProps) => {
   const [draftChildren, setDraftChildren] = useState(children);
   const [selectionState, setSelectionState] = useState<SelectionState>(() => buildSelectionState(children));
   const [activeChildId, setActiveChildId] = useState<string | null>(children[0]?.id ?? null);
@@ -203,6 +213,34 @@ export const InitialSetup = ({ children, signedInEmail, onSignOut, onChange, onC
             </div>
           </div>
         ) : null}
+
+        {cloudSyncError && (
+          <div className="mb-5 rounded-[28px] border border-destructive/20 bg-destructive/5 px-5 py-4 text-left shadow-sm">
+            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+              <div className="flex items-start gap-3">
+                <div className="mt-0.5 rounded-full bg-destructive/10 p-2 text-destructive">
+                  <AlertCircle size={18} />
+                </div>
+                <div>
+                  <p className="text-sm font-black uppercase tracking-[0.22em] text-destructive">Cloud sync needs attention</p>
+                  <p className="mt-1 text-sm text-destructive/90">
+                    {cloudSyncError}
+                  </p>
+                </div>
+              </div>
+              {onRetryCloudSync ? (
+                <button
+                  type="button"
+                  onClick={onRetryCloudSync}
+                  className="inline-flex items-center justify-center gap-2 rounded-full border border-destructive/20 bg-background px-4 py-2 text-sm font-bold text-foreground transition-colors hover:border-destructive/40 hover:text-destructive"
+                >
+                  <RefreshCw size={16} />
+                  Retry cloud save
+                </button>
+              ) : null}
+            </div>
+          </div>
+        )}
 
         <header className="mx-auto max-w-3xl text-center">
           <p className="text-sm font-black uppercase tracking-[0.32em] text-primary">Parent Setup</p>

--- a/src/components/ParentSettings.tsx
+++ b/src/components/ParentSettings.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Reorder } from 'framer-motion';
 import {
   Sun, Moon, Trash2, Plus, GripVertical, UserPlus, ArrowLeft, X, Check, Shuffle, Clock3, Palette, ChevronDown,
-  Users, House, Shield, CreditCard, LogOut, UserRound,
+  Users, House, Shield, CreditCard, LogOut, RefreshCw, UserRound,
 } from 'lucide-react';
 import { TaskIcon } from './TaskIcon';
 import { TaskSuggestionPicker } from './TaskSuggestionPicker';
@@ -17,6 +17,8 @@ import type { TaskCatalogItem } from '@/lib/task-catalog';
 interface ParentSettingsProps {
   children: Child[];
   homeScene: HomeScene;
+  cloudConfigSyncError?: string | null;
+  onRetryCloudConfigSync?: () => void;
   onChange: (children: Child[]) => void;
   onHomeSceneChange: (scene: HomeScene) => void;
   onRestartSetup: () => void;
@@ -257,6 +259,8 @@ const HOME_SCENE_OPTIONS: { key: HomeScene; label: string; preview: string; desc
 export const ParentSettings = ({
   children,
   homeScene,
+  cloudConfigSyncError,
+  onRetryCloudConfigSync,
   onChange,
   onHomeSceneChange,
   onRestartSetup,
@@ -424,6 +428,24 @@ export const ParentSettings = ({
               </button>
             )}
           </div>
+
+          {cloudConfigSyncError ? (
+            <div className="mt-8 rounded-[24px] border border-destructive/20 bg-destructive/5 p-4">
+              <p className="text-xs font-black uppercase tracking-[0.22em] text-destructive">Cloud sync needs attention</p>
+              <p className="mt-3 text-base font-bold text-foreground">This family setup has not saved to the cloud yet</p>
+              <p className="mt-1 text-sm text-muted-foreground">{cloudConfigSyncError}</p>
+              {onRetryCloudConfigSync ? (
+                <button
+                  type="button"
+                  onClick={onRetryCloudConfigSync}
+                  className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-full border border-destructive/20 bg-background px-4 py-3 text-sm font-bold text-foreground transition-colors hover:border-destructive/40 hover:text-destructive"
+                >
+                  <RefreshCw size={16} />
+                  Retry cloud save
+                </button>
+              ) : null}
+            </div>
+          ) : null}
         </aside>
 
         <div className="space-y-8">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -122,11 +122,14 @@ const Index = () => {
   const [isReady, setIsReady] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
   const [bootstrapError, setBootstrapError] = useState<string | null>(null);
+  const [cloudConfigSyncError, setCloudConfigSyncError] = useState<string | null>(null);
+  const [cloudConfigSyncRetryTick, setCloudConfigSyncRetryTick] = useState(0);
   const [isImporting, setIsImporting] = useState(false);
   const [now, setNow] = useState(() => new Date());
   const [homeScene, setHomeScene] = useState<HomeScene>('bike');
   const [bootstrapAttempt, setBootstrapAttempt] = useState(0);
   const lastSyncedConfigRef = useRef<string | null>(null);
+  const configSyncInFlightRef = useRef<string | null>(null);
   const shouldSyncFirstConfigRef = useRef(false);
   const skipLocalPersistenceRef = useRef(false);
   const currentSessionSetupRef = useRef<{
@@ -192,6 +195,7 @@ const Index = () => {
         if (!isMounted) return;
 
         setBootstrapError(null);
+        setCloudConfigSyncError(null);
         setChildren(createSetupChildren());
         setActiveChildId(null);
         setSetupComplete(false);
@@ -242,6 +246,7 @@ const Index = () => {
               homeScene: cloudState.homeScene,
               setupComplete: cloudState.children.length > 0,
             });
+            configSyncInFlightRef.current = null;
             shouldSyncFirstConfigRef.current = false;
             setIsReady(true);
           }
@@ -260,6 +265,7 @@ const Index = () => {
             setChildren(recoverableLocalState.children);
             setHomeScene(recoverableLocalState.homeScene);
             setSetupComplete(recoverableLocalState.setupComplete);
+            setCloudConfigSyncError(null);
             setView('import');
             setIsReady(true);
           }
@@ -280,6 +286,7 @@ const Index = () => {
             setActiveChildId(null);
             setSetupComplete(false);
             setHomeScene(recoverableLocalState.homeScene);
+            setCloudConfigSyncError(null);
             setView('recovery');
             setIsReady(true);
           }
@@ -302,6 +309,7 @@ const Index = () => {
 
         if (isMounted) {
           setBootstrapError(null);
+          setCloudConfigSyncError(null);
           setSetupComplete(recoverableLocalState.setupComplete);
           setHomeScene(recoverableLocalState.homeScene);
           setView(recoverableLocalState.setupComplete ? 'home' : 'setup');
@@ -314,6 +322,7 @@ const Index = () => {
         if (!isMounted) return;
 
         setBootstrapError(null);
+        setCloudConfigSyncError(null);
         setChildren(cloudState.children);
         setHomeScene(cloudState.homeScene);
         setSetupComplete(cloudState.children.length > 0);
@@ -324,6 +333,7 @@ const Index = () => {
             homeScene: cloudState.homeScene,
             setupComplete: true,
           });
+          configSyncInFlightRef.current = null;
           shouldSyncFirstConfigRef.current = false;
         } else if (authStatus === 'signed_in') {
           shouldSyncFirstConfigRef.current = true;
@@ -340,6 +350,7 @@ const Index = () => {
         setSetupComplete(false);
         setHomeScene('bike');
         setBootstrapError(cloudLoadError);
+        setCloudConfigSyncError(null);
         setView('bootstrap-error');
         setIsReady(true);
         return;
@@ -347,6 +358,7 @@ const Index = () => {
 
       if (isMounted) {
         setBootstrapError(null);
+        setCloudConfigSyncError(null);
         setChildren(createSetupChildren());
         setActiveChildId(null);
         setSetupComplete(false);
@@ -392,8 +404,12 @@ const Index = () => {
       return;
     }
 
+    if (configSyncInFlightRef.current === householdConfigSignature) {
+      return;
+    }
+
     shouldSyncFirstConfigRef.current = false;
-    lastSyncedConfigRef.current = householdConfigSignature;
+    configSyncInFlightRef.current = householdConfigSignature;
 
     void Promise.resolve(
       saveHouseholdConfigToCloud({
@@ -402,10 +418,30 @@ const Index = () => {
         homeScene,
         removeMissingChildren: true,
       })
-    ).catch((error) => {
-      console.warn('Could not sync household configuration to cloud.', error);
-    });
-  }, [authStatus, children, homeScene, household, householdConfigSignature, householdStatus, isReady, setupComplete]);
+    )
+      .then(() => {
+        lastSyncedConfigRef.current = householdConfigSignature;
+        configSyncInFlightRef.current = null;
+        setCloudConfigSyncError(null);
+      })
+      .catch((error) => {
+        configSyncInFlightRef.current = null;
+        setCloudConfigSyncError(
+          error instanceof Error ? error.message : 'Could not save this family setup to the cloud yet.'
+        );
+        console.warn('Could not sync household configuration to cloud.', error);
+      });
+  }, [
+    authStatus,
+    children,
+    cloudConfigSyncRetryTick,
+    homeScene,
+    household,
+    householdConfigSignature,
+    householdStatus,
+    isReady,
+    setupComplete,
+  ]);
 
   useEffect(() => {
     const timer = window.setInterval(() => {
@@ -595,11 +631,13 @@ const Index = () => {
               setHomeScene(cloudState.homeScene);
               setSetupComplete(cloudState.children.length > 0);
               setView(cloudState.children.length > 0 ? 'home' : 'setup');
+              setCloudConfigSyncError(null);
               lastSyncedConfigRef.current = serializeHouseholdConfig({
                 children: cloudState.children,
                 homeScene: cloudState.homeScene,
                 setupComplete: cloudState.children.length > 0,
               });
+              configSyncInFlightRef.current = null;
               shouldSyncFirstConfigRef.current = false;
             })
             .catch((error) => {
@@ -617,6 +655,7 @@ const Index = () => {
           setChildren(createSetupChildren());
           setSetupComplete(false);
           setHomeScene('bike');
+          setCloudConfigSyncError(null);
           setView('setup');
           setImportError(null);
           shouldSyncFirstConfigRef.current = true;
@@ -649,9 +688,19 @@ const Index = () => {
           children={children}
           signedInEmail={authStatus === 'signed_in' ? user?.email ?? null : null}
           onSignOut={authStatus === 'signed_in' ? () => void signOut() : undefined}
+          cloudSyncError={cloudConfigSyncError}
+          onRetryCloudSync={
+            authStatus === 'signed_in'
+              ? () => {
+                  setCloudConfigSyncError(null);
+                  setCloudConfigSyncRetryTick((count) => count + 1);
+                }
+              : undefined
+          }
           onChange={setChildren}
           onComplete={(configuredChildren) => {
             setChildren(configuredChildren);
+            setCloudConfigSyncError(null);
             setSetupComplete(true);
             setView('home');
           }}
@@ -679,6 +728,11 @@ const Index = () => {
         <ParentSettings
           children={children}
           homeScene={homeScene}
+          cloudConfigSyncError={cloudConfigSyncError}
+          onRetryCloudConfigSync={() => {
+            setCloudConfigSyncError(null);
+            setCloudConfigSyncRetryTick((count) => count + 1);
+          }}
           onChange={setChildren}
           onHomeSceneChange={setHomeScene}
           onRestartSetup={restartSetup}

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -124,10 +124,14 @@ vi.mock("@/components/ParentSettings", () => ({
     onBack,
     onRestartSetup,
     onResetAppData,
+    cloudConfigSyncError,
+    onRetryCloudConfigSync,
   }: {
     onBack: () => void;
     onRestartSetup: () => void;
     onResetAppData: () => void;
+    cloudConfigSyncError?: string | null;
+    onRetryCloudConfigSync?: () => void;
   }) => (
     <div>
       <button type="button" onClick={onBack}>
@@ -139,6 +143,10 @@ vi.mock("@/components/ParentSettings", () => ({
       <button type="button" onClick={onResetAppData}>
         reset-app-data
       </button>
+      <div data-testid="parent-cloud-sync-error">{cloudConfigSyncError ?? ""}</div>
+      <button type="button" onClick={onRetryCloudConfigSync}>
+        retry-parent-cloud-sync
+      </button>
     </div>
   ),
 }));
@@ -146,15 +154,23 @@ vi.mock("@/components/ParentSettings", () => ({
 vi.mock("@/components/InitialSetup", () => ({
   InitialSetup: ({
     children,
+    cloudSyncError,
+    onRetryCloudSync,
     onChange,
     onComplete,
   }: {
     children: Child[];
+    cloudSyncError?: string | null;
+    onRetryCloudSync?: () => void;
     onChange?: (children: Child[]) => void;
     onComplete: (children: Child[]) => void;
   }) => (
     <div>
       <div data-testid="setup-child-count">{children.length}</div>
+      <div data-testid="setup-cloud-sync-error">{cloudSyncError ?? ""}</div>
+      <button type="button" onClick={onRetryCloudSync}>
+        retry-setup-cloud-sync
+      </button>
       <button
         type="button"
         onClick={() =>
@@ -783,6 +799,75 @@ describe("Index", () => {
           removeMissingChildren: true,
         })
       );
+    });
+  });
+
+  it("does not treat a failed cloud config write as already synced", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [],
+    });
+    saveHouseholdConfigToCloud
+      .mockRejectedValueOnce(new Error("Row-level security blocked child_profiles insert"))
+      .mockResolvedValueOnce(undefined);
+
+    render(<Index />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "recovery-start-fresh" }));
+    fireEvent.click(await screen.findByRole("button", { name: "sync-draft-child" }));
+
+    await waitFor(() => {
+      expect(saveHouseholdConfigToCloud.mock.calls.length).toBeGreaterThan(1);
+    });
+
+    expect(
+      saveHouseholdConfigToCloud.mock.calls.some(
+        ([input]) =>
+          input.children?.some((child: { name?: string }) => child.name === "Elie")
+      )
+    ).toBe(true);
+
+    expect(screen.getByRole("button", { name: "retry-setup-cloud-sync" })).toBeInTheDocument();
+  });
+
+  it("lets a parent manually retry household setup cloud sync from setup", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "house-1",
+      name: "Routine Stars Family",
+      timezone: "Europe/Madrid",
+      homeScene: "kite",
+      createdByUserId: "user-1",
+      createdAt: "2026-04-20T10:00:00Z",
+      updatedAt: "2026-04-20T10:00:00Z",
+    };
+    loadCloudHouseholdState.mockResolvedValue({
+      homeScene: "kite",
+      children: [],
+    });
+    saveHouseholdConfigToCloud.mockResolvedValue(undefined);
+
+    render(<Index />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "recovery-start-fresh" }));
+    fireEvent.click(screen.getByRole("button", { name: "retry-setup-cloud-sync" }));
+
+    await waitFor(() => {
+      expect(saveHouseholdConfigToCloud).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- only mark setup config as synced after the cloud write actually succeeds
- keep failed signed-in setup writes retryable instead of silently treating them as done
- show the cloud sync failure in setup and parent settings with a retry action

## Testing
- npm test -- --run src/test/index.test.tsx src/test/cloudHouseholdWrite.test.ts
- npm run build

Closes #112