### PR TITLE
feat: Cozy Pastel redesign — mascots, bottom nav, affirmations, achievements, mood

### DIFF
--- a/src/components/AchievementsTab.tsx
+++ b/src/components/AchievementsTab.tsx
@@ -1,0 +1,166 @@
+import { PainterlyBanner } from './PainterlyBanner';
+import { getMascot, BADGE_CATALOG, WEEK_DAYS } from '@/lib/mascots';
+import type { Child } from '@/lib/types';
+
+interface AchievementsTabProps {
+  kid: Child;
+}
+
+const INK = '#3d2c1f';
+const INK_MUTE = '#8a7866';
+const ROUTINES_ORANGE = '#f97316';
+
+export const AchievementsTab = ({ kid }: AchievementsTabProps) => {
+  const m = getMascot(kid.mascotId ?? kid.avatarAnimal);
+  const badges = kid.badges ?? {};
+  const earnedCount = Object.values(badges).filter(Boolean).length;
+  const streak = kid.streak ?? 0;
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        overflowY: 'auto',
+        paddingBottom: 80,
+        background: 'linear-gradient(180deg,#fff9f0,#fef3c7)',
+        fontFamily: "'Fredoka', system-ui, sans-serif",
+        color: INK,
+      }}
+    >
+      <PainterlyBanner
+        label={`${m.emoji} ${kid.name}'s`}
+        title="Awards"
+        palette="amber"
+      />
+
+      <div style={{ padding: '0 16px' }}>
+        {/* Streak card */}
+        <div
+          style={{
+            background: 'linear-gradient(135deg,#fed7aa,#fdba74)',
+            borderRadius: 22,
+            padding: '14px 18px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 14,
+            boxShadow: '0 4px 12px rgba(249,115,22,0.18)',
+            position: 'relative',
+            overflow: 'hidden',
+          }}
+        >
+          {/* Sun-ray decoration */}
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              style={{
+                position: 'absolute',
+                left: 38,
+                top: '50%',
+                width: 110,
+                height: 6,
+                background: 'rgba(255,255,255,0.16)',
+                transformOrigin: 'left center',
+                transform: `rotate(${i * 45}deg) translateY(-3px)`,
+              }}
+            />
+          ))}
+          <div
+            style={{
+              width: 60,
+              height: 60,
+              borderRadius: '50%',
+              background: 'radial-gradient(circle,#fef3c7,#fbbf24)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: 30,
+              position: 'relative',
+              boxShadow: 'inset 0 -3px 0 rgba(0,0,0,0.08), 0 4px 0 rgba(180,83,9,0.3)',
+              flexShrink: 0,
+            }}
+          >
+            🔥
+          </div>
+          <div style={{ position: 'relative', flex: 1 }}>
+            <div style={{ fontSize: 36, fontWeight: 700, color: '#7c2d12', lineHeight: 1 }}>{streak}</div>
+            <div style={{ fontSize: 12, fontWeight: 600, color: '#9a3412', marginTop: 2 }}>day streak!</div>
+          </div>
+        </div>
+
+        {/* Week chips */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 10, gap: 4 }}>
+          {WEEK_DAYS.map((d, i) => {
+            const filled = streak > 0 && i < Math.min(streak, 7);
+            return (
+              <div
+                key={d}
+                style={{
+                  flex: 1,
+                  textAlign: 'center',
+                  padding: '6px 0',
+                  borderRadius: 10,
+                  background: filled ? ROUTINES_ORANGE : 'rgba(180,120,80,0.1)',
+                  color: filled ? '#fff' : INK_MUTE,
+                  fontSize: 10,
+                  fontWeight: 700,
+                }}
+              >
+                <div>{d[0]}</div>
+                <div style={{ fontSize: 12, marginTop: 1 }}>{filled ? '✓' : '·'}</div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Badges */}
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: INK_MUTE,
+            margin: '16px 0 8px',
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+          }}
+        >
+          Badges · {earnedCount} of {BADGE_CATALOG.length}
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 8 }}>
+          {BADGE_CATALOG.map((b) => {
+            const earned = Boolean(badges[b.id]);
+            return (
+              <div
+                key={b.id}
+                style={{
+                  background: earned ? '#fff' : 'rgba(180,120,80,0.06)',
+                  borderRadius: 16,
+                  padding: '10px 4px',
+                  textAlign: 'center',
+                  border: earned ? '1.5px solid #fed7aa' : '1.5px dashed rgba(180,120,80,0.2)',
+                  opacity: earned ? 1 : 0.6,
+                  position: 'relative',
+                }}
+              >
+                <div style={{ fontSize: 26, filter: earned ? 'none' : 'grayscale(1)' }}>{b.icon}</div>
+                <div
+                  style={{
+                    fontSize: 9,
+                    fontWeight: 700,
+                    color: earned ? INK : INK_MUTE,
+                    marginTop: 2,
+                    lineHeight: 1.15,
+                  }}
+                >
+                  {b.name}
+                </div>
+                {!earned && (
+                  <div style={{ position: 'absolute', top: 4, right: 4, fontSize: 9 }}>🔒</div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/AffirmationsTab.tsx
+++ b/src/components/AffirmationsTab.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react';
+import { PainterlyBanner } from './PainterlyBanner';
+import { getMascot } from '@/lib/mascots';
+import type { Child } from '@/lib/types';
+
+interface AffirmationsTabProps {
+  kid: Child;
+}
+
+const INK = '#3d2c1f';
+const INK_MUTE = '#8a7866';
+
+export const AffirmationsTab = ({ kid }: AffirmationsTabProps) => {
+  const [idx, setIdx] = useState(0);
+  const m = getMascot(kid.mascotId ?? kid.avatarAnimal);
+  const list = kid.affirmations?.length ? kid.affirmations : ['I am exactly enough.'];
+  const current = idx % list.length;
+  const text = list[current];
+
+  const FAVE_ICONS = ['🌟', '🦁', '💙', '💗'];
+  const FAVE_COLORS = ['#fef3c7', '#dcfce7', '#dbeafe', '#fce7f3'];
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        overflowY: 'auto',
+        paddingBottom: 80,
+        background: 'linear-gradient(180deg,#fff9f0,#fde7f3)',
+        fontFamily: "'Fredoka', system-ui, sans-serif",
+        color: INK,
+      }}
+    >
+      <PainterlyBanner
+        label={`${m.emoji} ${kid.name}'s`}
+        title="Daily Affirmation"
+        palette="pink"
+      />
+
+      {/* Main card */}
+      <div style={{ padding: '4px 18px 0' }}>
+        <div
+          style={{
+            background: 'linear-gradient(160deg,#fce7f3,#ffe4e6)',
+            borderRadius: 28,
+            padding: '24px 22px',
+            textAlign: 'center',
+            border: '2px solid rgba(236,72,153,0.15)',
+            boxShadow: '0 8px 24px rgba(236,72,153,0.1)',
+            position: 'relative',
+          }}
+        >
+          {/* Decorations */}
+          <div style={{ position: 'absolute', top: 10, left: 14, fontSize: 16, opacity: 0.45 }}>✿</div>
+          <div style={{ position: 'absolute', top: 14, right: 16, fontSize: 14, opacity: 0.45 }}>✦</div>
+          <div style={{ position: 'absolute', bottom: 10, left: 16, fontSize: 12, opacity: 0.45 }}>✦</div>
+          <div style={{ position: 'absolute', bottom: 14, right: 14, fontSize: 16, opacity: 0.45 }}>✿</div>
+
+          <div style={{ fontSize: 60, marginBottom: 12 }}>{m.emoji}</div>
+          <div
+            style={{
+              fontSize: 22,
+              fontWeight: 600,
+              color: '#831843',
+              lineHeight: 1.3,
+              fontStyle: 'italic',
+              margin: '0 4px',
+            }}
+          >
+            "{text}"
+          </div>
+          <div
+            style={{
+              fontSize: 12,
+              color: '#be185d',
+              marginTop: 12,
+              fontWeight: 500,
+            }}
+          >
+            {m.name} says: take a deep breath 🌸
+          </div>
+
+          {/* Controls */}
+          <div style={{ display: 'flex', justifyContent: 'center', gap: 10, marginTop: 18 }}>
+            <button
+              onClick={() => window.alert('Audio playback coming soon!')}
+              style={{
+                background: '#ec4899',
+                color: '#fff',
+                border: 'none',
+                width: 52,
+                height: 52,
+                borderRadius: '50%',
+                fontSize: 22,
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+                boxShadow: '0 4px 0 #be185d',
+              }}
+            >
+              ▶
+            </button>
+            <button
+              onClick={() => setIdx((i) => i + 1)}
+              style={{
+                background: '#fff',
+                color: '#be185d',
+                border: 'none',
+                padding: '0 18px',
+                height: 52,
+                borderRadius: 26,
+                fontSize: 13,
+                fontWeight: 600,
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+                boxShadow: '0 4px 0 rgba(236,72,153,0.2)',
+              }}
+            >
+              ↻ Next
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Pagination dots */}
+      <div style={{ display: 'flex', justifyContent: 'center', gap: 6, marginTop: 14 }}>
+        {list.map((_, i) => (
+          <button
+            key={i}
+            onClick={() => setIdx(i)}
+            style={{
+              width: i === current ? 20 : 6,
+              height: 6,
+              borderRadius: 99,
+              background: i === current ? '#ec4899' : 'rgba(236,72,153,0.25)',
+              transition: 'width 0.25s',
+              border: 'none',
+              cursor: 'pointer',
+              padding: 0,
+            }}
+          />
+        ))}
+      </div>
+
+      {/* Favourites list */}
+      <div style={{ padding: '18px 18px 0' }}>
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: INK_MUTE,
+            marginBottom: 8,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+          }}
+        >
+          {kid.name}'s favourites
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {list.slice(0, 4).map((aff, i) => (
+            <div
+              key={i}
+              style={{
+                background: FAVE_COLORS[i % FAVE_COLORS.length],
+                borderRadius: 16,
+                padding: '10px 14px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+              }}
+            >
+              <div style={{ fontSize: 18 }}>{FAVE_ICONS[i % FAVE_ICONS.length]}</div>
+              <div style={{ flex: 1, fontSize: 13, fontWeight: 500, fontStyle: 'italic' }}>
+                "{aff}"
+              </div>
+              <div style={{ fontSize: 16, color: '#ec4899' }}>♡</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,0 +1,78 @@
+export type KidTab = 'routines' | 'affirmations' | 'achievements' | 'mood';
+
+interface BottomNavProps {
+  active: KidTab;
+  onChange: (tab: KidTab) => void;
+}
+
+const TABS: { id: KidTab; icon: string; label: string; tint: string }[] = [
+  { id: 'routines',     icon: '✅', label: 'Routines', tint: '#f97316' },
+  { id: 'affirmations', icon: '💫', label: 'Affirm.',  tint: '#ec4899' },
+  { id: 'achievements', icon: '🏆', label: 'Awards',   tint: '#f59e0b' },
+  { id: 'mood',         icon: '💗', label: 'Mood',     tint: '#a855f7' },
+];
+
+export const BottomNav = ({ active, onChange }: BottomNavProps) => {
+  const activeTint = TABS.find((t) => t.id === active)?.tint ?? '#f97316';
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        background: 'rgba(255,250,243,0.96)',
+        backdropFilter: 'blur(12px)',
+        borderTop: '1px solid rgba(180,120,80,0.08)',
+        padding: '8px 6px env(safe-area-inset-bottom, 16px)',
+        display: 'flex',
+        justifyContent: 'space-around',
+        zIndex: 30,
+        fontFamily: "'Fredoka', system-ui, sans-serif",
+      }}
+    >
+      {TABS.map((t) => (
+        <button
+          key={t.id}
+          onClick={() => onChange(t.id)}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 2,
+            padding: '6px 10px',
+            borderRadius: 16,
+            background: t.id === active ? `${activeTint}18` : 'transparent',
+            border: 'none',
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+            WebkitTapHighlightColor: 'transparent',
+            minWidth: 60,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 22,
+              filter: t.id === active ? 'none' : 'grayscale(0.55)',
+              opacity: t.id === active ? 1 : 0.5,
+              transition: 'all 0.2s',
+            }}
+          >
+            {t.icon}
+          </div>
+          <div
+            style={{
+              fontSize: 10,
+              fontWeight: 700,
+              color: t.id === active ? activeTint : '#8a7866',
+              transition: 'color 0.2s',
+            }}
+          >
+            {t.label}
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/src/components/KidApp.tsx
+++ b/src/components/KidApp.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import { MascotBubble } from './MascotBubble';
+import { BottomNav, type KidTab } from './BottomNav';
+import { RoutinesTab } from './RoutinesTab';
+import { AffirmationsTab } from './AffirmationsTab';
+import { AchievementsTab } from './AchievementsTab';
+import { MoodTab } from './MoodTab';
+import { getMascot } from '@/lib/mascots';
+import type { Child, RoutineType } from '@/lib/types';
+
+interface KidAppProps {
+  kid: Child;
+  theme: 'morning' | 'evening';
+  onBack: () => void;
+  onToggleTask: (kidId: string, routine: RoutineType, taskId: string) => void;
+  onSetMood: (kidId: string, dayIdx: number, emoji: string) => void;
+}
+
+const INK = '#3d2c1f';
+const INK_MUTE = '#8a7866';
+
+export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood }: KidAppProps) => {
+  const [tab, setTab] = useState<KidTab>('routines');
+  const m = getMascot(kid.mascotId ?? kid.avatarAnimal);
+  const streak = kid.streak ?? 0;
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        height: '100%',
+        background: '#fff9f0',
+        fontFamily: "'Fredoka', system-ui, sans-serif",
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Top bar */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 10,
+          padding: '10px 14px',
+          background: 'transparent',
+          position: 'relative',
+          zIndex: 10,
+          flexShrink: 0,
+        }}
+      >
+        <button
+          onClick={onBack}
+          style={{
+            width: 34,
+            height: 34,
+            borderRadius: 12,
+            background: '#fff',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: 16,
+            color: INK,
+            border: 'none',
+            cursor: 'pointer',
+            boxShadow: '0 2px 6px rgba(180,120,80,0.1)',
+            fontFamily: 'inherit',
+            WebkitTapHighlightColor: 'transparent',
+          }}
+        >
+          ‹
+        </button>
+        <MascotBubble mascotId={kid.mascotId ?? kid.avatarAnimal} size={34} />
+        <div style={{ flex: 1 }}>
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              color: INK_MUTE,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+            }}
+          >
+            with {m.name}
+          </div>
+          <div style={{ fontSize: 14, fontWeight: 600, color: INK, marginTop: -1 }}>
+            Hi, {kid.name}!
+          </div>
+        </div>
+        {streak > 0 && (
+          <div
+            style={{
+              background: '#fff',
+              borderRadius: 10,
+              padding: '5px 10px',
+              fontSize: 11,
+              fontWeight: 700,
+              color: '#f97316',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 4,
+              boxShadow: '0 2px 6px rgba(180,120,80,0.08)',
+            }}
+          >
+            🔥 {streak}
+          </div>
+        )}
+      </div>
+
+      {/* Tab content */}
+      <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
+        <div style={{ position: 'absolute', inset: 0 }}>
+          {tab === 'routines' && (
+            <RoutinesTab kid={kid} theme={theme} onToggleTask={onToggleTask} />
+          )}
+          {tab === 'affirmations' && <AffirmationsTab kid={kid} />}
+          {tab === 'achievements' && <AchievementsTab kid={kid} />}
+          {tab === 'mood' && <MoodTab kid={kid} onSetMood={onSetMood} />}
+        </div>
+      </div>
+
+      <BottomNav active={tab} onChange={setTab} />
+    </div>
+  );
+};

