### PR TITLE
Fix Supabase permissions: grant authenticated access to household tables

### DIFF
--- a/src/lib/auth/household-bootstrap.ts
+++ b/src/lib/auth/household-bootstrap.ts
@@ -38,7 +38,10 @@ const getBootstrapErrorMessage = (error: unknown) => {
     normalized.includes('relation') ||
     normalized.includes('schema cache')
   ) {
-    return 'Could not prepare the family household in Supabase. The shared household schema appears to be missing in the live Supabase project. Apply the household SQL migration, then try again.';
+    // This bucket historically meant "schema is missing", but in practice it can also include
+    // permission/RLS errors. Keep the guidance user-friendly, but include the raw error so
+    // we can debug support tickets without requiring console access.
+    return `Could not prepare the family space in Supabase yet. Please press "Try again". If it keeps failing, share this error with support: ${message || 'unknown error'}`;
   }
 
   return message || 'Could not prepare the family household in Supabase.';

--- a/src/test/householdBootstrap.test.ts
+++ b/src/test/householdBootstrap.test.ts
@@ -31,6 +31,6 @@ describe('ensureHousehold', () => {
         id: 'user-1',
         email: 'parent@example.com',
       } as never)
-    ).rejects.toThrow(/shared household schema appears to be missing/i);
+    ).rejects.toThrow(/could not prepare the family space in supabase/i);
   });
 });

--- a/supabase/migrations/20260519121000_grant_authenticated_access.sql
+++ b/supabase/migrations/20260519121000_grant_authenticated_access.sql
@@ -1,0 +1,13 @@
+-- Ensure the authenticated role can access the household schema tables.
+-- RLS still applies; these grants just allow PostgREST/Supabase client to reach the tables.
+
+grant usage on schema public to authenticated;
+
+grant select, insert, update, delete on table public.households to authenticated;
+grant select, insert, update, delete on table public.household_members to authenticated;
+grant select, insert, update, delete on table public.child_profiles to authenticated;
+grant select, insert, update, delete on table public.routines to authenticated;
+grant select, insert, update, delete on table public.routine_tasks to authenticated;
+grant select, insert, update, delete on table public.daily_routine_progress to authenticated;
+grant select, insert, update, delete on table public.daily_task_progress to authenticated;
+


### PR DESCRIPTION
## Fix
Your screenshots show:
- `household_members` has **0 rows** for the household id
- `child_profiles` has **0 rows** overall
- iPad shows `Preparing family space` error

That indicates the app cannot insert membership/children into Supabase (so nothing can sync).

The most common cause in Supabase is missing GRANTs: RLS policies exist, but `authenticated` role lacks table privileges.

## This PR
- Adds a migration that explicitly grants `SELECT/INSERT/UPDATE/DELETE` on the household schema tables to `authenticated`.
- Improves the in-app bootstrap error message so it stops incorrectly saying "schema missing" for permission/RLS errors and includes the raw error text for debugging.

## After merge
Run this SQL in Supabase (SQL Editor) to apply the migration, then retry sign-in + create a kid:

```sql
-- paste the contents of: supabase/migrations/20260519121000_grant_authenticated_access.sql
```

`npm test` passes locally.