### PR TITLE
Fix: Save cloud household config during setup

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -474,10 +474,6 @@ const Index = () => {
       return;
     }
 
-    if (view === 'setup') {
-      return;
-    }
-
     if (lastSyncedConfigRef.current === null) {
       if (!shouldSyncFirstConfigRef.current) {
         lastSyncedConfigRef.current = householdConfigSignature;


### PR DESCRIPTION
## Why
In some signup/setup paths, kids/routines were never written to Supabase because background sync was disabled while `view === 'setup'`. That left the cloud household empty (0 kids) and other devices showed no profiles.

## What
- Always run the household config sync effect when signed-in (including during setup)

## Verification
- `npm test`
