### PR TITLE
Accounts: In-app account deletion (Edge Function)

### DIFF
--- a/docs/account-deletion.md
+++ b/docs/account-deletion.md
@@ -1,0 +1,58 @@
+# In-App Account Deletion (Supabase Email-Only Auth)
+
+## Goal
+
+Allow a parent to permanently delete their account **from inside the app** (App Store requirement) without exposing Supabase admin access or the Supabase dashboard to end users.
+
+## User Experience
+
+- Entry point: `Parent Settings` -> `Parent Account` card -> `Danger zone` -> `Delete account`.
+- Confirmation: modal confirm dialog, with a clear warning that deletion is permanent.
+- Result:
+  - The parent is signed out.
+  - Device-local cached data is cleared so stale profiles do not remain visible.
+
+## Architecture
+
+### Why an Edge Function
+
+Deleting a Supabase Auth user requires **admin privileges**. We do not (and must never) ship service role keys in the client.
+
+Instead, the client calls a Supabase **Edge Function** which:
+
+1. Verifies the caller is authenticated (JWT verification).
+2. Uses the **service role** key (server-side only) to delete the auth user.
+
+Because the database schema references `auth.users(id)` with `on delete cascade`, deleting the auth user automatically deletes the household and all related rows.
+
+### Security Model
+
+- Client sends `Authorization: Bearer <access_token>`.
+- Edge Function verifies the JWT using `SUPABASE_JWT_SECRET`.
+- The only user id deleted is the `sub` in the verified token.
+
+## Implementation
+
+### Edge Function
+
+- Path: `supabase/functions/delete-account/index.ts`
+- HTTP:
+  - `POST /functions/v1/delete-account`
+  - `OPTIONS` handled for CORS
+- Env required:
+  - `SUPABASE_URL`
+  - `SUPABASE_SERVICE_ROLE_KEY`
+  - `SUPABASE_JWT_SECRET`
+
+### Client
+
+- The app calls `POST ${VITE_SUPABASE_URL}/functions/v1/delete-account` using the current session access token.
+- On success the app clears `localStorage` key `routine_stars_data` and signs out.
+
+## Deployment Notes
+
+This repo includes the Edge Function source, but it must be deployed to Supabase:
+
+- `supabase functions deploy delete-account`
+- Ensure the required env vars are set for the function in Supabase.
+

--- a/src/components/AccountSettingsCard.tsx
+++ b/src/components/AccountSettingsCard.tsx
@@ -1,6 +1,17 @@
 import { useMemo, useState } from 'react';
-import { CheckCircle2, Cloud, CloudOff, LoaderCircle, LogIn, LogOut, Mail, RefreshCcw, ShieldCheck, UserRound, UserRoundPlus } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, Cloud, CloudOff, LoaderCircle, LogIn, LogOut, Mail, RefreshCcw, ShieldCheck, Trash2, UserRound, UserRoundPlus } from 'lucide-react';
 import { useAuth } from '@/lib/auth/use-auth';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 
 type AuthMode = 'signin' | 'signup';
 
@@ -16,11 +27,13 @@ export const AccountSettingsCard = () => {
     sendEmailLink,
     retryHousehold,
     signOut,
+    deleteAccount,
   } = useAuth();
   const [mode, setMode] = useState<AuthMode>('signin');
   const [parentName, setParentName] = useState('');
   const [email, setEmail] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const [emailSentTo, setEmailSentTo] = useState<string | null>(null);
   const [validationError, setValidationError] = useState<string | null>(null);
 
@@ -53,6 +66,19 @@ export const AccountSettingsCard = () => {
       setEmailSentTo(trimmedEmail);
     }
     setIsSubmitting(false);
