### PR TITLE
Configure Supabase client for PKCE magic links

### DIFF
--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -119,6 +119,9 @@ export const getSupabaseClient = () => {
   if (!supabaseClient) {
     supabaseClient = createClient(supabaseUrl, supabaseAnonKey, {
       auth: {
+        // PKCE is the recommended flow for magic links in SPAs.
+        // We still explicitly finalize the callback in `finalizeSupabaseAuthFromUrl`.
+        flowType: 'pkce',
         persistSession: true,
         autoRefreshToken: true,
       },

--- a/src/test/supabaseClient.test.ts
+++ b/src/test/supabaseClient.test.ts
@@ -3,15 +3,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const exchangeCodeForSession = vi.fn();
 const verifyOtp = vi.fn();
 const setSession = vi.fn();
+const createClient = vi.fn();
 
 vi.mock('@supabase/supabase-js', () => ({
-  createClient: () => ({
-    auth: {
-      exchangeCodeForSession,
-      verifyOtp,
-      setSession,
-    },
-  }),
+  createClient: (...args: unknown[]) => {
+    createClient(...args);
+    return {
+      auth: {
+        exchangeCodeForSession,
+        verifyOtp,
+        setSession,
+      },
+    };
+  },
 }));
 
 describe('supabase client helpers', () => {
@@ -20,8 +24,25 @@ describe('supabase client helpers', () => {
     exchangeCodeForSession.mockReset();
     verifyOtp.mockReset();
     setSession.mockReset();
+    createClient.mockReset();
     vi.stubEnv('VITE_SUPABASE_URL', 'https://example.supabase.co');
     vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'anon-key');
+  });
+
+  it('configures the supabase client for PKCE auth', async () => {
+    const { getSupabaseClient } = await import('@/lib/supabase/client');
+
+    getSupabaseClient();
+
+    expect(createClient).toHaveBeenCalledWith(
+      'https://example.supabase.co',
+      'anon-key',
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          flowType: 'pkce',
+        }),
+      })
+    );
   });
 
   it('targets the dedicated auth callback route', async () => {


### PR DESCRIPTION
## Why
Magic-link sign-in for this SPA should run with PKCE. We already finalize auth on `/auth/callback`, but the client itself should be configured for PKCE to avoid mismatched flows.

## What
- Set `auth.flowType = 'pkce'` in the Supabase client
- Add a unit test asserting PKCE configuration

## Verification
`npm test`
