### PR TITLE
Fix sync mismatch for existing accounts (Issue #100)

### DIFF
--- a/src/components/AccountSettingsCard.tsx
+++ b/src/components/AccountSettingsCard.tsx
@@ -124,6 +124,31 @@ export const AccountSettingsCard = () => {
             <p className="mt-2 text-sm text-muted-foreground">
               This browser is connected to the household saved under this parent account.
             </p>
+            <div className="mt-4 rounded-2xl border border-border bg-muted/35 px-4 py-3 text-xs text-muted-foreground">
+              <p>
+                <span className="font-semibold text-foreground">User</span>: {user.id}
+              </p>
+              <p className="mt-1">
+                <span className="font-semibold text-foreground">Household</span>: {household?.id ?? 'loading'}
+              </p>
+              <button
+                type="button"
+                onClick={() => {
+                  const payload = [
+                    `email=${user.email ?? ''}`,
+                    `user_id=${user.id}`,
+                    `household_id=${household?.id ?? ''}`,
+                    `household_status=${householdStatus}`,
+                    `ts=${new Date().toISOString()}`,
+                  ].join('\n');
+                  void navigator.clipboard?.writeText(payload);
+                }}
+                className="mt-3 inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-bold text-foreground transition-colors hover:border-primary/40 hover:text-primary"
+              >
+                <Mail size={14} />
+                Copy debug info
+              </button>
+            </div>
             <button
               type="button"
               onClick={() => void signOut()}

--- a/src/lib/data/supabase-household-repository.ts
+++ b/src/lib/data/supabase-household-repository.ts
@@ -42,22 +42,41 @@ export class SupabaseHouseholdRepository implements HouseholdRepository {
   async getCurrentHousehold(userId: string) {
     // IMPORTANT: a parent account should resolve to one stable household.
     // If multiple households exist (due to earlier bugs or tests), we pick the
-    // oldest owner membership to avoid randomly switching households across devices.
+    // most recently updated owner household so existing accounts converge on the
+    // household that actually contains data.
     const { data, error } = await this.supabase
       .from(HOUSEHOLD_MEMBERS_TABLE)
       .select('household:households(*)')
       .eq('user_id', userId)
       .eq('role', 'owner')
-      .order('created_at', { ascending: true })
-      .limit(1)
-      .maybeSingle();
+      .order('created_at', { ascending: true });
 
     if (error) {
       throw error;
     }
 
-    const householdRow = data && typeof data === 'object' && 'household' in data ? (data as any).household : null;
-    return householdRow ? mapHousehold(householdRow) : null;
+    const rows = Array.isArray(data) ? data : data ? [data] : [];
+    const households = rows
+      .map((row) => (row && typeof row === 'object' && 'household' in row ? (row as any).household : null))
+      .filter(Boolean) as Array<Record<string, unknown>>;
+
+    if (!households.length) {
+      return null;
+    }
+
+    const pick = households
+      .slice()
+      .sort((left, right) => {
+        const leftUpdated = Date.parse(String(left.updated_at ?? '')) || 0;
+        const rightUpdated = Date.parse(String(right.updated_at ?? '')) || 0;
+        if (leftUpdated !== rightUpdated) return rightUpdated - leftUpdated;
+
+        const leftCreated = Date.parse(String(left.created_at ?? '')) || 0;
+        const rightCreated = Date.parse(String(right.created_at ?? '')) || 0;
+        return leftCreated - rightCreated;
+      })[0];
+
+    return mapHousehold(pick);
   }
 
   async createInitialHousehold(input: { householdName: string; timezone: string; userId: string }) {

--- a/src/test/supabaseHouseholdRepository.test.ts
+++ b/src/test/supabaseHouseholdRepository.test.ts
@@ -8,27 +8,34 @@ const createSupabaseClient = (rpcResult: { data: unknown; error: unknown }, tabl
   }) as never;
 
 describe('SupabaseHouseholdRepository', () => {
-  it('selects the oldest owner membership household for stable cross-device loads', async () => {
-    const maybeSingle = vi.fn().mockResolvedValue({
-      data: {
-        household: {
-          id: 'house-old',
-          name: "Dora's Family",
-          timezone: 'Europe/Madrid',
-          home_scene: 'bike',
-          created_by_user_id: 'user-1',
-          created_at: '2026-05-01T12:00:00Z',
-          updated_at: '2026-05-01T12:00:00Z',
+  it('selects the most recently updated owner household when duplicates exist', async () => {
+    const order = vi.fn().mockResolvedValue({
+      data: [
+        {
+          household: {
+            id: 'house-old',
+            name: "Dora's Family",
+            timezone: 'Europe/Madrid',
+            home_scene: 'bike',
+            created_by_user_id: 'user-1',
+            created_at: '2026-05-01T12:00:00Z',
+            updated_at: '2026-05-01T12:00:00Z',
+          },
         },
-      },
+        {
+          household: {
+            id: 'house-new',
+            name: "Dora's Family",
+            timezone: 'Europe/Madrid',
+            home_scene: 'school',
+            created_by_user_id: 'user-1',
+            created_at: '2026-05-02T12:00:00Z',
+            updated_at: '2026-05-04T12:00:00Z',
+          },
+        },
+      ],
       error: null,
     });
-    const limit = vi.fn(() => ({
-      maybeSingle,
-    }));
-    const order = vi.fn(() => ({
-      limit,
-    }));
     const eqRole = vi.fn(() => ({
       order,
     }));
@@ -46,20 +53,19 @@ describe('SupabaseHouseholdRepository', () => {
     } as never);
 
     await expect(repository.getCurrentHousehold('user-1')).resolves.toEqual({
-      id: 'house-old',
+      id: 'house-new',
       name: "Dora's Family",
       timezone: 'Europe/Madrid',
-      homeScene: 'bike',
+      homeScene: 'school',
       createdByUserId: 'user-1',
-      createdAt: '2026-05-01T12:00:00Z',
-      updatedAt: '2026-05-01T12:00:00Z',
+      createdAt: '2026-05-02T12:00:00Z',
+      updatedAt: '2026-05-04T12:00:00Z',
     });
 
     expect(select).toHaveBeenCalledWith('household:households(*)');
     expect(eqUser).toHaveBeenCalledWith('user_id', 'user-1');
     expect(eqRole).toHaveBeenCalledWith('role', 'owner');
     expect(order).toHaveBeenCalledWith('created_at', { ascending: true });
-    expect(limit).toHaveBeenCalledWith(1);
   });
 
   it('returns the RPC household when bootstrap_household succeeds', async () => {


### PR DESCRIPTION
Fixes #100

Likely cause for the iPad-vs-laptop mismatch: some existing parent accounts ended up with multiple owner households from earlier bootstrap races; the client previously picked the *oldest* owner membership (often empty), so devices could bind to the wrong household.

Changes:
- Prefer the most recently updated owner household when duplicates exist (`getCurrentHousehold`)
- Add "Copy debug info" (user id + household id) to help support/reporting

Verified: `npm test`, `npm run build`