### PR TITLE
Fix cross-device split state by selecting a stable household

### DIFF
--- a/src/lib/auth/household-bootstrap.ts
+++ b/src/lib/auth/household-bootstrap.ts
@@ -51,7 +51,7 @@ export const ensureHousehold = async (user: User): Promise<HouseholdRecord> => {
   }
 
   const repository = new SupabaseHouseholdRepository(supabase);
-  const currentHousehold = await repository.getCurrentHousehold();
+  const currentHousehold = await repository.getCurrentHousehold(user.id);
   if (currentHousehold) {
     return currentHousehold;
   }

--- a/src/lib/data/repositories.ts
+++ b/src/lib/data/repositories.ts
@@ -10,7 +10,7 @@ import type {
 } from './models';
 
 export interface HouseholdRepository {
-  getCurrentHousehold(): Promise<HouseholdRecord | null>;
+  getCurrentHousehold(userId: string): Promise<HouseholdRecord | null>;
   createInitialHousehold(input: {
     householdName: string;
     timezone: string;

--- a/src/lib/data/supabase-household-repository.ts
+++ b/src/lib/data/supabase-household-repository.ts
@@ -39,12 +39,16 @@ const mapMember = (row: Record<string, unknown>): HouseholdMemberRecord => ({
 export class SupabaseHouseholdRepository implements HouseholdRepository {
   constructor(private readonly supabase: SupabaseClient) {}
 
-  async getCurrentHousehold() {
+  async getCurrentHousehold(userId: string) {
+    // IMPORTANT: a parent account should resolve to one stable household.
+    // If multiple households exist (due to earlier bugs or tests), we pick the
+    // oldest owner membership to avoid randomly switching households across devices.
     const { data, error } = await this.supabase
-      .from(HOUSEHOLDS_TABLE)
-      .select('*')
-      .order('updated_at', { ascending: false })
-      .order('created_at', { ascending: false })
+      .from(HOUSEHOLD_MEMBERS_TABLE)
+      .select('household:households(*)')
+      .eq('user_id', userId)
+      .eq('role', 'owner')
+      .order('created_at', { ascending: true })
       .limit(1)
       .maybeSingle();
 
@@ -52,7 +56,8 @@ export class SupabaseHouseholdRepository implements HouseholdRepository {
       throw error;
     }
 
-    return data ? mapHousehold(data) : null;
+    const householdRow = data && typeof data === 'object' && 'household' in data ? (data as any).household : null;
+    return householdRow ? mapHousehold(householdRow) : null;
   }
 
   async createInitialHousehold(input: { householdName: string; timezone: string; userId: string }) {

--- a/src/test/supabaseHouseholdRepository.test.ts
+++ b/src/test/supabaseHouseholdRepository.test.ts
@@ -8,49 +8,57 @@ const createSupabaseClient = (rpcResult: { data: unknown; error: unknown }, tabl
   }) as never;
 
 describe('SupabaseHouseholdRepository', () => {
-  it('prefers the most recently updated household when more than one is visible', async () => {
+  it('selects the oldest owner membership household for stable cross-device loads', async () => {
     const maybeSingle = vi.fn().mockResolvedValue({
       data: {
-        id: 'house-new',
-        name: "Dora's Family",
-        timezone: 'Europe/Madrid',
-        home_scene: 'kite',
-        created_by_user_id: 'user-1',
-        created_at: '2026-05-05T12:00:00Z',
-        updated_at: '2026-05-05T13:00:00Z',
+        household: {
+          id: 'house-old',
+          name: "Dora's Family",
+          timezone: 'Europe/Madrid',
+          home_scene: 'bike',
+          created_by_user_id: 'user-1',
+          created_at: '2026-05-01T12:00:00Z',
+          updated_at: '2026-05-01T12:00:00Z',
+        },
       },
       error: null,
     });
     const limit = vi.fn(() => ({
       maybeSingle,
     }));
-    const orderCreatedAt = vi.fn(() => ({
+    const order = vi.fn(() => ({
       limit,
     }));
-    const orderUpdatedAt = vi.fn(() => ({
-      order: orderCreatedAt,
+    const eqRole = vi.fn(() => ({
+      order,
+    }));
+    const eqUser = vi.fn(() => ({
+      eq: eqRole,
+    }));
+    const select = vi.fn(() => ({
+      eq: eqUser,
     }));
 
     const repository = new SupabaseHouseholdRepository({
       from: vi.fn(() => ({
-        select: vi.fn(() => ({
-          order: orderUpdatedAt,
-        })),
+        select,
       })),
     } as never);
 
-    await expect(repository.getCurrentHousehold()).resolves.toEqual({
-      id: 'house-new',
+    await expect(repository.getCurrentHousehold('user-1')).resolves.toEqual({
+      id: 'house-old',
       name: "Dora's Family",
       timezone: 'Europe/Madrid',
-      homeScene: 'kite',
+      homeScene: 'bike',
       createdByUserId: 'user-1',
-      createdAt: '2026-05-05T12:00:00Z',
-      updatedAt: '2026-05-05T13:00:00Z',
+      createdAt: '2026-05-01T12:00:00Z',
+      updatedAt: '2026-05-01T12:00:00Z',
     });
 
-    expect(orderUpdatedAt).toHaveBeenCalledWith('updated_at', { ascending: false });
-    expect(orderCreatedAt).toHaveBeenCalledWith('created_at', { ascending: false });
+    expect(select).toHaveBeenCalledWith('household:households(*)');
+    expect(eqUser).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(eqRole).toHaveBeenCalledWith('role', 'owner');
+    expect(order).toHaveBeenCalledWith('created_at', { ascending: true });
     expect(limit).toHaveBeenCalledWith(1);
   });
 

--- a/supabase/migrations/20260518150000_single_household_per_owner.sql
+++ b/supabase/migrations/20260518150000_single_household_per_owner.sql
@@ -1,0 +1,43 @@
+-- Ensure we don't create multiple owner households for the same parent account.
+-- This migration is safe to apply even if duplicates exist; it prevents new ones.
+
+create unique index if not exists households_one_owner_per_user
+on public.households (created_by_user_id);
+
+create or replace function public.bootstrap_household(p_name text, p_timezone text)
+returns public.households
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  existing_household public.households;
+  created_household public.households;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  select *
+    into existing_household
+    from public.households h
+    where h.created_by_user_id = auth.uid()
+    order by h.created_at asc
+    limit 1;
+
+  if existing_household.id is not null then
+    return existing_household;
+  end if;
+
+  insert into public.households (name, timezone, created_by_user_id)
+  values (p_name, p_timezone, auth.uid())
+  returning * into created_household;
+
+  insert into public.household_members (household_id, user_id, role)
+  values (created_household.id, auth.uid(), 'owner')
+  on conflict (household_id, user_id) do nothing;
+
+  return created_household;
+end;
+$$;
+


### PR DESCRIPTION
## Why
Same email was showing different kids on different devices. Root cause: the app fetched an arbitrary household (limit 1) when multiple households existed for the account, so devices could attach to different households.

## What
- Make household selection deterministic: pick the oldest owner membership household for the logged-in user
- Add migration to prevent creating multiple owner households for the same user (`unique index` + bootstrap RPC returns existing)
- Update repository tests

## Follow-up (one-time cleanup)
If duplicates already exist, we should delete the empty household(s) or merge them.

## Verification
- `npm test`
