### PR TITLE
Annotate cloud save failure steps

### DIFF
--- a/src/lib/data/cloud-household-write.ts
+++ b/src/lib/data/cloud-household-write.ts
@@ -13,6 +13,17 @@ const findTemplateForTask = (
 ) =>
   TASK_CATALOG[routine].find((task) => task.title === title && task.icon === icon) ?? null;
 
+const describeStepError = (step: string, error: unknown) => {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'object' && error !== null && 'message' in error
+        ? String(error.message)
+        : 'Unknown cloud sync failure.';
+
+  return new Error(`${step} Failed: ${message}`);
+};
+
 export const saveHouseholdConfigToCloud = async (input: {
   household: HouseholdRecord;
   children: Child[];
@@ -28,53 +39,86 @@ export const saveHouseholdConfigToCloud = async (input: {
   const childRepository = new SupabaseChildProfileRepository(supabase);
   const routineRepository = new SupabaseRoutineRepository(supabase);
 
-  await householdRepository.updateHomeScene(input.household.id, input.homeScene);
+  try {
+    await householdRepository.updateHomeScene(input.household.id, input.homeScene);
+  } catch (error) {
+    throw describeStepError('Updating household home scene.', error);
+  }
 
   if (input.removeMissingChildren) {
-    const existingChildren = await childRepository.listByHousehold(input.household.id);
+    let existingChildren;
+    try {
+      existingChildren = await childRepository.listByHousehold(input.household.id);
+    } catch (error) {
+      throw describeStepError('Loading existing child profiles.', error);
+    }
     const localChildIds = new Set(input.children.map((child) => child.id));
 
-    await Promise.all(
-      existingChildren
-        .filter((childProfile) => !localChildIds.has(childProfile.id))
-        .map((childProfile) => childRepository.remove(childProfile.id))
-    );
+    try {
+      await Promise.all(
+        existingChildren
+          .filter((childProfile) => !localChildIds.has(childProfile.id))
+          .map((childProfile) => childRepository.remove(childProfile.id))
+      );
+    } catch (error) {
+      throw describeStepError('Removing old cloud child profiles.', error);
+    }
   }
 
   for (const child of input.children) {
-    const savedChild = await childRepository.upsert({
-      id: child.id,
-      householdId: input.household.id,
-      name: child.name,
-      age: child.age ?? null,
-      ageBucket: child.ageBucket ?? null,
-      avatarAnimal: child.avatarAnimal ?? null,
-      avatarSeed: child.avatarSeed ?? null,
-    });
+    let savedChild;
+    try {
+      savedChild = await childRepository.upsert({
+        id: child.id,
+        householdId: input.household.id,
+        name: child.name,
+        age: child.age ?? null,
+        ageBucket: child.ageBucket ?? null,
+        avatarAnimal: child.avatarAnimal ?? null,
+        avatarSeed: child.avatarSeed ?? null,
+      });
+    } catch (error) {
+      throw describeStepError(`Upserting child profile "${child.name}".`, error);
+    }
 
     for (const routineType of ['morning', 'evening'] as const) {
-      const routine = await routineRepository.upsertRoutine({
-        id: `${savedChild.id}-${routineType}`,
-        childProfileId: savedChild.id,
-        type: routineType,
-        startTime: child.schedule?.[routineType].start ?? (routineType === 'morning' ? '07:00' : '17:00'),
-        endTime: child.schedule?.[routineType].end ?? (routineType === 'morning' ? '09:00' : '20:00'),
-      });
+      let routine;
+      try {
+        routine = await routineRepository.upsertRoutine({
+          id: `${savedChild.id}-${routineType}`,
+          childProfileId: savedChild.id,
+          type: routineType,
+          startTime: child.schedule?.[routineType].start ?? (routineType === 'morning' ? '07:00' : '17:00'),
+          endTime: child.schedule?.[routineType].end ?? (routineType === 'morning' ? '09:00' : '20:00'),
+        });
+      } catch (error) {
+        throw describeStepError(
+          `Upserting the ${routineType} routine for "${child.name}".`,
+          error
+        );
+      }
 
-      await routineRepository.replaceRoutineTasks({
-        routineId: routine.id,
-        tasks: child[routineType].map((task, index) => {
-          const matchedTemplate = findTemplateForTask(task.title, task.icon, routineType);
+      try {
+        await routineRepository.replaceRoutineTasks({
+          routineId: routine.id,
+          tasks: child[routineType].map((task, index) => {
+            const matchedTemplate = findTemplateForTask(task.title, task.icon, routineType);
 
-          return {
-            taskTemplateId: matchedTemplate?.id ?? null,
-            customTitle: matchedTemplate ? null : task.title,
-            customIcon: matchedTemplate ? null : task.icon,
-            sortOrder: index,
-            isArchived: false,
-          };
-        }),
-      });
+            return {
+              taskTemplateId: matchedTemplate?.id ?? null,
+              customTitle: matchedTemplate ? null : task.title,
+              customIcon: matchedTemplate ? null : task.icon,
+              sortOrder: index,
+              isArchived: false,
+            };
+          }),
+        });
+      } catch (error) {
+        throw describeStepError(
+          `Saving ${routineType} routine tasks for "${child.name}".`,
+          error
+        );
+      }
     }
   }
 };

--- a/src/test/cloudHouseholdWrite.test.ts
+++ b/src/test/cloudHouseholdWrite.test.ts
@@ -168,4 +168,34 @@ describe('saveHouseholdConfigToCloud', () => {
 
     expect(removeChildProfile).toHaveBeenCalledWith('child-stale');
   });
+
+  it('annotates the failing cloud save step when child profile upsert fails', async () => {
+    upsertChildProfile.mockRejectedValueOnce(new Error('new row violates row-level security policy'));
+
+    await expect(
+      saveHouseholdConfigToCloud({
+        household: {
+          id: 'house-1',
+          name: 'Routine Stars Family',
+          timezone: 'Europe/Madrid',
+          homeScene: 'bike',
+          createdByUserId: 'user-1',
+          createdAt: '2026-04-20T10:00:00Z',
+          updatedAt: '2026-04-20T10:00:00Z',
+        },
+        homeScene: 'school',
+        children: [
+          {
+            id: 'child-1',
+            name: 'Mila',
+            morning: [],
+            evening: [],
+          },
+        ],
+        removeMissingChildren: true,
+      })
+    ).rejects.toThrow(
+      'Upserting child profile "Mila". Failed: new row violates row-level security policy'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- wrap cloud household save steps with descriptive error messages
- include child/routine/task context in failures instead of a generic save message
- add regression coverage for child profile upsert failures

## Validation
- npm test -- --run src/test/cloudHouseholdWrite.test.ts src/test/index.test.tsx
- npm run build

Closes #120