+  };
+
+  const handleDeleteAccount = async () => {
+    setIsDeleting(true);
+    clearError();
+    const ok = await deleteAccount();
+    if (ok) {
+      setEmail('');
+      setParentName('');
+      setEmailSentTo(null);
+      setMode('signin');
+    }
+    setIsDeleting(false);
   };
 
   return (
@@ -105,6 +131,47 @@ export const AccountSettingsCard = () => {
               <LogOut size={16} />
               Sign out
             </button>
+
+            <div className="mt-6 rounded-2xl border border-destructive/20 bg-destructive/5 px-4 py-4">
+              <div className="flex items-center gap-2 text-destructive">
+                <AlertTriangle size={16} />
+                <p className="text-xs font-black uppercase tracking-[0.22em]">Danger zone</p>
+              </div>
+              <p className="mt-3 text-sm font-semibold text-foreground">Delete parent account</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                This permanently deletes the parent account and the synced household data. This cannot be undone.
+              </p>
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <button
+                    type="button"
+                    className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-full border border-destructive/30 bg-background px-4 py-2.5 text-sm font-bold text-destructive transition-colors hover:border-destructive/50"
+                  >
+                    <Trash2 size={16} />
+                    Delete account
+                  </button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>Delete this parent account?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      This will permanently remove your parent login and the synced family space. You will need to create a new account to use Routine Stars again.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => void handleDeleteAccount()}
+                      disabled={isDeleting}
+                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    >
+                      {isDeleting ? <LoaderCircle size={16} className="mr-2 inline animate-spin" /> : null}
+                      Delete account
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </div>
           </div>
 
           <div className="rounded-[28px] border border-border bg-background p-5">

--- a/src/lib/auth/auth-context.tsx
+++ b/src/lib/auth/auth-context.tsx
@@ -1,8 +1,14 @@
 import { createContext, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
 import type { HouseholdRecord } from '@/lib/data/models';
+import { clearLocalAppState } from '@/lib/storage/local-app-state';
 import { ensureHousehold } from './household-bootstrap';
-import { getSupabaseClient, getSupabaseEmailRedirectUrl, isSupabaseConfigured } from '@/lib/supabase/client';
+import {
+  getSupabaseClient,
+  getSupabaseEmailRedirectUrl,
+  getSupabaseProjectUrl,
+  isSupabaseConfigured,
+} from '@/lib/supabase/client';
 
 type AuthStatus = 'unavailable' | 'loading' | 'signed_out' | 'signed_in';
 type HouseholdStatus = 'idle' | 'loading' | 'ready' | 'error';
@@ -18,6 +24,7 @@ export interface AuthContextValue {
   sendEmailLink: (email: string, mode: AuthLinkMode, options?: { parentName?: string }) => Promise<boolean>;
   retryHousehold: () => Promise<void>;
   signOut: () => Promise<void>;
+  deleteAccount: () => Promise<boolean>;
   clearError: () => void;
   configured: boolean;
 }
@@ -151,7 +158,63 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
         if (signOutError) {
           setError(signOutError.message);
         } else {
+          clearLocalAppState();
           setError(null);
+        }
+      },
+      deleteAccount: async () => {
+        const supabase = getSupabaseClient();
+        if (!supabase) {
+          setError('Supabase is not configured yet.');
+          return false;
+        }
+
+        const {
+          data: { session: activeSession },
+          error: sessionError,
+        } = await supabase.auth.getSession();
+
+        if (sessionError) {
+          setError(sessionError.message);
+          return false;
+        }
+
+        const accessToken = activeSession?.access_token;
+        if (!accessToken) {
+          setError('You need to be signed in to delete this account.');
+          return false;
+        }
+
+        try {
+          const baseUrl = getSupabaseProjectUrl();
+          if (!baseUrl) {
+            setError('Supabase is not configured yet.');
+            return false;
+          }
+
+          const response = await fetch(new URL('functions/v1/delete-account', baseUrl).toString(), {
+            method: 'POST',
+            headers: {
+              authorization: `Bearer ${accessToken}`,
+              'content-type': 'application/json',
+            },
+            body: JSON.stringify({}),
+          });
+
+          if (!response.ok) {
+            const message = await response.text().catch(() => '');
+            setError(message.trim() || 'Could not delete the account. Please try again.');
+            return false;
+          }
+
+          // Clear device-local data even if sign-out errors, so the app resets cleanly.
+          clearLocalAppState();
+          await supabase.auth.signOut();
+          setError(null);
+          return true;
+        } catch (deleteError) {
+          setError(deleteError instanceof Error ? deleteError.message : 'Could not delete the account. Please try again.');
+          return false;
         }
       },
     }),

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -9,6 +9,8 @@ let supabaseClient: SupabaseClient | null = null;
 
 export const isSupabaseConfigured = () => isConfigured;
 
