### PR TITLE
Harden account sync + household bootstrap

### DIFF
--- a/docs/accounts-v2.md
+++ b/docs/accounts-v2.md
@@ -190,6 +190,11 @@ Why RPC:
 - It guarantees determinism (always the same household)
 - It avoids clients needing to piece together multiple writes under RLS
 
+Implementation note (current code):
+- The client attempts a direct-create path first (insert household + insert owner membership) for speed and debuggability.
+- If that fails due to missing function/table/policy errors, it falls back to the RPC (when present).
+- Long-term, we should prefer an atomic RPC so we never risk partial states.
+
 ---
 
 ## Data Ownership + RLS Model
@@ -237,8 +242,12 @@ Accounts v2 resolves this with a strict sync contract.
      - schedules (if separate)
    - write the snapshot into local cache with a `cloud_synced_at` timestamp
 2. **On any user edit:**
-   - write to Supabase first (or write-through with optimistic UI)
-   - on success, update local cache
+   - write-through with optimistic UI:
+     - update UI immediately
+     - persist to Supabase in the background
+   - if the household is still bootstrapping (common right after sign-in):
+     - queue the latest desired household config
+     - flush it automatically as soon as the household is ready
    - on failure, show error + retry (do not silently keep local-only edits as if saved)
 3. **While app is open:**
    - keep device updated via one of:
@@ -246,6 +255,9 @@ Accounts v2 resolves this with a strict sync contract.
      - polling every N seconds as a fallback
 4. **On return from background / tab refocus:**
    - do a quick “cloud refresh” (lightweight re-fetch of updated rows)
+
+Important UX rule:
+- Cloud refresh should run on both the **Home** view and the signed-in **Setup** view, so a brand-new device can “catch up” without a manual reload.
 
 ### Conflict rules (MVP)
 

--- a/memory.md
+++ b/memory.md
@@ -12,6 +12,7 @@ This file captures durable project decisions so future work stays aligned.
 - Goal: parent accounts with **email-only** sign in for MVP, and **cross-device sync** (iPad + laptop see the same household).
 - Supabase is the backend: Auth + Postgres + RLS.
 - Supabase auth storage must be safe on iPad Safari (Private mode can break `localStorage` writes); fall back to in-memory auth storage when needed.
+- Local app cache storage must be safe on iPad Safari too; use a safe storage wrapper that falls back to in-memory when `localStorage` rejects writes.
 - Canonical data model: **cloud is source of truth** for household configuration.
   - Local storage is an offline/cache layer and must never become a competing source of truth.
 - Deterministic household selection is required (no random “pick 1 household” queries).
@@ -37,6 +38,11 @@ This file captures durable project decisions so future work stays aligned.
 1. Make “create child / edit routines” reliably save to Supabase during setup.
 2. Make sync automatic across devices (realtime/polling + safe conflict rules).
 3. Implement in-app account deletion via a secure server-side action (Edge Function), not client-side service keys.
+
+## Sync Implementation Notes (Current)
+
+- Cloud config saves are queued while `householdStatus` is still bootstrapping; the latest desired config flushes automatically as soon as the household is ready.
+- Cloud refresh runs on both `home` and signed-in `setup` views (polling + realtime + focus/pageshow/visibility signals), so a new device can catch up without manual refresh.
 
 ## Account Deletion (Implemented)
 

