### PR TITLE
Fix GitHub Pages auth callback route (SPA 404 fallback)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+supabase/.temp/
 
 # Editor directories and files
 .vscode/*

--- a/index.html
+++ b/index.html
@@ -17,6 +17,35 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@Lovable" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+
+    <script>
+      // Restore GitHub Pages SPA routes that were rewritten by public/404.html.
+      (function () {
+        var url = new URL(window.location.href);
+        var ghPath = url.searchParams.get("__gh_path__");
+        if (!ghPath) return;
+
+        var ghSearch = url.searchParams.get("__gh_search__") || "";
+        var ghHash = url.searchParams.get("__gh_hash__") || "";
+
+        url.searchParams.delete("__gh_path__");
+        url.searchParams.delete("__gh_search__");
+        url.searchParams.delete("__gh_hash__");
+
+        var remainingSearch = url.searchParams.toString();
+        remainingSearch = remainingSearch ? "?" + remainingSearch : "";
+
+        var restoredPath = decodeURIComponent(ghPath);
+        var restoredSearch = ghSearch ? decodeURIComponent(ghSearch) : "";
+        var restoredHash = ghHash ? decodeURIComponent(ghHash) : "";
+
+        if (restoredPath.charAt(0) !== "/") restoredPath = "/" + restoredPath;
+
+        // Keep the repo base (`/routine-stars/`) and replace the rest.
+        var base = window.location.pathname.replace(/\/?$/, "");
+        window.history.replaceState(null, "", base + restoredPath + restoredSearch + restoredHash + remainingSearch);
+      })();
+    </script>
   </head>
 
   <body>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Routine Stars</title>
+    <script>
+      // GitHub Pages serves 404.html for all unknown routes. This preserves the
+      // original path by rewriting it into query params, then index.html
+      // restores it via history.replaceState before the SPA boots.
+      (function () {
+        var l = window.location;
+        var repoBase = "/routine-stars";
+
+        // Strip repo base prefix if present.
+        var path = l.pathname.indexOf(repoBase + "/") === 0 ? l.pathname.slice(repoBase.length) : l.pathname;
+
+        // Preserve path + existing query/hash.
+        var redirectUrl =
+          repoBase +
+          "/?__gh_path__=" +
+          encodeURIComponent(path) +
+          "&__gh_search__=" +
+          encodeURIComponent(l.search || "") +
+          "&__gh_hash__=" +
+          encodeURIComponent(l.hash || "");
+
+        l.replace(redirectUrl);
+      })();
+    </script>
+  </head>
+  <body></body>
+</html>
+


### PR DESCRIPTION
## Why
GitHub Pages returns a hard 404 for deep links like `/routine-stars/auth/callback`, which breaks Supabase magic-link sign-in and any direct navigation.

## What
- Add `public/404.html` redirect shim for GitHub Pages
- Add `index.html` bootstrap script to restore the original SPA route
- Ignore `supabase/.temp/`

## Verification
- `npm test`