+export const getSupabaseProjectUrl = () => supabaseUrl;
+
 export const getSupabaseEmailRedirectUrl = () => {
   if (typeof window === 'undefined') {
     return undefined;

--- a/src/test/accountSettingsCard.test.tsx
+++ b/src/test/accountSettingsCard.test.tsx
@@ -1,9 +1,42 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AccountSettingsCard } from '@/components/AccountSettingsCard';
 
+// Radix AlertDialog uses portals + focus-locking that can be flaky in JSDOM.
+// For this unit test, we only care that the delete action exists and calls the hook.
+vi.mock('@/components/ui/alert-dialog', () => {
+  const passthrough =
+    (Tag: keyof JSX.IntrinsicElements = 'div') =>
+    ({ children, asChild: _asChild, ...props }: any) =>
+      React.createElement(Tag, props, children);
+
+  const AlertDialog = passthrough('div');
+  const AlertDialogTrigger = passthrough('div');
+  const AlertDialogContent = passthrough('div');
+  const AlertDialogHeader = passthrough('div');
+  const AlertDialogTitle = passthrough('div');
+  const AlertDialogDescription = passthrough('div');
+  const AlertDialogFooter = passthrough('div');
+  const AlertDialogCancel = passthrough('button');
+  const AlertDialogAction = passthrough('button');
+
+  return {
+    AlertDialog,
+    AlertDialogTrigger,
+    AlertDialogContent,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogCancel,
+    AlertDialogAction,
+  };
+});
+
 const sendEmailLink = vi.fn();
 const signOut = vi.fn();
+const deleteAccount = vi.fn();
 const clearError = vi.fn();
 const retryHousehold = vi.fn();
 const authState = {
@@ -17,6 +50,7 @@ const authState = {
   sendEmailLink,
   retryHousehold,
   signOut,
+  deleteAccount,
 };
 
 vi.mock('@/lib/auth/use-auth', () => ({
@@ -27,6 +61,7 @@ describe('AccountSettingsCard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sendEmailLink.mockResolvedValue(true);
+    deleteAccount.mockResolvedValue(true);
     authState.configured = true;
     authState.status = 'signed_out';
     authState.user = null;
@@ -76,5 +111,22 @@ describe('AccountSettingsCard', () => {
     expect(screen.getByText(/shared household schema appears to be missing/i)).toBeInTheDocument();
     expect(screen.getByText(/after the supabase household schema is applied/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it('offers account deletion when signed in', async () => {
+    authState.status = 'signed_in';
+    authState.user = { email: 'parent@example.com' };
+    authState.householdStatus = 'ready';
+    authState.household = { id: 'household-1', name: 'Test Family', timezone: 'UTC', created_by_user_id: 'user-1' };
+
+    render(<AccountSettingsCard />);
+
+    const deleteButtons = screen.getAllByRole('button', { name: /^delete account$/i });
+    expect(deleteButtons.length).toBeGreaterThanOrEqual(2);
+    fireEvent.click(deleteButtons[1]);
+
+    await waitFor(() => {
+      expect(deleteAccount).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,71 @@
+/// <reference lib="deno.ns" />
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.49.1';
+import { jwtVerify } from 'https://deno.land/x/jose@v5.6.3/jwt/verify.ts';
+
+const allowedOrigin = Deno.env.get('ALLOWED_ORIGIN') ?? '*';
+const corsHeaders = {
+  'access-control-allow-origin': allowedOrigin,
+  'access-control-allow-headers': 'authorization, x-client-info, apikey, content-type',
+  'access-control-allow-methods': 'POST, OPTIONS',
+};
+
+const unauthorized = (message = 'Unauthorized') =>
+  new Response(JSON.stringify({ error: message }), {
+    status: 401,
+    headers: { ...corsHeaders, 'content-type': 'application/json' },
+  });
+
+Deno.serve(async (request) => {
+  if (request.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  if (request.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { ...corsHeaders, 'content-type': 'application/json' },
+    });
+  }
+
+  const authHeader = request.headers.get('authorization') ?? '';
+  const token = authHeader.startsWith('Bearer ') ? authHeader.slice('Bearer '.length) : '';
+  if (!token) return unauthorized('Missing bearer token');
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+  const jwtSecret = Deno.env.get('SUPABASE_JWT_SECRET') ?? '';
+
+  if (!supabaseUrl || !serviceRoleKey || !jwtSecret) {
+    return new Response(JSON.stringify({ error: 'Server is not configured for account deletion.' }), {
+      status: 500,
+      headers: { ...corsHeaders, 'content-type': 'application/json' },
+    });
+  }
+
+  try {
+    const secretKey = new TextEncoder().encode(jwtSecret);
+    const { payload } = await jwtVerify(token, secretKey);
+    const userId = typeof payload.sub === 'string' ? payload.sub : null;
+    if (!userId) return unauthorized('Invalid token');
+
+    const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+
+    const { error } = await supabaseAdmin.auth.admin.deleteUser(userId);
+    if (error) {
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: 400,
+        headers: { ...corsHeaders, 'content-type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { ...corsHeaders, 'content-type': 'application/json' },
+    });
+  } catch (_error) {
+    return unauthorized('Invalid or expired token');
+  }
+});


### PR DESCRIPTION
Implements App Store–required in-app account deletion for email-only Supabase auth.

- Adds Supabase Edge Function `delete-account` (service-role deletion after JWT verification)
- Adds `deleteAccount()` to auth context and wires UI in Parent Account card
- Clears local cache on sign-out/deletion
- Adds docs `docs/account-deletion.md`
- Tests: `npm test`