--- a/src/lib/data/supabase-household-repository.ts
+++ b/src/lib/data/supabase-household-repository.ts
@@ -61,19 +61,8 @@ export class SupabaseHouseholdRepository implements HouseholdRepository {
   }
 
   async createInitialHousehold(input: { householdName: string; timezone: string; userId: string }) {
-    const { data, error } = await this.supabase.rpc('bootstrap_household', {
-      p_name: input.householdName,
-      p_timezone: input.timezone,
-    });
-
-    if (!error && data) {
-      return mapHousehold(data);
-    }
-
-    if (error && !shouldFallbackToDirectBootstrap(error)) {
-      throw error;
-    }
-
+    // Prefer direct inserts first for speed and debuggability. The RPC path is a
+    // legacy bootstrap option and can be slower on cold starts.
     const { data: householdRow, error: householdError } = await this.supabase
       .from(HOUSEHOLDS_TABLE)
       .insert({
@@ -85,6 +74,22 @@ export class SupabaseHouseholdRepository implements HouseholdRepository {
       .single();
 
     if (householdError) {
+      // If direct inserts fail due to missing tables/policies, try the bootstrap RPC.
+      if (shouldFallbackToDirectBootstrap(householdError)) {
+        const { data, error } = await this.supabase.rpc('bootstrap_household', {
+          p_name: input.householdName,
+          p_timezone: input.timezone,
+        });
+
+        if (!error && data) {
+          return mapHousehold(data);
+        }
+
+        if (error) {
+          throw error;
+        }
+      }
+
       throw householdError;
     }
 
@@ -98,11 +103,31 @@ export class SupabaseHouseholdRepository implements HouseholdRepository {
         role: 'owner',
       });
 
-    if (membershipError) {
-      throw membershipError;
+    if (!membershipError) {
+      return household;
     }
 
-    return household;
+    // Best-effort cleanup: avoid leaving an orphan household row behind.
+    await this.supabase.from(HOUSEHOLDS_TABLE).delete().eq('id', household.id);
+
+    // If membership insert failed with a bootstrap-style error, fall back to the RPC
+    // (when present) which can create membership atomically.
+    if (shouldFallbackToDirectBootstrap(membershipError)) {
+      const { data, error } = await this.supabase.rpc('bootstrap_household', {
+        p_name: input.householdName,
+        p_timezone: input.timezone,
+      });
+
+      if (!error && data) {
+        return mapHousehold(data);
+      }
+
+      if (error) {
+        throw error;
+      }
+    }
+
+    throw membershipError;
   }
 
   async listMembers(householdId: string) {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -464,7 +464,7 @@ const Index = () => {
         }
       }
     },
-    [authStatus, household, householdStatus, isReady]
+    [authStatus, household, householdStatus, isReady, view]
   );
 
   useEffect(() => {

--- a/src/test/supabaseHouseholdRepository.test.ts
+++ b/src/test/supabaseHouseholdRepository.test.ts
@@ -155,7 +155,22 @@ describe('SupabaseHouseholdRepository', () => {
     });
   });
 
-  it('does not fall back when the RPC fails for a non-bootstrap reason', async () => {
+  it('does not fall back to RPC when membership insert fails for a non-bootstrap reason', async () => {
+    const householdRow = {
+      id: 'house-3',
+      name: "Dora's Family",
+      timezone: 'Europe/Madrid',
+      home_scene: 'bike',
+      created_by_user_id: 'user-1',
+      created_at: '2026-05-03T12:00:00Z',
+      updated_at: '2026-05-03T12:00:00Z',
+    };
+
+    const single = vi.fn().mockResolvedValue({ data: householdRow, error: null });
+    const householdInsert = vi.fn(() => ({ select: vi.fn(() => ({ single })) }));
+    const cleanupEq = vi.fn().mockResolvedValue({ error: null });
+    const householdDelete = vi.fn(() => ({ eq: cleanupEq }));
+
     const repository = new SupabaseHouseholdRepository(
       createSupabaseClient(
         {
@@ -164,10 +179,11 @@ describe('SupabaseHouseholdRepository', () => {
         },
         {
           households: {
-            insert: vi.fn(),
+            insert: householdInsert,
+            delete: householdDelete,
           },
           household_members: {
-            insert: vi.fn(),
+            insert: vi.fn().mockResolvedValue({ error: { message: 'Not authenticated' } }),
           },
         }
       )
@@ -179,7 +195,7 @@ describe('SupabaseHouseholdRepository', () => {
         timezone: 'Europe/Madrid',
         userId: 'user-1',
       })
-    ).rejects.toEqual({ message: 'Not authenticated' });
+    ).rejects.toMatchObject({ message: 'Not authenticated' });
   });
 
   it('deletes the household row by id', async () => {


### PR DESCRIPTION
## What
- Makes cloud household config saves deterministic: if a user edits setup before the household is finished bootstrapping, we queue the latest config and flush it automatically once the household becomes `ready`.
- Allows cloud refresh in signed-in `setup` view (not just `home`), so a new device can catch up without manual refresh.
- Hardens household bootstrap: prefer direct inserts for speed, best-effort cleanup on partial failure, and fallback to `bootstrap_household` RPC when a bootstrap-style error is encountered.
- Updates `docs/accounts-v2.md` + `memory.md` to reflect the above.

## Why
Fixes the split-brain / non-syncing behavior across iPad + laptop where local edits could exist without ever reaching Supabase (especially during sign-in/bootstrap), and reduces “stuck on first cloud save” scenarios.

## Testing
- `npm test`
