### PR TITLE
test: fix household repo RPC fallback case

### DIFF
--- a/src/test/supabaseHouseholdRepository.test.ts
+++ b/src/test/supabaseHouseholdRepository.test.ts
@@ -63,6 +63,14 @@ describe('SupabaseHouseholdRepository', () => {
   });
 
   it('returns the RPC household when bootstrap_household succeeds', async () => {
+    // Repository tries direct inserts first; force that path to fail with a bootstrap-style
+    // error so it falls back to the RPC result.
+    const single = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: 'Could not find the function public.bootstrap_household' },
+    });
+    const householdInsert = vi.fn(() => ({ select: vi.fn(() => ({ single })) }));
+
     const repository = new SupabaseHouseholdRepository(
       createSupabaseClient(
         {
@@ -77,7 +85,11 @@ describe('SupabaseHouseholdRepository', () => {
           },
           error: null,
         },
-        {}
+        {
+          households: {
+            insert: householdInsert,
+          },
+        }
       )
     );
 


### PR DESCRIPTION
Fixes a failing unit test on `main` after the household repository started preferring direct inserts before RPC bootstrap.

- Updates `src/test/supabaseHouseholdRepository.test.ts` so the RPC-success test simulates a failing direct insert (bootstrap-style error) and then expects the repository to return the RPC household.

`npm test` passes locally.