### PR TITLE
Improve create-account UX (parent name + clearer CTA)

### DIFF
--- a/src/components/AccountSettingsCard.tsx
+++ b/src/components/AccountSettingsCard.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { CheckCircle2, Cloud, CloudOff, LoaderCircle, LogIn, LogOut, Mail, RefreshCcw, ShieldCheck, UserRoundPlus } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { CheckCircle2, Cloud, CloudOff, LoaderCircle, LogIn, LogOut, Mail, RefreshCcw, ShieldCheck, UserRound, UserRoundPlus } from 'lucide-react';
 import { useAuth } from '@/lib/auth/use-auth';
 
 type AuthMode = 'signin' | 'signup';
@@ -18,16 +18,37 @@ export const AccountSettingsCard = () => {
     signOut,
   } = useAuth();
   const [mode, setMode] = useState<AuthMode>('signin');
+  const [parentName, setParentName] = useState('');
   const [email, setEmail] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [emailSentTo, setEmailSentTo] = useState<string | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const isCreateMode = mode === 'signup';
+  const trimmedEmail = useMemo(() => email.trim(), [email]);
+  const trimmedParentName = useMemo(() => parentName.trim(), [parentName]);
+
+  const primaryLabel = isCreateMode ? 'Create account' : 'Send sign-in link';
+  const canSubmit =
+    !isSubmitting &&
+    status !== 'loading' &&
+    Boolean(trimmedEmail) &&
+    (!isCreateMode || Boolean(trimmedParentName)) &&
+    !emailSentTo;
 
   const handleSubmit = async () => {
     setIsSubmitting(true);
     clearError();
+    setValidationError(null);
     setEmailSentTo(null);
-    const trimmedEmail = email.trim();
-    const ok = await sendEmailLink(trimmedEmail, mode);
+
+    if (isCreateMode && !trimmedParentName) {
+      setValidationError('Please enter the parent name before creating the account.');
+      setIsSubmitting(false);
+      return;
+    }
+
+    const ok = await sendEmailLink(trimmedEmail, mode, isCreateMode ? { parentName: trimmedParentName } : undefined);
     if (ok) {
       setEmailSentTo(trimmedEmail);
     }
@@ -135,6 +156,7 @@ export const AccountSettingsCard = () => {
                 type="button"
                 onClick={() => {
                   clearError();
+                  setValidationError(null);
                   setEmailSentTo(null);
                   setMode(value);
                 }}
@@ -148,6 +170,23 @@ export const AccountSettingsCard = () => {
           </div>
 
           <div className="mt-5">
+            {isCreateMode && (
+              <label className="block text-sm font-semibold text-muted-foreground">
+                Parent name
+                <div className="mt-2 flex items-center gap-3 rounded-2xl bg-muted px-4 py-3">
+                  <UserRound size={18} className="text-muted-foreground" />
+                  <input
+                    type="text"
+                    value={parentName}
+                    onChange={(event) => setParentName(event.target.value)}
+                    className="w-full bg-transparent text-base font-medium text-foreground outline-none"
+                    placeholder="e.g. Dora"
+                    autoComplete="name"
+                  />
+                </div>
+              </label>
+            )}
+
             <label className="text-sm font-semibold text-muted-foreground">
               Parent email
               <div className="mt-2 flex items-center gap-3 rounded-2xl bg-muted px-4 py-3">
@@ -158,6 +197,7 @@ export const AccountSettingsCard = () => {
                   onChange={(event) => setEmail(event.target.value)}
                   className="w-full bg-transparent text-base font-medium text-foreground outline-none"
                   placeholder="parent@example.com"
+                  autoComplete="email"
                 />
               </div>
             </label>
@@ -184,6 +224,12 @@ export const AccountSettingsCard = () => {
             </div>
           )}
 
+          {validationError && (
+            <div className="mt-4 rounded-2xl border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+              {validationError}
+            </div>
+          )}
+
           {error && (
             <div className="mt-4 rounded-2xl border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
               {error}
@@ -193,12 +239,25 @@ export const AccountSettingsCard = () => {
           <button
             type="button"
             onClick={() => void handleSubmit()}
-            disabled={isSubmitting || !email.trim() || status === 'loading'}
+            disabled={!canSubmit}
             className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-full bg-primary px-5 py-3 text-sm font-bold text-primary-foreground shadow-button transition-transform active:translate-y-0.5 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isSubmitting || status === 'loading' ? <LoaderCircle size={16} className="animate-spin" /> : <LogIn size={16} />}
-            {mode === 'signin' ? 'Email me a sign-in link' : 'Email me a sign-up link'}
+            {emailSentTo ? 'Email sent' : primaryLabel}
           </button>
+
+          {emailSentTo && (
+            <button
+              type="button"
+              onClick={() => {
+                setEmailSentTo(null);
+                void handleSubmit();
+              }}
+              className="mt-3 inline-flex w-full items-center justify-center rounded-full border border-border bg-background px-5 py-3 text-sm font-bold text-foreground transition-colors hover:border-primary/40 hover:text-primary"
+            >
+              Resend email link
+            </button>
+          )}
         </div>
       )}
     </section>

--- a/src/lib/auth/auth-context.tsx
+++ b/src/lib/auth/auth-context.tsx
@@ -15,7 +15,7 @@ export interface AuthContextValue {
   householdStatus: HouseholdStatus;
   household: HouseholdRecord | null;
   error: string | null;
-  sendEmailLink: (email: string, mode: AuthLinkMode) => Promise<boolean>;
+  sendEmailLink: (email: string, mode: AuthLinkMode, options?: { parentName?: string }) => Promise<boolean>;
   retryHousehold: () => Promise<void>;
   signOut: () => Promise<void>;
   clearError: () => void;
@@ -111,7 +111,7 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
       household,
       error,
       clearError: () => setError(null),
-      sendEmailLink: async (email, mode) => {
+      sendEmailLink: async (email, mode, options) => {
         const supabase = getSupabaseClient();
         if (!supabase) {
           setError('Supabase is not configured yet.');
@@ -123,6 +123,11 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
           options: {
             emailRedirectTo: getSupabaseEmailRedirectUrl(),
             shouldCreateUser: mode === 'signup',
+            // For new signups, keep a friendly parent name on the user metadata so
+            // we can name the first household without guessing from the email.
+            ...(mode === 'signup' && options?.parentName
+              ? { data: { parent_name: options.parentName.trim() } }
+              : {}),
           },
         });
 

--- a/src/lib/auth/household-bootstrap.ts
+++ b/src/lib/auth/household-bootstrap.ts
@@ -4,6 +4,14 @@ import type { HouseholdRecord } from '@/lib/data/models';
 import { getSupabaseClient } from '@/lib/supabase/client';
 
 const getSuggestedHouseholdName = (user: User) => {
+  const parentName = (user.user_metadata && (user.user_metadata as Record<string, unknown>).parent_name)
+    ? String((user.user_metadata as Record<string, unknown>).parent_name).trim()
+    : '';
+  if (parentName) {
+    const normalized = parentName.charAt(0).toUpperCase() + parentName.slice(1);
+    return `${normalized}'s Family`;
+  }
+
   const emailName = user.email?.split('@')[0]?.trim();
   if (!emailName) {
     return 'My Family';

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -518,16 +518,80 @@ const Index = () => {
   }, []);
 
   useEffect(() => {
-    const syncNow = () => setNow(new Date());
+    const refreshFromCloudIfSafe = async () => {
+      // Always keep time-based UI fresh.
+      setNow(new Date());
 
-    window.addEventListener('focus', syncNow);
-    document.addEventListener('visibilitychange', syncNow);
+      // Pull remote updates when:
+      // - signed in with a ready household
+      // - we're not currently editing setup/import flows
+      // - local state has no unsynced changes (so we won't clobber local edits)
+      if (
+        !isReady ||
+        authStatus !== 'signed_in' ||
+        householdStatus !== 'ready' ||
+        !household ||
+        view !== 'home'
+      ) {
+        return;
+      }
+
+      if (cloudConfigSyncStatus === 'saving' || configSyncInFlightRef.current) {
+        return;
+      }
+
+      // If local diverged from last known synced signature, do not overwrite it.
+      if (lastSyncedConfigRef.current && lastSyncedConfigRef.current !== householdConfigSignature) {
+        return;
+      }
+
+      try {
+        const cloudState = await loadCloudHouseholdState(household);
+        const nextSetupComplete = cloudState.children.length > 0;
+        const nextSignature = serializeHouseholdConfig({
+          children: cloudState.children,
+          homeScene: cloudState.homeScene,
+          setupComplete: nextSetupComplete,
+        });
+
+        // No change, nothing to do.
+        if (lastSyncedConfigRef.current === nextSignature) {
+          return;
+        }
+
+        setChildren(cloudState.children);
+        setHomeScene(cloudState.homeScene);
+        setSetupComplete(nextSetupComplete);
+        setView(nextSetupComplete ? 'home' : 'setup');
+        setCloudConfigSyncStatus(nextSetupComplete ? 'saved' : 'idle');
+        setCloudConfigSyncError(null);
+        lastSyncedConfigRef.current = nextSignature;
+      } catch (error) {
+        // Keep running with existing local state; cloud refresh can fail temporarily.
+        console.warn('Could not refresh cloud household state.', error);
+      }
+    };
+
+    const onFocus = () => {
+      void refreshFromCloudIfSafe();
+    };
+
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onFocus);
 
     return () => {
-      window.removeEventListener('focus', syncNow);
-      document.removeEventListener('visibilitychange', syncNow);
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onFocus);
     };
-  }, []);
+  }, [
+    authStatus,
+    cloudConfigSyncStatus,
+    household,
+    householdConfigSignature,
+    householdStatus,
+    isReady,
+    view,
+  ]);
 
   // Persist
   useEffect(() => {

--- a/src/test/accountSettingsCard.test.tsx
+++ b/src/test/accountSettingsCard.test.tsx
@@ -40,7 +40,9 @@ describe('AccountSettingsCard', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /create account/i }));
 
-    expect(screen.getByRole('button', { name: /email me a sign-up link/i })).toBeInTheDocument();
+    const createButtons = screen.getAllByRole('button', { name: /^create account$/i });
+    expect(createButtons.length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText(/parent name/i)).toBeInTheDocument();
     expect(screen.queryByPlaceholderText(/at least 6 characters/i)).toBeNull();
   });
 