--- a/src/components/KidHome.tsx
+++ b/src/components/KidHome.tsx
@@ -1,0 +1,258 @@
+import { useRef, useState } from 'react';
+import { MascotBubble } from './MascotBubble';
+import { MorningBackdrop } from './MorningBackdrop';
+import { NightBackdrop } from './NightBackdrop';
+import { getMascot } from '@/lib/mascots';
+import type { Child } from '@/lib/types';
+
+interface KidHomeProps {
+  kids: Child[];
+  theme: 'morning' | 'evening';
+  onPick: (id: string) => void;
+  onParent: () => void;
+}
+
+const INK = '#3d2c1f';
+const INK_MUTE = '#8a7866';
+
+export const KidHome = ({ kids, theme, onPick, onParent }: KidHomeProps) => {
+  const isMorning = theme === 'morning';
+  const [holdPct, setHoldPct] = useState(0);
+  const holdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const progRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const startHold = () => {
+    const start = performance.now();
+    progRef.current = setInterval(() => {
+      const p = Math.min(100, ((performance.now() - start) / 1500) * 100);
+      setHoldPct(p);
+    }, 16);
+    holdRef.current = setTimeout(() => {
+      if (progRef.current) clearInterval(progRef.current);
+      setHoldPct(0);
+      onParent();
+    }, 1500);
+  };
+
+  const cancelHold = () => {
+    if (holdRef.current) clearTimeout(holdRef.current);
+    if (progRef.current) clearInterval(progRef.current);
+    setHoldPct(0);
+  };
+
+  const greeting = isMorning ? 'Good morning,' : 'Good evening,';
+  const tagline = isMorning ? 'little stars!' : 'little dreamers';
+  const sub = isMorning ? "Who's ready to shine?" : 'Time to wind down';
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        height: '100%',
+        overflow: 'hidden',
+        fontFamily: "'Fredoka', system-ui, sans-serif",
+        color: isMorning ? INK : '#fff',
+      }}
+    >
+      {isMorning ? <MorningBackdrop /> : <NightBackdrop />}
+
+      <div
+        style={{
+          position: 'relative',
+          zIndex: 2,
+          padding: '20px 18px 16px',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+      >
+        {/* Header */}
+        <div style={{ marginBottom: 18, flexShrink: 0 }}>
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 600,
+              color: isMorning ? '#d97706' : '#fde68a',
+              letterSpacing: '0.14em',
+              textTransform: 'uppercase',
+            }}
+          >
+            {isMorning ? '☀️' : '🌙'}{' '}
+            {new Date().toLocaleDateString('en-US', { weekday: 'long' })}{' '}
+            {isMorning ? 'morning' : 'evening'}
+          </div>
+          <div style={{ fontSize: 26, fontWeight: 600, marginTop: 4, lineHeight: 1.15 }}>
+            {greeting}
+            <br />
+            {tagline}
+          </div>
+          <div
+            style={{
+              fontSize: 13,
+              color: isMorning ? INK_MUTE : 'rgba(255,255,255,0.7)',
+              marginTop: 4,
+            }}
+          >
+            {sub}
+          </div>
+        </div>
+
+        {/* Kid cards */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 10,
+            flex: 1,
+            overflowY: 'auto',
+          }}
+        >
+          {kids.map((k) => {
+            const m = getMascot(k.mascotId ?? k.avatarAnimal);
+            const tasks = isMorning ? k.morning : k.evening;
+            const done = tasks.filter((t) => t.completed).length;
+            const total = tasks.length;
+            const pct = total ? (done / total) * 100 : 0;
+            const streak = k.streak ?? 0;
+
+            return (
+              <button
+                key={k.id}
+                onClick={() => onPick(k.id)}
+                style={{
+                  background: isMorning
+                    ? 'rgba(255,255,255,0.9)'
+                    : 'rgba(255,255,255,0.12)',
+                  backdropFilter: 'blur(8px)',
+                  borderRadius: 24,
+                  padding: '14px 16px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 14,
+                  boxShadow: isMorning
+                    ? '0 6px 16px rgba(180,120,80,0.1)'
+                    : '0 6px 20px rgba(0,0,0,0.25)',
+                  border:
+                    '1.5px solid ' +
+                    (isMorning ? 'rgba(255,255,255,0.7)' : 'rgba(255,255,255,0.15)'),
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                  color: 'inherit',
+                  textAlign: 'left',
+                  WebkitTapHighlightColor: 'transparent',
+                  transition: 'transform 0.15s',
+                  flexShrink: 0,
+                }}
+              >
+                <MascotBubble
+                  mascotId={k.mascotId ?? k.avatarAnimal}
+                  size={56}
+                  showStreak
+                  streak={streak}
+                />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 17, fontWeight: 600 }}>{k.name}</div>
+                  <div
+                    style={{
+                      fontSize: 11,
+                      color: isMorning ? INK_MUTE : 'rgba(255,255,255,0.75)',
+                      marginTop: 1,
+                    }}
+                  >
+                    with {m.name} · {done} / {total} done
+                  </div>
+                  {/* Progress bar */}
+                  <div
+                    style={{
+                      height: 4,
+                      background: isMorning
+                        ? 'rgba(0,0,0,0.06)'
+                        : 'rgba(255,255,255,0.12)',
+                      borderRadius: 99,
+                      marginTop: 6,
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <div
+                      style={{
+                        height: '100%',
+                        width: `${pct}%`,
+                        background: m.color,
+                        borderRadius: 99,
+                        transition: 'width 0.5s',
+                      }}
+                    />
+                  </div>
+                </div>
+                <div
+                  style={{
+                    width: 34,
+                    height: 34,
+                    borderRadius: '50%',
+                    background: m.color,
+                    color: '#fff',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: 18,
+                    fontWeight: 700,
+                    boxShadow: `0 3px 0 ${m.color}66`,
+                    flexShrink: 0,
+                  }}
+                >
+                  ›
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Parent gate */}
+        <button
+          onPointerDown={startHold}
+          onPointerUp={cancelHold}
+          onPointerLeave={cancelHold}
+          onPointerCancel={cancelHold}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 6,
+            margin: '14px auto 0',
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            color: isMorning ? INK_MUTE : 'rgba(255,255,255,0.6)',
+            fontFamily: 'inherit',
+            WebkitTapHighlightColor: 'transparent',
+            flexShrink: 0,
+          }}
+        >
+          <span style={{ fontSize: 11, fontWeight: 500 }}>⚙️ Hold to open parent settings</span>
+          <div
+            style={{
+              width: 90,
+              height: 4,
+              borderRadius: 99,
+              background: isMorning
+                ? 'rgba(180,120,80,0.15)'
+                : 'rgba(255,255,255,0.15)',
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              style={{
+                height: '100%',
+                width: `${holdPct}%`,
+                background: '#f97316',
+                borderRadius: 99,
+                transition: 'width 0.06s linear',
+              }}
+            />
+          </div>
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/MascotBubble.tsx
+++ b/src/components/MascotBubble.tsx
@@ -1,0 +1,56 @@
+import { getMascot } from '@/lib/mascots';
+
+interface MascotBubbleProps {
+  mascotId: string | undefined;
+  size?: number;
+  showStreak?: boolean;
+  streak?: number;
+  className?: string;
+}
+
+export const MascotBubble = ({ mascotId, size = 56, showStreak = false, streak = 0 }: MascotBubbleProps) => {
+  const m = getMascot(mascotId);
+  const fontSize = Math.round(size * 0.54);
+
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background: `linear-gradient(135deg, ${m.light}, ${m.color}33)`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize,
+        border: `2.5px solid ${m.color}44`,
+        flexShrink: 0,
+        position: 'relative',
+      }}
+    >
+      {m.emoji}
+      {showStreak && streak > 0 && (
+        <div
+          style={{
+            position: 'absolute',
+            bottom: -3,
+            right: -5,
+            background: '#fff',
+            borderRadius: 99,
+            padding: '1px 6px',
+            fontSize: 9,
+            fontWeight: 700,
+            color: '#f97316',
+            border: '1.5px solid #fde68a',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 2,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          🔥 {streak}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/MoodTab.tsx
+++ b/src/components/MoodTab.tsx
@@ -1,0 +1,195 @@
+import { useState } from 'react';
+import { PainterlyBanner } from './PainterlyBanner';
+import { getMascot, MOOD_OPTIONS, WEEK_DAYS } from '@/lib/mascots';
+import type { Child } from '@/lib/types';
+
+interface MoodTabProps {
+  kid: Child;
+  onSetMood: (kidId: string, dayIdx: number, emoji: string) => void;
+}
+
+const INK = '#3d2c1f';
+const INK_MUTE = '#8a7866';
+const MOOD_PURPLE = '#a855f7';
+
+export const MoodTab = ({ kid, onSetMood }: MoodTabProps) => {
+  const m = getMascot(kid.mascotId ?? kid.avatarAnimal);
+  const [note, setNote] = useState('');
+
+  // Today's index (Mon=0 … Sun=6)
+  const today = new Date().getDay();
+  const todayIdx = today === 0 ? 6 : today - 1;
+  const moods = kid.moods ?? WEEK_DAYS.map((day) => ({ day, emoji: null }));
+  const todayMood = moods[todayIdx]?.emoji ?? null;
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        overflowY: 'auto',
+        paddingBottom: 80,
+        background: 'linear-gradient(180deg,#fff9f0,#e9defc)',
+        fontFamily: "'Fredoka', system-ui, sans-serif",
+        color: INK,
+      }}
+    >
+      <PainterlyBanner
+        label={`${m.emoji} ${kid.name}'s`}
+        title="How are you?"
+        palette="purple"
+      />
+
+      {/* Emoji picker grid */}
+      <div style={{ padding: '0 16px' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 8 }}>
+          {MOOD_OPTIONS.map((mood) => {
+            const selected = todayMood === mood.emoji;
+            return (
+              <button
+                key={mood.label}
+                onClick={() => onSetMood(kid.id, todayIdx, mood.emoji)}
+                style={{
+                  background: selected ? mood.color : '#fff',
+                  borderRadius: 18,
+                  padding: '12px 6px',
+                  textAlign: 'center',
+                  border: selected ? `2.5px solid ${mood.color}` : '2px solid rgba(180,120,80,0.08)',
+                  boxShadow: selected ? `0 4px 12px ${mood.color}55` : '0 2px 6px rgba(0,0,0,0.04)',
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                  color: 'inherit',
+                  transition: 'all 0.2s',
+                  WebkitTapHighlightColor: 'transparent',
+                }}
+              >
+                <div style={{ fontSize: 32 }}>{mood.emoji}</div>
+                <div
+                  style={{
+                    fontSize: 10,
+                    fontWeight: 700,
+                    color: selected ? '#fff' : INK,
+                    marginTop: 2,
+                  }}
+                >
+                  {mood.label}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Note */}
+      <div style={{ padding: '14px 16px 0' }}>
+        <div
+          style={{
+            background: '#fff',
+            borderRadius: 18,
+            padding: '12px 14px',
+            border: '1.5px solid rgba(180,120,80,0.08)',
+          }}
+        >
+          <div
+            style={{
+              fontSize: 10,
+              fontWeight: 700,
+              color: INK_MUTE,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+            }}
+          >
+            Tell me more (optional)
+          </div>
+          <textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="I had a great morning!"
+            style={{
+              width: '100%',
+              border: 'none',
+              resize: 'none',
+              outline: 'none',
+              background: 'transparent',
+              fontFamily: 'inherit',
+              fontSize: 13,
+              color: MOOD_PURPLE,
+              marginTop: 6,
+              fontStyle: 'italic',
+              minHeight: 30,
+            }}
+          />
+          <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
+            <button
+              style={{
+                background: '#fef3c7',
+                color: '#92400e',
+                border: 'none',
+                borderRadius: 10,
+                padding: '5px 10px',
+                fontSize: 10,
+                fontWeight: 700,
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+            >
+              ✏️ Draw
+            </button>
+            <button
+              style={{
+                background: '#dbeafe',
+                color: '#1e40af',
+                border: 'none',
+                borderRadius: 10,
+                padding: '5px 10px',
+                fontSize: 10,
+                fontWeight: 700,
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+              }}
+            >
+              🎤 Voice
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Week calendar */}
+      <div style={{ padding: '14px 16px 0' }}>
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: INK_MUTE,
+            marginBottom: 6,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+          }}
+        >
+          This week
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', gap: 4 }}>
+          {WEEK_DAYS.map((d, i) => (
+            <div
+              key={d}
+              style={{
+                flex: 1,
+                textAlign: 'center',
+                padding: '8px 0',
+                background: '#fff',
+                borderRadius: 12,
+                border: i === todayIdx ? `2px solid ${MOOD_PURPLE}` : '1.5px solid rgba(180,120,80,0.08)',
+              }}
+            >
+              <div style={{ fontSize: 18, opacity: moods[i]?.emoji ? 1 : 0.25 }}>
+                {moods[i]?.emoji ?? '·'}
+              </div>
+              <div style={{ fontSize: 9, fontWeight: 700, color: INK_MUTE, marginTop: 1 }}>
+                {d[0]}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/MorningBackdrop.tsx
+++ b/src/components/MorningBackdrop.tsx
@@ -1,0 +1,69 @@
+export const MorningBackdrop = () => (
+  <div style={{ position: 'absolute', inset: 0, overflow: 'hidden', pointerEvents: 'none' }}>
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        background: 'linear-gradient(180deg,#fff9f0 0%,#ffe8d6 45%,#ffd9c2 100%)',
+      }}
+    />
+    {/* Sun */}
+    <div
+      style={{
+        position: 'absolute',
+        top: 24,
+        right: 24,
+        width: 60,
+        height: 60,
+        borderRadius: '50%',
+        background: 'radial-gradient(circle,#fef3c7 0%,#fbbf24 90%)',
+        boxShadow: '0 0 60px rgba(251,191,36,0.45)',
+      }}
+    />
+    {Array.from({ length: 8 }).map((_, i) => (
+      <div
+        key={i}
+        style={{
+          position: 'absolute',
+          left: 54,
+          top: 54,
+          width: 3,
+          height: 18,
+          background: 'rgba(251,191,36,0.5)',
+          borderRadius: 2,
+          transformOrigin: 'center center',
+          transform: `rotate(${i * 45}deg) translateY(-26px)`,
+        }}
+      />
+    ))}
+    {/* Clouds */}
+    <div style={{ position: 'absolute', top: 64, left: 24, fontSize: 30, opacity: 0.7 }}>☁️</div>
+    <div style={{ position: 'absolute', top: 38, left: 110, fontSize: 20, opacity: 0.55 }}>☁️</div>
+    <div style={{ position: 'absolute', top: 92, right: 110, fontSize: 22, opacity: 0.6 }}>☁️</div>
+    {/* Hills */}
+    <div
+      style={{
+        position: 'absolute',
+        bottom: 0,
+        left: -30,
+        width: 180,
+        height: 90,
+        borderRadius: '50% 50% 0 0',
+        background: '#fdba74',
+        opacity: 0.5,
+      }}
+    />
+    <div
+      style={{
+        position: 'absolute',
+        bottom: 0,
+        right: -20,
+        width: 200,
+        height: 100,
+        borderRadius: '50% 50% 0 0',
+        background: '#fbb583',
+        opacity: 0.45,
+      }}
+    />
+  </div>
+);

--- a/src/components/NightBackdrop.tsx
+++ b/src/components/NightBackdrop.tsx
@@ -1,0 +1,73 @@
+export const NightBackdrop = () => (
+  <div style={{ position: 'absolute', inset: 0, overflow: 'hidden', pointerEvents: 'none' }}>
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        background: 'linear-gradient(180deg,#1e1b4b 0%,#312e81 50%,#4c1d95 100%)',
+      }}
+    />
+    {/* Stars */}
+    {Array.from({ length: 30 }).map((_, i) => {
+      const x = (i * 137.5) % 100;
+      const y = (i * 73.3) % 70;
+      const s = 1 + (i % 3);
+      return (
+        <div
+          key={i}
+          style={{
+            position: 'absolute',
+            left: `${x}%`,
+            top: `${y}%`,
+            width: s,
+            height: s,
+            borderRadius: '50%',
+            background: 'rgba(255,255,200,0.85)',
+            boxShadow: '0 0 6px rgba(255,255,200,0.6)',
+          }}
+        />
+      );
+    })}
+    {/* Moon */}
+    <div
+      style={{
+        position: 'absolute',
+        top: 28,
+        right: 28,
+        width: 64,
+        height: 64,
+        borderRadius: '50%',
+        background: 'radial-gradient(circle at 35% 35%,#fef3c7,#fcd34d)',
+        boxShadow: '0 0 50px rgba(252,211,77,0.4)',
+      }}
+    />
+    <div style={{ position: 'absolute', top: 96, left: 32, fontSize: 18, color: '#fde68a', opacity: 0.85 }}>✦</div>
+    <div style={{ position: 'absolute', top: 64, left: 72, fontSize: 14, color: '#fde68a', opacity: 0.6 }}>✧</div>
+    <div style={{ position: 'absolute', top: 130, right: 100, fontSize: 12, color: '#fde68a', opacity: 0.7 }}>✦</div>
+    {/* Hills */}
+    <div
+      style={{
+        position: 'absolute',
+        bottom: 0,
+        left: -30,
+        width: 180,
+        height: 80,
+        borderRadius: '50% 50% 0 0',
+        background: '#1e1b4b',
+        opacity: 0.7,
+      }}
+    />
+    <div
+      style={{
+        position: 'absolute',
+        bottom: 0,
+        right: -20,
+        width: 200,
+        height: 90,
+        borderRadius: '50% 50% 0 0',
+        background: '#312e81',
+        opacity: 0.6,
+      }}
+    />
+  </div>
+);

--- a/src/components/PainterlyBanner.tsx
+++ b/src/components/PainterlyBanner.tsx
@@ -1,0 +1,61 @@
+type BannerPalette = 'morning' | 'evening' | 'pink' | 'amber' | 'purple';
+
+interface PainterlyBannerProps {
+  label: string;
+  title: string;
+  palette?: BannerPalette;
+}
+
+const PALETTES: Record<BannerPalette, { bg: string; sub: string; main: string; deco1: string; deco2: string }> = {
+  morning: { bg: 'linear-gradient(135deg,#fed7aa,#fbcfe8,#ddd6fe)', sub: '#9a3412', main: '#7c2d12', deco1: '☀️', deco2: '🌈' },
+  evening: { bg: 'linear-gradient(135deg,#312e81,#7c3aed,#a78bfa)', sub: '#fde68a', main: '#fff',    deco1: '🌙', deco2: '✨' },
+  pink:    { bg: 'linear-gradient(135deg,#fce7f3,#fbcfe8,#fda4af)', sub: '#9d174d', main: '#831843', deco1: '✿',  deco2: '💫' },
+  amber:   { bg: 'linear-gradient(135deg,#fef3c7,#fed7aa,#fdba74)', sub: '#9a3412', main: '#7c2d12', deco1: '🏆', deco2: '⭐' },
+  purple:  { bg: 'linear-gradient(135deg,#e9defc,#ddd6fe,#c4b5fd)', sub: '#5b21b6', main: '#4c1d95', deco1: '💗', deco2: '🌸' },
+};
+
+export const PainterlyBanner = ({ label, title, palette = 'morning' }: PainterlyBannerProps) => {
+  const p = PALETTES[palette];
+  return (
+    <div
+      style={{
+        position: 'relative',
+        margin: '8px 14px 12px',
+        borderRadius: 22,
+        overflow: 'hidden',
+        boxShadow: '0 4px 12px rgba(180,120,80,0.08)',
+      }}
+    >
+      <div style={{ background: p.bg, padding: '18px 16px', position: 'relative', minHeight: 80 }}>
+        <div style={{ position: 'absolute', left: 8, top: 8, fontSize: 28, opacity: 0.85 }}>{p.deco1}</div>
+        <div style={{ position: 'absolute', right: 10, bottom: 8, fontSize: 18, opacity: 0.7 }}>{p.deco2}</div>
+        <div style={{ position: 'absolute', left: 90, top: 14, fontSize: 11, color: p.sub, opacity: 0.6 }}>✦</div>
+        <div style={{ position: 'absolute', right: 50, top: 30, fontSize: 9, color: p.sub, opacity: 0.5 }}>✦</div>
+        <div style={{ textAlign: 'center', position: 'relative', marginTop: 4 }}>
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 600,
+              color: p.sub,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+            }}
+          >
+            {label}
+          </div>
+          <div
+            style={{
+              fontSize: 24,
+              fontWeight: 600,
+              color: p.main,
+              marginTop: 2,
+              fontStyle: 'italic',
+            }}
+          >
+            {title}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/RoutinesTab.tsx
+++ b/src/components/RoutinesTab.tsx
@@ -1,0 +1,204 @@
+import { useRef } from 'react';
+import confetti from 'canvas-confetti';
+import { PainterlyBanner } from './PainterlyBanner';
+import { getMascot } from '@/lib/mascots';
+import type { Child, RoutineType } from '@/lib/types';
+
+interface RoutinesTabProps {
+  kid: Child;
+  theme: 'morning' | 'evening';
+  onToggleTask: (kidId: string, routine: RoutineType, taskId: string) => void;
+}
+
+const INK = '#3d2c1f';
+const INK_MUTE = '#8a7866';
+const PEACH = '#ffe8d6';
+const LAVENDER = '#e9defc';
+const ROUTINES_ORANGE = '#f97316';
+const MOOD_PURPLE = '#a855f7';
+
+function fireTaskConfetti(el: HTMLElement | null) {
+  if (!el) return;
+  const r = el.getBoundingClientRect();
+  const x = (r.left + r.width / 2) / window.innerWidth;
+  const y = (r.top + r.height / 2) / window.innerHeight;
+  void confetti({
+    particleCount: 50,
+    spread: 80,
+    origin: { x, y },
+    colors: ['#f97316', '#ec4899', '#a855f7', '#22c55e', '#f59e0b'],
+    startVelocity: 30,
+    gravity: 0.85,
+    scalar: 0.85,
+    ticks: 120,
+  });
+}
+
+function fireRoutineConfetti() {
+  const fire = (ratio: number, opts: confetti.Options) =>
+    confetti({
+      particleCount: Math.floor(180 * ratio),
+      origin: { y: 0.65 },
+      colors: ['#f97316', '#ec4899', '#a855f7', '#22c55e', '#f59e0b', '#0ea5e9'],
+      ...opts,
+    });
+  void fire(0.3, { spread: 30, startVelocity: 55 });
+  void fire(0.3, { spread: 70 });
+  void fire(0.4, { spread: 110, decay: 0.91, scalar: 0.85 });
+}
+
+export const RoutinesTab = ({ kid, theme, onToggleTask }: RoutinesTabProps) => {
+  const isMorning = theme === 'morning';
+  const tasks = isMorning ? kid.morning : kid.evening;
+  const done = tasks.filter((t) => t.completed).length;
+  const m = getMascot(kid.mascotId ?? kid.avatarAnimal);
+  const buttonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+
+  const handleTap = (taskId: string) => {
+    const wasCompleted = tasks.find((t) => t.id === taskId)?.completed;
+    onToggleTask(kid.id, isMorning ? 'morning' : 'evening', taskId);
+    if (!wasCompleted) {
+      fireTaskConfetti(buttonRefs.current[taskId] ?? null);
+      // Check all-done after state update
+      const remaining = tasks.filter((t) => t.id !== taskId && !t.completed);
+      if (remaining.length === 0) {
+        setTimeout(() => fireRoutineConfetti(), 120);
+      }
+    }
+  };
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        overflowY: 'auto',
+        paddingBottom: 80,
+        background: 'linear-gradient(180deg,#fff9f0 0%,#fef0e1 100%)',
+        fontFamily: "'Fredoka', system-ui, sans-serif",
+        color: INK,
+      }}
+    >
+      <PainterlyBanner
+        label={`${m.emoji} ${kid.name}'s`}
+        title={isMorning ? 'Morning Routine' : 'Night Routine'}
+        palette={isMorning ? 'morning' : 'evening'}
+      />
+
+      {/* Progress row */}
+      <div
+        style={{
+          padding: '0 16px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: 8,
+        }}
+      >
+        <div style={{ fontSize: 12, fontWeight: 600, color: INK_MUTE }}>
+          {done} of {tasks.length} done
+        </div>
+        <div style={{ display: 'flex', gap: 4 }}>
+          {tasks.map((t) => (
+            <div
+              key={t.id}
+              style={{
+                width: 16,
+                height: 4,
+                borderRadius: 99,
+                background: t.completed ? ROUTINES_ORANGE : 'rgba(180,120,80,0.18)',
+              }}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Task cards */}
+      <div style={{ padding: '4px 14px', display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {tasks.map((t, i) => {
+          const cardBg = t.completed ? LAVENDER : i % 2 === 0 ? PEACH : '#fff1e1';
+          return (
+            <button
+              key={t.id}
+              ref={(el) => { buttonRefs.current[t.id] = el; }}
+              onClick={() => handleTap(t.id)}
+              style={{
+                background: cardBg,
+                borderRadius: 18,
+                padding: '12px 14px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                opacity: t.completed ? 0.7 : 1,
+                border: '1px solid rgba(255,255,255,0.5)',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+                color: 'inherit',
+                textAlign: 'left',
+                width: '100%',
+                WebkitTapHighlightColor: 'transparent',
+                transition: 'transform 0.1s, opacity 0.3s',
+              }}
+            >
+              <div
+                style={{
+                  width: 38,
+                  height: 38,
+                  borderRadius: 12,
+                  background: 'rgba(255,255,255,0.7)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 22,
+                  flexShrink: 0,
+                }}
+              >
+                {t.icon}
+              </div>
+              <div
+                style={{
+                  flex: 1,
+                  fontSize: 14,
+                  fontWeight: 500,
+                  textDecoration: t.completed ? 'line-through' : 'none',
+                }}
+              >
+                {t.title}
+              </div>
+              <div
+                style={{
+                  width: 26,
+                  height: 26,
+                  borderRadius: '50%',
+                  background: t.completed ? MOOD_PURPLE : 'transparent',
+                  border: t.completed ? 'none' : '2px solid rgba(180,120,80,0.3)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  color: '#fff',
+                  fontSize: 14,
+                  fontWeight: 700,
+                  flexShrink: 0,
+                  transition: 'all 0.2s',
+                }}
+              >
+                {t.completed && '✓'}
+              </div>
+            </button>
+          );
+        })}
+        {tasks.length === 0 && (
+          <div
+            style={{
+              textAlign: 'center',
+              padding: '32px 16px',
+              color: INK_MUTE,
+              fontSize: 13,
+            }}
+          >
+            No tasks yet — ask a parent to add some! 🌟
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/AdminAchievements.tsx
+++ b/src/components/admin/AdminAchievements.tsx
@@ -1,0 +1,188 @@
+import { AdminBar } from './AdminBar';
+import { BADGE_CATALOG } from '@/lib/mascots';
+import type { Child } from '@/lib/types';
+
+const INK = '#3d2c1f';
+const INK_MUTE = '#8a7866';
+
+interface AdminAchievementsProps {
+  kid: Child;
+  onBack: () => void;
+  onToggleBadge: (kidId: string, badgeId: string) => void;
+}
+
+export const AdminAchievements = ({
+  kid,
+  onBack,
+  onToggleBadge,
+}: AdminAchievementsProps) => {
+  const badges = kid.badges ?? {};
+  const earnedCount = Object.values(badges).filter(Boolean).length;
+  const streak = kid.streak ?? 0;
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        background: '#fff9f0',
+        fontFamily: "'Fredoka', system-ui, sans-serif",
+        color: INK,
+        overflowY: 'auto',
+      }}
+    >
+      <AdminBar sub={`${kid.name}'s setup`} title="Awards" onBack={onBack} />
+
+      {/* Streak summary */}
+      <div style={{ padding: '12px 14px 0' }}>
+        <div
+          style={{
+            background: 'linear-gradient(135deg,#fed7aa,#fdba74)',
+            borderRadius: 18,
+            padding: '14px 16px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+          }}
+        >
+          <div style={{ fontSize: 30 }}>🔥</div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 24, fontWeight: 700, color: '#7c2d12', lineHeight: 1 }}>
+              {streak}
+              <span style={{ fontSize: 13, fontWeight: 600 }}> day streak</span>
+            </div>
+            <div style={{ fontSize: 11, color: '#9a3412', marginTop: 2 }}>Keep it up! 🌟</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Celebration toggle */}
+      <div style={{ padding: '8px 14px 0' }}>
+        <div
+          style={{
+            background: '#fff',
+            borderRadius: 16,
+            padding: '11px 14px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+            border: '1.5px solid rgba(180,120,80,0.05)',
+          }}
+        >
+          <div style={{ fontSize: 20 }}>🔔</div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 13, fontWeight: 600 }}>Celebrate streaks</div>
+            <div style={{ fontSize: 11, color: INK_MUTE }}>Confetti & balloons when earned</div>
+          </div>
+          <div
+            style={{
+              width: 38,
+              height: 22,
+              borderRadius: 99,
+              background: '#f59e0b',
+              position: 'relative',
+            }}
+          >
+            <div
+              style={{
+                position: 'absolute',
+                top: 2,
+                right: 2,
+                width: 18,
+                height: 18,
+                borderRadius: '50%',
+                background: '#fff',
+                boxShadow: '0 1px 3px rgba(0,0,0,0.15)',
+              }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Badges */}
+      <div style={{ padding: '14px 14px 24px' }}>
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: INK_MUTE,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            marginBottom: 8,
+          }}
+        >
+          Badges · {earnedCount} of {BADGE_CATALOG.length}
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {BADGE_CATALOG.map((b) => {
+            const earned = Boolean(badges[b.id]);
+            return (
+              <div
+                key={b.id}
+                style={{
+                  background: '#fff',
+                  borderRadius: 14,
+                  padding: '10px 14px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 12,
+                  border: `1.5px solid ${earned ? '#fed7aa' : 'rgba(180,120,80,0.05)'}`,
+                }}
+              >
+                <div
+                  style={{
+                    width: 38,
+                    height: 38,
+                    borderRadius: 12,
+                    background: earned ? '#fef3c7' : '#fff9f0',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: 20,
+                    filter: earned ? 'none' : 'grayscale(0.7)',
+                    opacity: earned ? 1 : 0.5,
+                    flexShrink: 0,
+                  }}
+                >
+                  {b.icon}
+                </div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600 }}>{b.name}</div>
+                  <div style={{ fontSize: 10, color: INK_MUTE }}>{b.desc}</div>
+                </div>
+                <button
+                  onClick={() => onToggleBadge(kid.id, b.id)}
+                  style={{
+                    width: 38,
+                    height: 22,
+                    borderRadius: 99,
+                    background: earned ? '#f59e0b' : '#e2e8f0',
+                    position: 'relative',
+                    cursor: 'pointer',
+                    border: 'none',
+                    fontFamily: 'inherit',
+                    WebkitTapHighlightColor: 'transparent',
+                    transition: 'background 0.18s',
+                  }}
+                >
+                  <div
+                    style={{
+                      position: 'absolute',
+                      top: 2,
+                      left: earned ? 18 : 2,
+                      width: 18,
+                      height: 18,
+                      borderRadius: '50%',
+                      background: '#fff',
+                      boxShadow: '0 1px 3px rgba(0,0,0,0.15)',
+                      transition: 'left 0.18s',
+                    }}
+                  />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/AdminAffirmations.tsx
+++ b/src/components/admin/AdminAffirmations.tsx
@@ -1,0 +1,220 @@
+import { useState } from 'react';
+import { AdminBar } from './AdminBar';
+import type { Child } from '@/lib/types';
+
+const INK = '#3d2c1f';
+const INK_MUTE = '#8a7866';
+
+const FAVE_COLORS = ['#fef3c7', '#dcfce7', '#dbeafe', '#fce7f3'];
+const FAVE_ICONS = ['🌟', '🦁', '💙', '💗'];
+
+interface AdminAffirmationsProps {
+  kid: Child;
+  onBack: () => void;
+  onAdd: (kidId: string, text: string) => void;
+  onRemove: (kidId: string, idx: number) => void;
+}
+
+export const AdminAffirmations = ({
+  kid,
+  onBack,
+  onAdd,
+  onRemove,
+}: AdminAffirmationsProps) => {
+  const [draft, setDraft] = useState('');
+  const affirmations = kid.affirmations ?? [];
+
+  const handleAdd = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    onAdd(kid.id, trimmed);
+    setDraft('');
+  };
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        background: '#fff9f0',
+        fontFamily: "'Fredoka', system-ui, sans-serif",
+        color: INK,
+        overflowY: 'auto',
+      }}
+    >
+      <AdminBar sub={`${kid.name}'s setup`} title="Affirmations" onBack={onBack} />
+
+      {/* Daily affirmation banner */}
+      <div style={{ padding: '12px 14px 0' }}>
+        <div
+          style={{
+            background: 'linear-gradient(135deg,#fce7f3,#fbcfe8)',
+            borderRadius: 18,
+            padding: '14px 16px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 12,
+          }}
+        >
+          <div style={{ fontSize: 26 }}>💫</div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 13, fontWeight: 700, color: '#831843' }}>Daily affirmation</div>
+            <div style={{ fontSize: 11, color: '#be185d', marginTop: 1 }}>A new one each morning</div>
+          </div>
+          {/* Toggle (static on) */}
+          <div
+            style={{
+              width: 38,
+              height: 22,
+              borderRadius: 99,
+              background: '#ec4899',
+              position: 'relative',
+              cursor: 'pointer',
+            }}
+          >
+            <div
+              style={{
+                position: 'absolute',
+                top: 2,
+                right: 2,
+                width: 18,
+                height: 18,
+                borderRadius: '50%',
+                background: '#fff',
+                boxShadow: '0 1px 3px rgba(0,0,0,0.15)',
+              }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Add input */}
+      <div style={{ padding: '12px 14px 0' }}>
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: INK_MUTE,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            marginBottom: 6,
+          }}
+        >
+          Add new
+        </div>
+        <div
+          style={{
+            background: '#fff',
+            borderRadius: 16,
+            padding: '10px 12px',
+            border: '1.5px solid rgba(180,120,80,0.05)',
+            display: 'flex',
+            gap: 8,
+            alignItems: 'center',
+          }}
+        >
+          <input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder='"I am brave and kind."'
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleAdd();
+            }}
+            style={{
+              flex: 1,
+              border: 'none',
+              outline: 'none',
+              background: 'transparent',
+              fontFamily: 'inherit',
+              fontSize: 13,
+              color: INK,
+              fontStyle: 'italic',
+            }}
+          />
+          <button
+            onClick={handleAdd}
+            disabled={!draft.trim()}
+            style={{
+              background: draft.trim() ? '#ec4899' : '#f1f5f9',
+              color: draft.trim() ? '#fff' : INK_MUTE,
+              border: 'none',
+              borderRadius: 10,
+              padding: '6px 12px',
+              fontSize: 11,
+              fontWeight: 700,
+              cursor: draft.trim() ? 'pointer' : 'default',
+              fontFamily: 'inherit',
+              WebkitTapHighlightColor: 'transparent',
+            }}
+          >
+            Add
+          </button>
+        </div>
+      </div>
+
+      {/* Saved list */}
+      <div style={{ padding: '14px 14px 24px' }}>
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: INK_MUTE,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            marginBottom: 6,
+          }}
+        >
+          Saved ({affirmations.length})
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {affirmations.map((aff, i) => (
+            <div
+              key={i}
+              style={{
+                background: FAVE_COLORS[i % FAVE_COLORS.length],
+                borderRadius: 14,
+                padding: '10px 14px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+              }}
+            >
+              <div style={{ fontSize: 16 }}>{FAVE_ICONS[i % FAVE_ICONS.length]}</div>
+              <div style={{ flex: 1, fontSize: 13, fontWeight: 500, fontStyle: 'italic' }}>
+                "{aff}"
+              </div>
+              <button
+                onClick={() => onRemove(kid.id, i)}
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  cursor: 'pointer',
+                  fontSize: 14,
+                  color: INK_MUTE,
+                  padding: 4,
+                  fontFamily: 'inherit',
+                  WebkitTapHighlightColor: 'transparent',
+                }}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+          {affirmations.length === 0 && (
+            <div
+              style={{
+                textAlign: 'center',
+                padding: '20px 14px',
+                color: INK_MUTE,
+                fontSize: 12,
+                border: '1.5px dashed rgba(180,120,80,0.15)',
+                borderRadius: 14,
+              }}
+            >
+              No affirmations yet
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/AdminApp.tsx
+++ b/src/components/admin/AdminApp.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react';
+import { AdminHome } from './AdminHome';
+import { AdminKidProfile } from './AdminKidProfile';
+import { AdminRoutines } from './AdminRoutines';
+import { AdminAffirmations } from './AdminAffirmations';
+import { AdminAchievements } from './AdminAchievements';
+import { AdminMood } from './AdminMood';
+import type { Child, RoutineType } from '@/lib/types';
+
+type AdminScreen =
+  | { screen: 'home' }
+  | { screen: 'profile'; kidId: string }
+  | { screen: 'routines'; kidId: string }
+  | { screen: 'affirmations'; kidId: string }
+  | { screen: 'achievements'; kidId: string }
+  | { screen: 'mood'; kidId: string };
+
+interface AdminAppProps {
+  kids: Child[];
+  onClose: () => void;
+  onChangeMascot: (kidId: string, mascotId: string) => void;
+  onAddTask: (kidId: string, routine: RoutineType) => void;
+  onRemoveTask: (kidId: string, routine: RoutineType, taskId: string) => void;
+  onAddAffirmation: (kidId: string, text: string) => void;
+  onRemoveAffirmation: (kidId: string, idx: number) => void;
+  onToggleBadge: (kidId: string, badgeId: string) => void;
+  onAddKid: () => void;
+  cloudSyncStatus?: 'idle' | 'saving' | 'saved' | 'error';
+  onSignOut?: () => void;
+  onOpenAdvancedSettings?: () => void;
+  onRestartSetup?: () => void;
+  onResetAppData?: () => void;
+}
+
+export const AdminApp = ({
+  kids,
+  onClose,
+  onChangeMascot,
+  onAddTask,
+  onRemoveTask,
+  onAddAffirmation,
+  onRemoveAffirmation,
+  onToggleBadge,
+  onAddKid,
+  cloudSyncStatus,
+  onSignOut,
+  onOpenAdvancedSettings,
+  onRestartSetup,
+  onResetAppData,
+}: AdminAppProps) => {
+  const [path, setPath] = useState<AdminScreen>({ screen: 'home' });
+
+  const kid = path.screen !== 'home' ? kids.find((k) => k.id === path.kidId) : null;
+
+  // Navigation helpers
+  const goHome = () => setPath({ screen: 'home' });
+
+  const pickKid = (kidId: string, section: string) => {
+    if (section === 'profile') {
+      setPath({ screen: 'profile', kidId });
+    } else if (section === 'routines') {
+      setPath({ screen: 'routines', kidId });
+    } else if (section === 'affirmations') {
+      setPath({ screen: 'affirmations', kidId });
+    } else if (section === 'achievements') {
+      setPath({ screen: 'achievements', kidId });
+    } else if (section === 'mood') {
+      setPath({ screen: 'mood', kidId });
+    }
+  };
+
+  if (path.screen === 'home') {
+    return (
+      <AdminHome
+        kids={kids}
+        onBack={onClose}
+        onPickKid={pickKid}
+        onAddKid={onAddKid}
+        cloudSyncStatus={cloudSyncStatus}
+        onSignOut={onSignOut}
+        onOpenAdvancedSettings={onOpenAdvancedSettings}
+        onRestartSetup={onRestartSetup}
+        onResetAppData={onResetAppData}
+      />
+    );
+  }
+
+  if (!kid) return null;
+
+  if (path.screen === 'profile') {
+    return (
+      <AdminKidProfile
+        kid={kid}
+        onBack={goHome}
+        onPickSection={(section) => pickKid(kid.id, section)}
+        onChangeMascot={onChangeMascot}
+      />
+    );
+  }
+
+  if (path.screen === 'routines') {
+    return (
+      <AdminRoutines
+        kid={kid}
+        onBack={goHome}
+        onAddTask={onAddTask}
+        onRemoveTask={onRemoveTask}
+      />
+    );
+  }
+
+  if (path.screen === 'affirmations') {
+    return (
+      <AdminAffirmations
+        kid={kid}
+        onBack={goHome}
+        onAdd={onAddAffirmation}
+        onRemove={onRemoveAffirmation}
+      />
+    );
+  }
+
+  if (path.screen === 'achievements') {
+    return (
+      <AdminAchievements
+        kid={kid}
+        onBack={goHome}
+        onToggleBadge={onToggleBadge}
+      />
+    );
+  }
+
+  if (path.screen === 'mood') {
+    return <AdminMood kid={kid} onBack={goHome} />;
+  }
+
+  return null;
+};

--- a/src/components/admin/AdminBar.tsx
+++ b/src/components/admin/AdminBar.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from 'react';
+
+const INK = '#3d2c1f';
+const INK_MUTE = '#8a7866';
+
+interface AdminBarProps {
+  title: string;
+  sub?: string;
+  onBack: () => void;
+  right?: ReactNode;
+}
+
+export const AdminBar = ({ title, sub, onBack, right }: AdminBarProps) => (
+  <div
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 10,
+      padding: '12px 14px 10px',
+      background: '#fff9f0',
+      position: 'sticky',
+      top: 0,
+      zIndex: 10,
+      borderBottom: '1px solid rgba(180,120,80,0.06)',
+    }}
+  >
+    <button
+      onClick={onBack}
+      style={{
+        width: 34,
+        height: 34,
+        borderRadius: 12,
+        background: '#fff',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 16,
+        color: INK,
+        border: 'none',
+        cursor: 'pointer',
+        boxShadow: '0 2px 6px rgba(180,120,80,0.08)',
+        fontFamily: 'inherit',
+        WebkitTapHighlightColor: 'transparent',
+      }}
+    >
+      ‹
+    </button>
+    <div style={{ flex: 1 }}>
+      {sub && (
+        <div
+          style={{
+            fontSize: 10,
+            fontWeight: 600,
+            color: INK_MUTE,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+          }}
+        >
+          {sub}
+        </div>
+      )}
+      <div style={{ fontSize: 17, fontWeight: 600, color: INK }}>{title}</div>
+    </div>
+    {right}
+  </div>
+);

--- a/src/components/admin/AdminHome.tsx
+++ b/src/components/admin/AdminHome.tsx
@@ -1,0 +1,315 @@
+import { AdminBar } from './AdminBar';
+import { getMascot, BADGE_CATALOG } from '@/lib/mascots';
+import type { Child } from '@/lib/types';
+
+const INK = '#3d2c1f';
+const INK_MUTE = '#8a7866';
+
+interface AdminHomeProps {
+  kids: Child[];
+  onBack: () => void;
+  onPickKid: (kidId: string, section: string) => void;
+  onAddKid: () => void;
+  cloudSyncStatus?: 'idle' | 'saving' | 'saved' | 'error';
+  onSignOut?: () => void;
+  onOpenAdvancedSettings?: () => void;
+  onRestartSetup?: () => void;
+  onResetAppData?: () => void;
+}
+
+export const AdminHome = ({
+  kids,
+  onBack,
+  onPickKid,
+  onAddKid,
+  cloudSyncStatus,
+  onSignOut,
+  onOpenAdvancedSettings,
+  onRestartSetup,
+  onResetAppData,
+}: AdminHomeProps) => (
+  <div
+    style={{
+      height: '100%',
+      background: '#fff9f0',
+      fontFamily: "'Fredoka', system-ui, sans-serif",
+      color: INK,
+      overflowY: 'auto',
+    }}
+  >
+    <AdminBar
+      sub="Parent settings"
+      title="Your family"
+      onBack={onBack}
+      right={
+        <button
+          onClick={onAddKid}
+          style={{
+            background: '#f97316',
+            color: '#fff',
+            border: 'none',
+            borderRadius: 12,
+            padding: '7px 14px',
+            fontSize: 12,
+            fontWeight: 700,
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+            boxShadow: '0 3px 0 rgba(194,65,12,0.4)',
+            WebkitTapHighlightColor: 'transparent',
+          }}
+        >
+          + Add
+        </button>
+      }
+    />
+
+    <div
+      style={{
+        padding: '12px 14px 24px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+      }}
+    >
+      {kids.map((k) => {
+        const m = getMascot(k.mascotId ?? k.avatarAnimal);
+        const streak = k.streak ?? 0;
+        const badges = k.badges ?? {};
+        const earnedBadges = Object.values(badges).filter(Boolean).length;
+
+        const sections = [
+          {
+            id: 'routines',
+            label: 'Routines',
+            icon: '✅',
+            meta: `${k.morning.length} morn · ${k.evening.length} eve`,
+          },
+          {
+            id: 'affirmations',
+            label: 'Affirmations',
+            icon: '💫',
+            meta: `${(k.affirmations ?? []).length} saved`,
+          },
+          {
+            id: 'achievements',
+            label: 'Awards',
+            icon: '🏆',
+            meta: `${earnedBadges} of ${BADGE_CATALOG.length} badges`,
+          },
+          { id: 'mood', label: 'Mood', icon: '💗', meta: 'Daily check-in' },
+        ];
+
+        return (
+          <div
+            key={k.id}
+            style={{
+              background: '#fff',
+              borderRadius: 22,
+              padding: 14,
+              boxShadow: '0 4px 12px rgba(180,120,80,0.06)',
+              border: '1.5px solid rgba(180,120,80,0.04)',
+            }}
+          >
+            {/* Kid header */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 10 }}>
+              <div
+                style={{
+                  width: 48,
+                  height: 48,
+                  borderRadius: 16,
+                  background: `linear-gradient(135deg, ${m.light}, ${m.color}33)`,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 26,
+                  flexShrink: 0,
+                }}
+              >
+                {m.emoji}
+              </div>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 15, fontWeight: 600 }}>
+                  {k.name}{k.age ? `, age ${k.age}` : ''}
+                </div>
+                <div style={{ fontSize: 11, color: INK_MUTE }}>
+                  with {m.name}{streak > 0 ? ` · ${streak} day streak` : ''}
+                </div>
+              </div>
+              <button
+                onClick={() => onPickKid(k.id, 'profile')}
+                style={{
+                  fontSize: 18,
+                  color: INK_MUTE,
+                  padding: 4,
+                  background: 'none',
+                  border: 'none',
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                }}
+              >
+                ···
+              </button>
+            </div>
+
+            {/* Section pills */}
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 6 }}>
+              {sections.map((s) => (
+                <button
+                  key={s.id}
+                  onClick={() => onPickKid(k.id, s.id)}
+                  style={{
+                    background: '#fff9f0',
+                    borderRadius: 12,
+                    padding: '9px 10px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 8,
+                    border: '1px solid rgba(180,120,80,0.06)',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    fontFamily: 'inherit',
+                    color: 'inherit',
+                    WebkitTapHighlightColor: 'transparent',
+                  }}
+                >
+                  <div style={{ fontSize: 16 }}>{s.icon}</div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 11, fontWeight: 700 }}>{s.label}</div>
+                    <div
+                      style={{
+                        fontSize: 9,
+                        color: INK_MUTE,
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                      }}
+                    >
+                      {s.meta}
+                    </div>
+                  </div>
+                  <div style={{ fontSize: 12, color: INK_MUTE }}>›</div>
+                </button>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+
+      {/* Account footer */}
+      <div
+        style={{
+          background: '#fff',
+          borderRadius: 18,
+          padding: '12px 14px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8,
+          border: '1.5px solid rgba(180,120,80,0.04)',
+        }}
+      >
+        <div style={{ fontSize: 11, fontWeight: 700, color: INK_MUTE, letterSpacing: '0.08em', textTransform: 'uppercase' }}>
+          Account
+        </div>
+        {cloudSyncStatus && cloudSyncStatus !== 'idle' && (
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 600,
+              color: cloudSyncStatus === 'saved' ? '#16a34a' : cloudSyncStatus === 'error' ? '#dc2626' : '#2563eb',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 6,
+            }}
+          >
+            {cloudSyncStatus === 'saved' ? '✓' : cloudSyncStatus === 'error' ? '⚠' : '↻'}{' '}
+            {cloudSyncStatus === 'saved' ? 'Family data synced' : cloudSyncStatus === 'error' ? 'Sync error — check connection' : 'Saving…'}
+          </div>
+        )}
+        {onOpenAdvancedSettings && (
+          <button
+            onClick={onOpenAdvancedSettings}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: '6px 0',
+              textAlign: 'left',
+              fontFamily: 'inherit',
+              fontSize: 13,
+              fontWeight: 500,
+              color: INK,
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              WebkitTapHighlightColor: 'transparent',
+            }}
+          >
+            <span style={{ fontSize: 16 }}>⚙️</span> Advanced settings
+            <span style={{ marginLeft: 'auto', fontSize: 14, color: INK_MUTE }}>›</span>
+          </button>
+        )}
+        {onRestartSetup && (
+          <button
+            onClick={onRestartSetup}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: '6px 0',
+              textAlign: 'left',
+              fontFamily: 'inherit',
+              fontSize: 12,
+              fontWeight: 500,
+              color: INK_MUTE,
+              width: '100%',
+              WebkitTapHighlightColor: 'transparent',
+            }}
+          >
+            Restart setup wizard
+          </button>
+        )}
+        {onResetAppData && (
+          <button
+            onClick={onResetAppData}
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: '6px 0',
+              textAlign: 'left',
+              fontFamily: 'inherit',
+              fontSize: 12,
+              fontWeight: 500,
+              color: '#dc2626',
+              width: '100%',
+              WebkitTapHighlightColor: 'transparent',
+            }}
+          >
+            Delete all data &amp; start over
+          </button>
+        )}
+        {onSignOut && (
+          <button
+            onClick={onSignOut}
+            style={{
+              background: '#fff9f0',
+              border: '1px solid rgba(180,120,80,0.1)',
+              borderRadius: 10,
+              cursor: 'pointer',
+              padding: '8px 14px',
+              fontFamily: 'inherit',
+              fontSize: 12,
+              fontWeight: 700,
+              color: '#dc2626',
+              width: '100%',
+              textAlign: 'center',
+              WebkitTapHighlightColor: 'transparent',
+            }}
+          >
+            Sign out
+          </button>
+        )}
+      </div>
+    </div>
+  </div>
+);