@@ -48,13 +50,14 @@ describe('AccountSettingsCard', () => {
     render(<AccountSettingsCard />);
 
     fireEvent.click(screen.getByRole('button', { name: /create account/i }));
+    fireEvent.change(screen.getByPlaceholderText(/e\.g\. dora/i), { target: { value: 'Dora' } });
     fireEvent.change(screen.getByPlaceholderText(/parent@example.com/i), {
       target: { value: 'parent@example.com' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /email me a sign-up link/i }));
+    fireEvent.click(screen.getAllByRole('button', { name: /^create account$/i })[1]);
 
     await waitFor(() => {
-      expect(sendEmailLink).toHaveBeenCalledWith('parent@example.com', 'signup');
+      expect(sendEmailLink).toHaveBeenCalledWith('parent@example.com', 'signup', { parentName: 'Dora' });
     });
 
     expect(screen.getByText(/check your email/i)).toBeInTheDocument();

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -322,6 +322,65 @@ describe("Index", () => {
     authState.signOut.mockReset();
   });
 
+  it("refreshes the signed-in home view from cloud on focus when there are no local unsynced changes", async () => {
+    authState.status = "signed_in";
+    authState.user = { id: "user-1", email: "parent@example.com" };
+    authState.householdStatus = "ready";
+    authState.household = {
+      id: "household-1",
+      name: "Test Family",
+      timezone: "UTC",
+      homeScene: "bike",
+      createdByUserId: "user-1",
+      createdAt: "now",
+      updatedAt: "now",
+    };
+
+    const firstCloudChildren: Child[] = [
+      {
+        id: "child-1",
+        name: "Child 1",
+        morning: [],
+        evening: [],
+        avatarSeed: "child-1",
+      } as Child,
+      {
+        id: "child-2",
+        name: "Child 2",
+        morning: [],
+        evening: [],
+        avatarSeed: "child-2",
+      } as Child,
+    ];
+
+    const secondCloudChildren: Child[] = [
+      ...firstCloudChildren,
+      {
+        id: "child-3",
+        name: "Child 3",
+        morning: [],
+        evening: [],
+        avatarSeed: "child-3",
+      } as Child,
+    ];
+
+    loadCloudHouseholdState.mockResolvedValueOnce({ homeScene: "bike", children: firstCloudChildren });
+    loadCloudHouseholdState.mockResolvedValueOnce({ homeScene: "bike", children: secondCloudChildren });
+
+    render(<Index />);
+
+    // Initial bootstrap should render home with 2 children.
+    await waitFor(() => {
+      expect(screen.getByTestId("child-count").textContent).toBe("2");
+    });
+
+    fireEvent.focus(window);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("child-count").textContent).toBe("3");
+    });
+  });
+
   it("prefers cloud progress when local storage is from a previous day", async () => {
     authState.status = "signed_in";
     authState.user = { id: "user-1", email: "parent@example.com" };


### PR DESCRIPTION
## Why
Create-account UX was confusing:
- Primary button remained active after the email was sent
- Signup looked identical to sign-in

Cross-device edits were also confusing:
- Device B would not automatically refresh cloud changes made on Device A unless the page was reloaded.

## What
- Add required `Parent name` field for create-account
- Change primary CTA copy to `Create account` / `Send sign-in link`
- Disable primary CTA after sending and show a resend option
- Store `parent_name` in Supabase user metadata on signup and use it to name the first household
- Refresh signed-in home state from cloud on browser focus when there are no local unsynced edits

## Verification
- `npm test`