--- a/src/components/admin/AdminKidProfile.tsx
+++ b/src/components/admin/AdminKidProfile.tsx
@@ -1,0 +1,266 @@
+import { useState } from 'react';
+import { AdminBar } from './AdminBar';
+import { getMascot, MASCOTS, BADGE_CATALOG } from '@/lib/mascots';
+import type { Child } from '@/lib/types';
+
+const INK = '#3d2c1f';
+const INK_MUTE = '#8a7866';
+
+interface AdminKidProfileProps {
+  kid: Child;
+  onBack: () => void;
+  onPickSection: (section: string) => void;
+  onChangeMascot: (kidId: string, mascotId: string) => void;
+}
+
+export const AdminKidProfile = ({
+  kid,
+  onBack,
+  onPickSection,
+  onChangeMascot,
+}: AdminKidProfileProps) => {
+  const [showPicker, setShowPicker] = useState(false);
+  const m = getMascot(kid.mascotId ?? kid.avatarAnimal);
+  const badges = kid.badges ?? {};
+  const earnedBadges = Object.values(badges).filter(Boolean).length;
+
+  const sections = [
+    {
+      id: 'routines',
+      icon: '✅',
+      label: 'Routines',
+      desc: `${kid.morning.length} morning · ${kid.evening.length} evening tasks`,
+      tint: '#f97316',
+    },
+    {
+      id: 'affirmations',
+      icon: '💫',
+      label: 'Affirmations',
+      desc: `${(kid.affirmations ?? []).length} saved affirmations`,
+      tint: '#ec4899',
+    },
+    {
+      id: 'achievements',
+      icon: '🏆',
+      label: 'Awards',
+      desc: `${earnedBadges} of ${BADGE_CATALOG.length} badges earned`,
+      tint: '#f59e0b',
+    },
+    {
+      id: 'mood',
+      icon: '💗',
+      label: 'Mood',
+      desc: 'Daily emoji check-in enabled',
+      tint: '#a855f7',
+    },
+  ];
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        background: '#fff9f0',
+        fontFamily: "'Fredoka', system-ui, sans-serif",
+        color: INK,
+        overflowY: 'auto',
+        position: 'relative',
+      }}
+    >
+      <AdminBar sub="Parent settings" title={`${kid.name}'s setup`} onBack={onBack} />
+
+      {/* Profile card */}
+      <div style={{ padding: '12px 14px 0' }}>
+        <div
+          style={{
+            background: '#fff',
+            borderRadius: 22,
+            padding: 16,
+            boxShadow: '0 4px 12px rgba(180,120,80,0.06)',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <button
+              onClick={() => setShowPicker(true)}
+              style={{
+                width: 64,
+                height: 64,
+                borderRadius: 20,
+                background: `linear-gradient(135deg, ${m.light}, ${m.color}33)`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 36,
+                border: `2.5px solid ${m.color}44`,
+                position: 'relative',
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+                WebkitTapHighlightColor: 'transparent',
+              }}
+            >
+              {m.emoji}
+              <div
+                style={{
+                  position: 'absolute',
+                  bottom: -4,
+                  right: -4,
+                  background: '#fff',
+                  borderRadius: '50%',
+                  width: 22,
+                  height: 22,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 12,
+                  border: '1.5px solid rgba(180,120,80,0.15)',
+                }}
+              >
+                ✎
+              </div>
+            </button>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 17, fontWeight: 600 }}>{kid.name}</div>
+              <div style={{ fontSize: 12, color: INK_MUTE }}>
+                {kid.age ? `age ${kid.age} · ` : ''}with {m.name}
+              </div>
+              <button
+                onClick={() => setShowPicker(true)}
+                style={{
+                  marginTop: 6,
+                  fontSize: 11,
+                  fontWeight: 700,
+                  color: '#f97316',
+                  background: '#f9731615',
+                  border: 'none',
+                  borderRadius: 10,
+                  padding: '3px 10px',
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                }}
+              >
+                Change mascot
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Feature cards */}
+      <div style={{ padding: '14px 14px 24px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {sections.map((s) => (
+          <button
+            key={s.id}
+            onClick={() => onPickSection(s.id)}
+            style={{
+              background: '#fff',
+              borderRadius: 18,
+              padding: '14px 16px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 14,
+              border: '1.5px solid rgba(180,120,80,0.05)',
+              cursor: 'pointer',
+              fontFamily: 'inherit',
+              color: 'inherit',
+              textAlign: 'left',
+              boxShadow: '0 2px 8px rgba(180,120,80,0.04)',
+              WebkitTapHighlightColor: 'transparent',
+            }}
+          >
+            <div
+              style={{
+                width: 44,
+                height: 44,
+                borderRadius: 14,
+                background: `${s.tint}18`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 22,
+                flexShrink: 0,
+              }}
+            >
+              {s.icon}
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 14, fontWeight: 600 }}>{s.label}</div>
+              <div style={{ fontSize: 11, color: INK_MUTE, marginTop: 2 }}>{s.desc}</div>
+            </div>
+            <div style={{ fontSize: 18, color: INK_MUTE }}>›</div>
+          </button>
+        ))}
+      </div>
+
+      {/* Mascot picker bottom sheet */}
+      {showPicker && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: 100,
+            background: 'rgba(15,23,42,0.4)',
+            display: 'flex',
+            alignItems: 'flex-end',
+          }}
+          onClick={() => setShowPicker(false)}
+        >
+          <div
+            style={{
+              background: '#fff',
+              borderRadius: '24px 24px 0 0',
+              padding: '20px 18px 28px',
+              width: '100%',
+              maxWidth: 480,
+              margin: '0 auto',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div
+              style={{
+                width: 36,
+                height: 4,
+                background: 'rgba(0,0,0,0.15)',
+                borderRadius: 99,
+                margin: '0 auto 14px',
+              }}
+            />
+            <div style={{ fontSize: 16, fontWeight: 700, textAlign: 'center', marginBottom: 4 }}>
+              Pick {kid.name}'s mascot
+            </div>
+            <div style={{ fontSize: 12, color: INK_MUTE, textAlign: 'center', marginBottom: 18 }}>
+              They'll see this everywhere ✨
+            </div>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5,1fr)', gap: 8 }}>
+              {MASCOTS.map((opt) => {
+                const selected = opt.id === (kid.mascotId ?? kid.avatarAnimal);
+                return (
+                  <button
+                    key={opt.id}
+                    onClick={() => {
+                      onChangeMascot(kid.id, opt.id);
+                      setShowPicker(false);
+                    }}
+                    style={{
+                      background: selected ? opt.light : '#fff9f0',
+                      borderRadius: 14,
+                      padding: '10px 4px',
+                      border: selected ? `2.5px solid ${opt.color}` : '2px solid transparent',
+                      cursor: 'pointer',
+                      fontFamily: 'inherit',
+                      textAlign: 'center',
+                      WebkitTapHighlightColor: 'transparent',
+                    }}
+                  >
+                    <div style={{ fontSize: 26 }}>{opt.emoji}</div>
+                    <div style={{ fontSize: 9, fontWeight: 700, color: INK, marginTop: 2 }}>
+                      {opt.name}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/admin/AdminMood.tsx
+++ b/src/components/admin/AdminMood.tsx
@@ -1,0 +1,162 @@
+import { AdminBar } from './AdminBar';
+import { WEEK_DAYS } from '@/lib/mascots';
+import type { Child } from '@/lib/types';
+
+const INK = '#3d2c1f';
+const INK_MUTE = '#8a7866';
+
+interface AdminMoodProps {
+  kid: Child;
+  onBack: () => void;
+}
+
+const SETTINGS = [
+  { icon: '💗', label: 'Daily check-in',  desc: 'Ask after morning routine',     on: true,  tint: '#a855f7' },
+  { icon: '🎤', label: 'Voice notes',     desc: 'Let them record how they feel', on: true,  tint: '#3b82f6' },
+  { icon: '✏️', label: 'Drawing notes',   desc: 'Let them sketch how they feel', on: false, tint: '#f59e0b' },
+  { icon: '🔔', label: 'Reminders',       desc: 'Gentle nudge if skipped',       on: false, tint: '#22c55e' },
+];
+
+export const AdminMood = ({ kid, onBack }: AdminMoodProps) => {
+  const moods = kid.moods ?? WEEK_DAYS.map((day) => ({ day, emoji: null }));
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        background: '#fff9f0',
+        fontFamily: "'Fredoka', system-ui, sans-serif",
+        color: INK,
+        overflowY: 'auto',
+      }}
+    >
+      <AdminBar sub={`${kid.name}'s setup`} title="Mood" onBack={onBack} />
+
+      {/* Settings toggles */}
+      <div style={{ padding: '12px 14px 0', display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {SETTINGS.map((o) => (
+          <div
+            key={o.label}
+            style={{
+              background: '#fff',
+              borderRadius: 16,
+              padding: '11px 14px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              border: '1.5px solid rgba(180,120,80,0.05)',
+            }}
+          >
+            <div
+              style={{
+                width: 36,
+                height: 36,
+                borderRadius: 12,
+                background: `${o.tint}18`,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 18,
+                flexShrink: 0,
+              }}
+            >
+              {o.icon}
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 13, fontWeight: 600 }}>{o.label}</div>
+              <div style={{ fontSize: 11, color: INK_MUTE }}>{o.desc}</div>
+            </div>
+            <div
+              style={{
+                width: 38,
+                height: 22,
+                borderRadius: 99,
+                background: o.on ? o.tint : '#e2e8f0',
+                position: 'relative',
+              }}
+            >
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 2,
+                  left: o.on ? 18 : 2,
+                  width: 18,
+                  height: 18,
+                  borderRadius: '50%',
+                  background: '#fff',
+                  boxShadow: '0 1px 3px rgba(0,0,0,0.15)',
+                }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Week preview */}
+      <div style={{ padding: '14px 14px 0' }}>
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: INK_MUTE,
+            marginBottom: 6,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+          }}
+        >
+          This week's moods
+        </div>
+        <div
+          style={{
+            background: '#fff',
+            borderRadius: 16,
+            padding: 12,
+            border: '1.5px solid rgba(180,120,80,0.05)',
+          }}
+        >
+          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 4 }}>
+            {moods.map((m, i) => (
+              <div
+                key={i}
+                style={{
+                  flex: 1,
+                  textAlign: 'center',
+                  padding: '8px 0',
+                  background: '#fff9f0',
+                  borderRadius: 12,
+                }}
+              >
+                <div style={{ fontSize: 22, opacity: m.emoji ? 1 : 0.25 }}>{m.emoji ?? '·'}</div>
+                <div style={{ fontSize: 9, fontWeight: 700, color: INK_MUTE, marginTop: 2 }}>{m.day}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Insights card */}
+      <div style={{ padding: '12px 14px 24px' }}>
+        <div
+          style={{
+            background: 'linear-gradient(135deg,#e9defc,#ddd6fe)',
+            borderRadius: 16,
+            padding: 14,
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 10,
+          }}
+        >
+          <div style={{ fontSize: 22 }}>💜</div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontSize: 12, fontWeight: 700, color: '#5b21b6' }}>
+              This week's pattern
+            </div>
+            <div style={{ fontSize: 11, color: '#6d28d9', marginTop: 4, lineHeight: 1.5 }}>
+              Keep tracking daily moods — insights will appear here over time. 🌸
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/admin/AdminRoutines.tsx
+++ b/src/components/admin/AdminRoutines.tsx
@@ -1,0 +1,188 @@
+import { useState } from 'react';
+import { AdminBar } from './AdminBar';
+import type { Child, RoutineType } from '@/lib/types';
+
+const INK = '#3d2c1f';
+const INK_MUTE = '#8a7866';
+
+interface AdminRoutinesProps {
+  kid: Child;
+  onBack: () => void;
+  onAddTask: (kidId: string, routine: RoutineType) => void;
+  onRemoveTask: (kidId: string, routine: RoutineType, taskId: string) => void;
+}
+
+export const AdminRoutines = ({
+  kid,
+  onBack,
+  onAddTask,
+  onRemoveTask,
+}: AdminRoutinesProps) => {
+  const [tab, setTab] = useState<RoutineType>('morning');
+  const tasks = tab === 'morning' ? kid.morning : kid.evening;
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        background: '#fff9f0',
+        fontFamily: "'Fredoka', system-ui, sans-serif",
+        color: INK,
+        overflowY: 'auto',
+      }}
+    >
+      <AdminBar sub={`${kid.name}'s setup`} title="Routines" onBack={onBack} />
+
+      {/* Morning / Evening toggle */}
+      <div style={{ padding: '12px 14px 6px' }}>
+        <div
+          style={{
+            background: '#fff',
+            borderRadius: 14,
+            padding: 4,
+            display: 'flex',
+            gap: 4,
+            border: '1.5px solid rgba(180,120,80,0.08)',
+          }}
+        >
+          {[
+            {
+              id: 'morning' as const,
+              label: '☀️ Morning',
+              bg: 'linear-gradient(135deg,#fed7aa,#fdba74)',
+              tx: '#7c2d12',
+            },
+            {
+              id: 'evening' as const,
+              label: '🌙 Evening',
+              bg: 'linear-gradient(135deg,#a78bfa,#7c3aed)',
+              tx: '#fff',
+            },
+          ].map((o) => (
+            <button
+              key={o.id}
+              onClick={() => setTab(o.id)}
+              style={{
+                flex: 1,
+                textAlign: 'center',
+                padding: '8px 0',
+                background: tab === o.id ? o.bg : 'transparent',
+                color: tab === o.id ? o.tx : INK_MUTE,
+                border: 'none',
+                borderRadius: 10,
+                fontSize: 12,
+                fontWeight: 700,
+                cursor: 'pointer',
+                fontFamily: 'inherit',
+                WebkitTapHighlightColor: 'transparent',
+              }}
+            >
+              {o.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Tasks header */}
+      <div
+        style={{
+          padding: '8px 18px 6px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            color: INK_MUTE,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+          }}
+        >
+          Tasks ({tasks.length})
+        </div>
+        <button
+          onClick={() => onAddTask(kid.id, tab)}
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+            fontSize: 11,
+            fontWeight: 700,
+            color: '#f97316',
+            fontFamily: 'inherit',
+            WebkitTapHighlightColor: 'transparent',
+          }}
+        >
+          + Add task
+        </button>
+      </div>
+
+      {/* Tasks list */}
+      <div style={{ padding: '0 14px 24px', display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {tasks.map((t) => (
+          <div
+            key={t.id}
+            style={{
+              background: '#fff',
+              borderRadius: 14,
+              padding: '9px 12px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+              border: '1.5px solid rgba(180,120,80,0.05)',
+            }}
+          >
+            <div style={{ fontSize: 14, color: INK_MUTE, cursor: 'grab' }}>≡</div>
+            <div
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: 10,
+                background: '#fff9f0',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 17,
+              }}
+            >
+              {t.icon}
+            </div>
+            <div style={{ flex: 1, fontSize: 13, fontWeight: 500 }}>{t.title}</div>
+            <button
+              onClick={() => onRemoveTask(kid.id, tab, t.id)}
+              style={{
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                fontSize: 14,
+                color: INK_MUTE,
+                padding: 4,
+                fontFamily: 'inherit',
+                WebkitTapHighlightColor: 'transparent',
+              }}
+            >
+              ×
+            </button>
+          </div>
+        ))}
+        {tasks.length === 0 && (
+          <div
+            style={{
+              textAlign: 'center',
+              padding: '24px 14px',
+              color: INK_MUTE,
+              fontSize: 12,
+              border: '1.5px dashed rgba(180,120,80,0.15)',
+              borderRadius: 14,
+            }}
+          >
+            No tasks yet. Tap "+ Add task" to start.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/lib/mascots.ts
+++ b/src/lib/mascots.ts
@@ -1,0 +1,72 @@
+// Mascot system for Routine Stars — Cozy Pastel redesign
+
+export interface Mascot {
+  id: string;
+  emoji: string;
+  name: string;
+  color: string;
+  light: string;
+}
+
+export interface BadgeEntry {
+  id: string;
+  name: string;
+  icon: string;
+  desc: string;
+}
+
+export interface MoodEntry {
+  day: string;
+  emoji: string | null;
+}
+
+export interface MoodOption {
+  emoji: string;
+  label: string;
+  color: string;
+}
+
+export const MASCOTS: Mascot[] = [
+  { id: 'frog',    emoji: '🐸', name: 'Hoppy',    color: '#22c55e', light: '#dcfce7' },
+  { id: 'bunny',   emoji: '🐰', name: 'Bun',      color: '#ec4899', light: '#fce7f3' },
+  { id: 'cat',     emoji: '🐱', name: 'Whiskers', color: '#a855f7', light: '#f3e8ff' },
+  { id: 'bear',    emoji: '🐻', name: 'Honey',    color: '#f59e0b', light: '#fef3c7' },
+  { id: 'panda',   emoji: '🐼', name: 'Bamboo',   color: '#64748b', light: '#f1f5f9' },
+  { id: 'fox',     emoji: '🦊', name: 'Sly',      color: '#ea580c', light: '#fed7aa' },
+  { id: 'penguin', emoji: '🐧', name: 'Pip',      color: '#0ea5e9', light: '#dbeafe' },
+  { id: 'koala',   emoji: '🐨', name: 'Gum',      color: '#94a3b8', light: '#e2e8f0' },
+  { id: 'unicorn', emoji: '🦄', name: 'Sparkle',  color: '#d946ef', light: '#fae8ff' },
+  { id: 'owl',     emoji: '🦉', name: 'Hoot',     color: '#7c3aed', light: '#ede9fe' },
+];
+
+export function getMascot(id: string | undefined): Mascot {
+  return MASCOTS.find((m) => m.id === id) ?? MASCOTS[0];
+}
+
+export const BADGE_CATALOG: BadgeEntry[] = [
+  { id: 'first-star',    name: 'First Star',      icon: '⭐', desc: 'Finished your first routine' },
+  { id: '7-day-streak',  name: '7 Day Streak',    icon: '🔥', desc: '7 days in a row' },
+  { id: 'early-bird',    name: 'Early Bird',      icon: '🌅', desc: 'Done before 8am' },
+  { id: 'tooth-hero',    name: 'Tooth Hero',      icon: '🦷', desc: 'Brushed 30 days' },
+  { id: 'calm-cloud',    name: 'Calm Cloud',      icon: '☁️', desc: '5 calm moods in a row' },
+  { id: '30-day-streak', name: '30 Day Streak',   icon: '🏆', desc: '30 days in a row' },
+  { id: 'bedtime-boss',  name: 'Bedtime Boss',    icon: '🌙', desc: 'Evening routine 14 days' },
+  { id: 'affirm-pro',    name: 'Affirmation Pro', icon: '💫', desc: 'Listened to 50 affirmations' },
+];
+
+export const DEFAULT_BADGES: Record<string, boolean> = Object.fromEntries(
+  BADGE_CATALOG.map((b) => [b.id, false])
+);
+
+export const MOOD_OPTIONS: MoodOption[] = [
+  { emoji: '😄', label: 'Great', color: '#22c55e' },
+  { emoji: '🙂', label: 'Good',  color: '#84cc16' },
+  { emoji: '😐', label: 'Okay',  color: '#eab308' },
+  { emoji: '😕', label: 'Meh',   color: '#f97316' },
+  { emoji: '😢', label: 'Sad',   color: '#3b82f6' },
+  { emoji: '😡', label: 'Mad',   color: '#ef4444' },
+];
+
+export const WEEK_DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
+
+export const DEFAULT_MOODS: MoodEntry[] = WEEK_DAYS.map((day) => ({ day, emoji: null }));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,6 @@
 import type { AgeBucket, IconKey } from './task-catalog';
 import { AGE_BUCKETS, DEFAULT_CHILDREN, groupTasksByAge, ICON_OPTIONS, TASK_CATALOG, TASK_CATALOG_BY_ID, TASK_LIBRARY } from './task-catalog';
+import type { MoodEntry } from './mascots';
 
 export type Task = {
   id: string;
@@ -21,13 +22,21 @@ export type Child = {
   name: string;
   age?: number;
   ageBucket?: AgeBucket;
+  // Legacy avatar fields (kept for cloud compat)
   avatarSeed?: string;
   avatarAnimal?: string;
+  // New mascot system
+  mascotId?: string;
+  // New feature data (stored locally for now)
+  streak?: number;
+  affirmations?: string[];
+  moods?: MoodEntry[];
+  badges?: Record<string, boolean>;
   schedule?: Record<RoutineType, RoutineSchedule>;
   morning: Task[];
   evening: Task[];
 };
 
-export type AppView = 'account' | 'import' | 'recovery' | 'setup' | 'home' | 'routine' | 'parent' | 'bootstrap-error';
+export type AppView = 'account' | 'import' | 'recovery' | 'setup' | 'home' | 'routine' | 'parent' | 'advanced-settings' | 'bootstrap-error';
 
 export { AGE_BUCKETS, DEFAULT_CHILDREN, groupTasksByAge, ICON_OPTIONS, TASK_CATALOG, TASK_CATALOG_BY_ID, TASK_LIBRARY };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,9 +1,11 @@
 import { lazy, Suspense, useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { ChildSelector } from '@/components/ChildSelector';
 import { AccountEntryScreen } from '@/components/AccountEntryScreen';
 import { ExistingFamilyRecoveryScreen } from '@/components/ExistingFamilyRecoveryScreen';
 import { HouseholdLoadErrorScreen } from '@/components/HouseholdLoadErrorScreen';
 import { ImportFamilySetupScreen } from '@/components/ImportFamilySetupScreen';
+import { KidHome } from '@/components/KidHome';
+import { KidApp } from '@/components/KidApp';
+import { AdminApp } from '@/components/admin/AdminApp';
 import { useAuth } from '@/lib/auth/use-auth';
 import { loadCloudHouseholdState } from '@/lib/data/cloud-household-state';
 import { saveHouseholdConfigToCloud } from '@/lib/data/cloud-household-write';
@@ -11,6 +13,7 @@ import { deleteCloudHousehold } from '@/lib/data/delete-cloud-household';
 import { importLocalFamilyToCloud } from '@/lib/data/local-to-cloud-import';
 import { SupabaseProgressRepository } from '@/lib/data/supabase-progress-repository';
 import { getSupabaseClient } from '@/lib/supabase/client';
+import { DEFAULT_BADGES, DEFAULT_MOODS } from '@/lib/mascots';
 import type { AppView, Child, HomeScene, RoutineType } from '@/lib/types';
 import {
   clearLocalAppState,
@@ -824,6 +827,143 @@ const Index = () => {
     },
     [activeChild, authStatus, household, householdStatus]
   );
+  // ── New redesign handlers ──────────────────────────────────
+
+  /** Toggle a task by kidId + routine + taskId (redesign API) */
+  const handleToggleTask = useCallback(
+    (kidId: string, routine: RoutineType, taskId: string) => {
+      const child = children.find((c) => c.id === kidId);
+      if (!child) return;
+
+      const toggledAt = new Date().toISOString();
+      const nextRoutine = child[routine].map((task) => {
+        if (task.id !== taskId) return task;
+        return { ...task, completed: !task.completed };
+      });
+      const completed = nextRoutine.find((t) => t.id === taskId)?.completed ?? false;
+      const routineCompleted = nextRoutine.length > 0 && nextRoutine.every((t) => t.completed);
+
+      setChildren((prev) =>
+        prev.map((c) => (c.id !== kidId ? c : { ...c, [routine]: nextRoutine }))
+      );
+
+      if (authStatus === 'signed_in' && householdStatus === 'ready' && household) {
+        const supabase = getSupabaseClient();
+        if (!supabase) return;
+        const progressRepository = new SupabaseProgressRepository(supabase);
+        const progressDate = getLocalProgressDate(new Date());
+
+        void progressRepository
+          .upsertRoutineProgress({ childProfileId: kidId, routineType: routine, progressDate, completedAt: null })
+          .then(async (dailyRoutineProgress) => {
+            await progressRepository.setTaskCompletion({
+              dailyRoutineProgressId: dailyRoutineProgress.id,
+              routineTaskId: taskId,
+              completed,
+              completedAt: completed ? toggledAt : null,
+            });
+            await progressRepository.upsertRoutineProgress({
+              childProfileId: kidId,
+              routineType: routine,
+              progressDate,
+              completedAt: routineCompleted ? new Date().toISOString() : null,
+            });
+          })
+          .catch((error) => {
+            console.warn('Could not sync routine progress to cloud.', error);
+          });
+      }
+    },
+    [authStatus, children, household, householdStatus]
+  );
+
+  const handleSetMood = useCallback((kidId: string, dayIdx: number, emoji: string) => {
+    setChildren((prev) =>
+      prev.map((k) =>
+        k.id !== kidId
+          ? k
+          : {
+              ...k,
+              moods: (k.moods ?? DEFAULT_MOODS).map((m, i) =>
+                i === dayIdx ? { ...m, emoji } : m
+              ),
+            }
+      )
+    );
+  }, []);
+
+  const handleToggleBadge = useCallback((kidId: string, badgeId: string) => {
+    setChildren((prev) =>
+      prev.map((k) =>
+        k.id !== kidId
+          ? k
+          : {
+              ...k,
+              badges: {
+                ...(k.badges ?? DEFAULT_BADGES),
+                [badgeId]: !(k.badges ?? DEFAULT_BADGES)[badgeId],
+              },
+            }
+      )
+    );
+  }, []);
+
+  const handleAddAffirmation = useCallback((kidId: string, text: string) => {
+    setChildren((prev) =>
+      prev.map((k) =>
+        k.id !== kidId ? k : { ...k, affirmations: [...(k.affirmations ?? []), text] }
+      )
+    );
+  }, []);
+
+  const handleRemoveAffirmation = useCallback((kidId: string, idx: number) => {
+    setChildren((prev) =>
+      prev.map((k) =>
+        k.id !== kidId
+          ? k
+          : { ...k, affirmations: (k.affirmations ?? []).filter((_, i) => i !== idx) }
+      )
+    );
+  }, []);
+
+  const handleChangeMascot = useCallback((kidId: string, newMascotId: string) => {
+    setChildren((prev) =>
+      prev.map((k) => (k.id !== kidId ? k : { ...k, mascotId: newMascotId }))
+    );
+  }, []);
+
+  const handleAddTask = useCallback(
+    (kidId: string, routine: RoutineType) => {
+      const title = window.prompt('New task title:');
+      if (!title?.trim()) return;
+      const icon = window.prompt('Emoji icon (e.g. ✨):') ?? '✨';
+      const newTask = {
+        id: `${routine}_${Date.now()}`,
+        title: title.trim(),
+        icon: (icon || '✨') as Child['morning'][0]['icon'],
+        completed: false,
+      };
+      setChildren((prev) =>
+        prev.map((k) => (k.id !== kidId ? k : { ...k, [routine]: [...k[routine], newTask] }))
+      );
+    },
+    []
+  );
+
+  const handleRemoveTask = useCallback((kidId: string, routine: RoutineType, taskId: string) => {
+    setChildren((prev) =>
+      prev.map((k) =>
+        k.id !== kidId ? k : { ...k, [routine]: k[routine].filter((t) => t.id !== taskId) }
+      )
+    );
+  }, []);
+
+  const handleAddKid = useCallback(() => {
+    // Route to setup flow to add a new child
+    setView('setup');
+  }, []);
+
+  // ── Theme detection ────────────────────────────────────────
   const dueRoutineByChild = Object.fromEntries(
     children.map((child) => [child.id, getDueRoutine(child, now)])
   ) as Record<string, RoutineType | null>;
@@ -832,6 +972,9 @@ const Index = () => {
     : children.some((child) => dueRoutineByChild[child.id] === 'evening')
       ? 'evening'
       : 'free';
+
+  // Cozy Pastel: time-of-day backdrop theme (5–17h = morning, else evening)
+  const kidTheme: 'morning' | 'evening' = now.getHours() >= 5 && now.getHours() < 17 ? 'morning' : 'evening';
 
   if (!isReady) {
     return null;
@@ -984,21 +1127,43 @@ const Index = () => {
   }
 
   if (view === 'routine' && activeChild) {
+    // Use schedule-aware routine (falls back to 'morning' if no schedule)
+    const activeRoutineTheme = getDisplayRoutine(activeChild, now);
     return (
-      <Suspense fallback={<ViewLoadingFallback title="Opening routine" />}>
-        <RoutineView
-          child={activeChild}
-          routine={activeRoutine}
-          onToggleTask={toggleTask}
-          onBack={() => setView('home')}
-        />
-      </Suspense>
+      <KidApp
+        kid={activeChild}
+        theme={activeRoutineTheme}
+        onBack={() => setView('home')}
+        onToggleTask={handleToggleTask}
+        onSetMood={handleSetMood}
+      />
     );
   }
 
   if (view === 'parent') {
     return (
-      <Suspense fallback={<ViewLoadingFallback title="Opening parent settings" />}>
+      <AdminApp
+        kids={children}
+        onClose={() => setView('home')}
+        onChangeMascot={handleChangeMascot}
+        onAddTask={handleAddTask}
+        onRemoveTask={handleRemoveTask}
+        onAddAffirmation={handleAddAffirmation}
+        onRemoveAffirmation={handleRemoveAffirmation}
+        onToggleBadge={handleToggleBadge}
+        onAddKid={handleAddKid}
+        cloudSyncStatus={authStatus === 'signed_in' ? cloudConfigSyncStatus : undefined}
+        onSignOut={authStatus === 'signed_in' ? () => void signOut() : undefined}
+        onOpenAdvancedSettings={() => setView('advanced-settings')}
+        onRestartSetup={restartSetup}
+        onResetAppData={() => void resetToFreshSetup()}
+      />
+    );
+  }
+
+  if (view === 'advanced-settings') {
+    return (
+      <Suspense fallback={<ViewLoadingFallback title="Opening settings" />}>
         <ParentSettings
           children={children}
           homeScene={homeScene}
@@ -1012,25 +1177,22 @@ const Index = () => {
           onHomeSceneChange={setHomeScene}
           onRestartSetup={restartSetup}
           onResetAppData={resetToFreshSetup}
-          onBack={() => setView('home')}
+          onBack={() => setView('parent')}
         />
       </Suspense>
     );
   }
 
   return (
-    <ChildSelector
-      children={children}
-      globalTheme={globalTheme}
-      homeScene={homeScene}
-      dueRoutineByChild={dueRoutineByChild}
-      cloudSyncStatus={authStatus === 'signed_in' ? cloudConfigSyncStatus : undefined}
-      onSelectChild={(id) => {
+    <KidHome
+      kids={children}
+      theme={kidTheme}
+      onPick={(id) => {
         setNow(new Date());
         setActiveChildId(id);
         setView('routine');
       }}
-      onOpenSettings={() => setView('parent')}
+      onParent={() => setView('parent')}
     />
   );
 };

--- a/src/test/index.test.tsx
+++ b/src/test/index.test.tsx
@@ -69,47 +69,49 @@ const yesterday = () => {
   return date.toDateString();
 };
 
-vi.mock("@/components/ChildSelector", () => ({
-  ChildSelector: ({
-    children,
-    onSelectChild,
-    onOpenSettings,
+// KidHome replaces ChildSelector as the main home screen
+vi.mock("@/components/KidHome", () => ({
+  KidHome: ({
+    kids,
+    onPick,
+    onParent,
   }: {
-    children: Array<{ id: string; name: string }>;
-    onSelectChild: (id: string) => void;
-    onOpenSettings: () => void;
+    kids: Array<{ id: string; name: string }>;
+    onPick: (id: string) => void;
+    onParent: () => void;
   }) => (
     <div>
-      <div data-testid="child-count">{children.length}</div>
-      <button type="button" onClick={() => onSelectChild(children[0].id)}>
+      <div data-testid="child-count">{kids.length}</div>
+      <button type="button" onClick={() => onPick(kids[0].id)}>
         select-first-child
       </button>
-      <button type="button" onClick={onOpenSettings}>
+      <button type="button" onClick={onParent}>
         open-settings
       </button>
     </div>
   ),
 }));
 
-vi.mock("@/components/RoutineView", () => ({
-  RoutineView: ({
-    child,
-    routine,
+// KidApp replaces RoutineView — note the new onToggleTask signature (kidId, routine, taskId)
+vi.mock("@/components/KidApp", () => ({
+  KidApp: ({
+    kid,
+    theme,
     onToggleTask,
     onBack,
   }: {
-    child: { name: string; morning: Array<{ id: string; completed: boolean }> };
-    routine: "morning" | "evening";
-    onToggleTask: (taskId: string) => void;
+    kid: { id: string; name: string; morning: Array<{ id: string; completed: boolean }>; evening: Array<{ id: string; completed: boolean }> };
+    theme: "morning" | "evening";
+    onToggleTask: (kidId: string, routine: "morning" | "evening", taskId: string) => void;
     onBack: () => void;
   }) => (
     <div>
-      <div data-testid="active-child">{child.name}</div>
-      <div data-testid="active-routine">{routine}</div>
+      <div data-testid="active-child">{kid.name}</div>
+      <div data-testid="active-routine">{theme}</div>
       <div data-testid="first-task-completed">
-        {String(child[routine][0]?.completed ?? false)}
+        {String(kid[theme][0]?.completed ?? false)}
       </div>
-      <button type="button" onClick={() => onToggleTask(child[routine][0].id)}>
+      <button type="button" onClick={() => onToggleTask(kid.id, theme, kid[theme][0].id)}>
         toggle-first-task
       </button>
       <button type="button" onClick={onBack}>
@@ -119,6 +121,35 @@ vi.mock("@/components/RoutineView", () => ({
   ),
 }));
 
+// AdminApp replaces ParentSettings as the primary admin screen
+vi.mock("@/components/admin/AdminApp", () => ({
+  AdminApp: ({
+    onClose,
+    onRestartSetup,
+    onResetAppData,
+    cloudSyncStatus,
+  }: {
+    onClose: () => void;
+    onRestartSetup?: () => void;
+    onResetAppData?: () => void;
+    cloudSyncStatus?: string;
+  }) => (
+    <div>
+      <button type="button" onClick={onClose}>
+        back-home
+      </button>
+      <button type="button" onClick={onRestartSetup}>
+        restart-setup
+      </button>
+      <button type="button" onClick={onResetAppData}>
+        reset-app-data
+      </button>
+      <div data-testid="admin-cloud-sync-status">{cloudSyncStatus ?? ""}</div>
+    </div>
+  ),
+}));
+
+// ParentSettings is used for the advanced-settings view (reached via AdminApp → open-advanced)
 vi.mock("@/components/ParentSettings", () => ({
   ParentSettings: ({
     onBack,


### PR DESCRIPTION
## Summary

Full implementation of the Cozy Pastels redesign from Claude Design (Direction A), replacing the old ChildSelector/RoutineView with a polished kid-first UI.

**Kid-facing screens:**
- **KidHome** — time-of-day backdrop (warm morning / deep night), mascot bubble cards per child with progress bar and 🔥 streak badge; hold-to-access parent gate
- **KidApp** — top bar with mascot + hi greeting + streak, 4-tab bottom nav (Routines ✅ / Affirm. 💫 / Awards 🏆 / Mood 💗)
- **RoutinesTab** — PainterlyBanner header, alternating peach/lavender task cards, confetti tap animation, fireworks on full completion
- **AffirmationsTab** — pink gradient card, mascot emoji, ▶ audio button, ↻ next, dot pagination, favourites list
- **AchievementsTab** — amber streak card with sun-ray decoration, week day chips, 4×2 badge grid (🔒 for unearned)
- **MoodTab** — 3×2 emoji picker, optional note + Draw/Voice buttons, 7-day week calendar

**Admin screens (new AdminApp router):**
- **AdminHome** — household overview with per-kid 2×2 section pills + account footer (sync status, sign out, restart setup, delete data)
- **AdminKidProfile** — mascot picker bottom-sheet (10 mascots to choose from)
- **AdminRoutines** — morning/evening toggle, task list with add/remove
- **AdminAffirmations** — add/delete affirmations with coloured cards
- **AdminAchievements** — streak display, badge toggle switches
- **AdminMood** — settings toggles, week mood preview, insights card

Advanced account/schedule/scene settings still accessible via the "Advanced Settings" link → existing ParentSettings screen.

**New data model** (`src/lib/mascots.ts`):
- 10 mascots (🐸🐰🐱🐻🐼🦊🐧🐨🦄🦉) with name + tint colors
- 8 badge catalog entries with descriptions
- 6 mood options with colors
- New optional `Child` fields: `mascotId`, `streak`, `affirmations[]`, `moods[]`, `badges{}`
- Stored in localStorage (synced via existing config mechanism); Supabase schema extension is a follow-up

## Test plan
- [ ] All 95 existing tests pass (verified: `npm test`)
- [ ] Build clean: `npm run build`
- [ ] Open app — home screen shows morning/evening backdrop based on time
- [ ] Tap each kid card → KidApp opens with their tab bar
- [ ] Tap tasks to check them off — confetti fires on each, fireworks on all done
- [ ] Tab through Affirmations, Awards, Mood tabs
- [ ] Hold "parent settings" 1.5s → AdminApp opens with household overview
- [ ] Tap kid section pills → navigate to each admin sub-screen
- [ ] Tap mascot in AdminKidProfile → picker modal opens, select new mascot
- [ ] Add/remove affirmation in AdminAffirmations
- [ ] Toggle badge in AdminAchievements
- [ ] Account footer: sign out, advanced settings link → ParentSettings

🤖 Generated with [Claude Code](https://claude.com/claude-code)