### PR TITLE
Add cloud-backed household schedules

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,10 +9,10 @@ import { AuthProvider } from "@/lib/auth/auth-context";
 import { APP_VERSION, getRefreshUrl, getVersionManifestUrl } from "@/lib/app-version";
 const AuthCallback = lazy(() => import("./pages/AuthCallback.tsx"));
 const Index = lazy(() => import("./pages/Index.tsx"));
+const SchedulesPage = lazy(() => import("./pages/SchedulesPage.tsx"));
 const NotFound = lazy(() => import("./pages/NotFound.tsx"));
 
 const queryClient = new QueryClient();
-
 const UPDATE_CHECK_INTERVAL = 5 * 60 * 1000;
 
 const AppShell = () => {
@@ -20,38 +20,22 @@ const AppShell = () => {
 
   useEffect(() => {
     let isMounted = true;
-
     const checkForUpdate = async () => {
       try {
         const response = await fetch(getVersionManifestUrl(), { cache: "no-store" });
         if (!response.ok) return;
-
         const payload = (await response.json()) as { version?: string };
         const nextVersion = payload.version?.trim();
-
-        if (isMounted && nextVersion && nextVersion !== APP_VERSION) {
-          setLatestVersion(nextVersion);
-        }
+        if (isMounted && nextVersion && nextVersion !== APP_VERSION) setLatestVersion(nextVersion);
       } catch {
-        // If the version check fails, keep the current app running quietly.
+        // Keep the current app running quietly when version checks fail.
       }
     };
-
     void checkForUpdate();
-
-    const intervalId = window.setInterval(() => {
-      void checkForUpdate();
-    }, UPDATE_CHECK_INTERVAL);
-
-    const refreshOnFocus = () => {
-      if (document.visibilityState === "visible") {
-        void checkForUpdate();
-      }
-    };
-
+    const intervalId = window.setInterval(() => void checkForUpdate(), UPDATE_CHECK_INTERVAL);
+    const refreshOnFocus = () => { if (document.visibilityState === "visible") void checkForUpdate(); };
     window.addEventListener("focus", refreshOnFocus);
     document.addEventListener("visibilitychange", refreshOnFocus);
-
     return () => {
       isMounted = false;
       window.clearInterval(intervalId);
@@ -60,67 +44,22 @@ const AppShell = () => {
     };
   }, []);
 
-  return (
-    <>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter basename={import.meta.env.BASE_URL}>
-        <Suspense
-          fallback={
-            <div className="flex min-h-svh items-center justify-center px-5 py-10">
-              <div className="w-full max-w-lg rounded-[32px] border border-border bg-card p-8 text-center shadow-card">
-                <p className="text-sm font-black uppercase tracking-[0.22em] text-primary">Loading Little Loops</p>
-                <h1 className="mt-4 text-3xl font-bold text-foreground">Getting everything ready</h1>
-                <p className="mt-3 text-sm text-muted-foreground">
-                  This should only take a moment.
-                </p>
-              </div>
-            </div>
-          }
-        >
-          <Routes>
-            <Route path="/" element={<Index />} />
-            <Route path="/auth/callback" element={<AuthCallback />} />
-            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </Suspense>
-      </BrowserRouter>
-
-      {latestVersion && (
-        <div className="pointer-events-none fixed inset-x-0 bottom-4 z-50 flex justify-center px-4">
-          <div className="pointer-events-auto flex max-w-xl flex-col gap-3 rounded-[28px] border border-primary/20 bg-white/95 px-5 py-4 shadow-2xl backdrop-blur-md sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <p className="text-sm font-black uppercase tracking-[0.22em] text-primary">Update Ready</p>
-              <p className="mt-1 text-sm text-muted-foreground">
-                A fresher version of Little Loops is available.
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={() => {
-                window.location.assign(getRefreshUrl(latestVersion));
-              }}
-              className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-bold text-primary-foreground shadow-button transition-transform active:translate-y-0.5"
-            >
-              <RefreshCw size={16} />
-              Refresh now
-            </button>
-          </div>
-        </div>
-      )}
-    </>
-  );
+  return <>
+    <Toaster />
+    <Sonner />
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
+      <Suspense fallback={<div className="flex min-h-svh items-center justify-center px-5 py-10"><div className="w-full max-w-lg rounded-[32px] border border-border bg-card p-8 text-center shadow-card"><p className="text-sm font-black uppercase tracking-[0.22em] text-primary">Loading Little Loops</p><h1 className="mt-4 text-3xl font-bold text-foreground">Getting everything ready</h1><p className="mt-3 text-sm text-muted-foreground">This should only take a moment.</p></div></div>}>
+        <Routes>
+          <Route path="/" element={<Index />} />
+          <Route path="/parent/schedules" element={<SchedulesPage />} />
+          <Route path="/auth/callback" element={<AuthCallback />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Suspense>
+    </BrowserRouter>
+    {latestVersion && <div className="pointer-events-none fixed inset-x-0 bottom-4 z-50 flex justify-center px-4"><div className="pointer-events-auto flex max-w-xl flex-col gap-3 rounded-[28px] border border-primary/20 bg-white/95 px-5 py-4 shadow-2xl backdrop-blur-md sm:flex-row sm:items-center sm:justify-between"><div><p className="text-sm font-black uppercase tracking-[0.22em] text-primary">Update Ready</p><p className="mt-1 text-sm text-muted-foreground">A fresher version of Little Loops is available.</p></div><button type="button" onClick={() => window.location.assign(getRefreshUrl(latestVersion))} className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-4 py-2 text-sm font-bold text-primary-foreground shadow-button transition-transform active:translate-y-0.5"><RefreshCw size={16} />Refresh now</button></div></div>}
+  </>;
 };
 
-const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <AuthProvider>
-      <TooltipProvider>
-        <AppShell />
-      </TooltipProvider>
-    </AuthProvider>
-  </QueryClientProvider>
-);
-
+const App = () => <QueryClientProvider client={queryClient}><AuthProvider><TooltipProvider><AppShell /></TooltipProvider></AuthProvider></QueryClientProvider>;
 export default App;

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,4 +1,4 @@
-export type KidTab = 'routines' | 'affirmations' | 'achievements' | 'mood';
+export type KidTab = 'routines' | 'schedule' | 'affirmations' | 'achievements' | 'mood';
 
 interface BottomNavProps {
   active: KidTab;
@@ -8,15 +8,16 @@ interface BottomNavProps {
 }
 
 const TABS: { id: KidTab; icon: string; label: string; tint: string }[] = [
-  { id: 'routines',     icon: '📋', label: 'Routines', tint: '#f97316' },
-  { id: 'affirmations', icon: '💫', label: 'Affirm.',  tint: '#ec4899' },
-  { id: 'achievements', icon: '🏆', label: 'Awards',   tint: '#f59e0b' },
-  { id: 'mood',         icon: '😌', label: 'Mood',     tint: '#a855f7' },
+  { id: 'routines', icon: '📋', label: 'Routines', tint: '#f97316' },
+  { id: 'schedule', icon: '📅', label: 'Schedule', tint: '#0ea5e9' },
+  { id: 'affirmations', icon: '💫', label: 'Affirm.', tint: '#ec4899' },
+  { id: 'achievements', icon: '🏆', label: 'Awards', tint: '#f59e0b' },
+  { id: 'mood', icon: '😌', label: 'Mood', tint: '#a855f7' },
 ];
 
 export const BottomNav = ({ active, onChange, theme = 'morning', placement = 'side' }: BottomNavProps) => {
   const isNight = theme === 'evening';
-  const activeTint = TABS.find((t) => t.id === active)?.tint ?? '#f97316';
+  const activeTint = TABS.find((tab) => tab.id === active)?.tint ?? '#f97316';
   const isBottom = placement === 'bottom';
 
   if (isBottom) {
@@ -30,27 +31,30 @@ export const BottomNav = ({ active, onChange, theme = 'morning', placement = 'si
           backdropFilter: 'blur(12px)',
           borderTop: `1px solid ${isNight ? 'rgba(255,255,255,0.07)' : 'rgba(180,120,80,0.08)'}`,
           display: 'flex',
-          flexDirection: 'row',
           alignItems: 'stretch',
           zIndex: 30,
           fontFamily: "'Fredoka', system-ui, sans-serif",
         }}
       >
-        {TABS.map((t) => (
+        {TABS.map((tab) => (
           <button
-            key={t.id}
-            onClick={() => onChange(t.id)}
+            key={tab.id}
+            type="button"
+            aria-label={tab.label}
+            aria-pressed={tab.id === active}
+            onClick={() => onChange(tab.id)}
             style={{
               flex: 1,
+              minWidth: 0,
               display: 'flex',
               flexDirection: 'column',
               alignItems: 'center',
               justifyContent: 'center',
               gap: 4,
-              padding: '8px 4px',
-              background: t.id === active ? `${activeTint}18` : 'transparent',
+              padding: '8px 2px',
+              background: tab.id === active ? `${activeTint}18` : 'transparent',
               border: 'none',
-              borderTop: t.id === active ? `3px solid ${activeTint}` : '3px solid transparent',
+              borderTop: tab.id === active ? `3px solid ${activeTint}` : '3px solid transparent',
               cursor: 'pointer',
               fontFamily: 'inherit',
               WebkitTapHighlightColor: 'transparent',
@@ -59,14 +63,14 @@ export const BottomNav = ({ active, onChange, theme = 'morning', placement = 'si
           >
             <div
               style={{
-                fontSize: 32,
+                fontSize: 29,
                 lineHeight: 1,
-                filter: t.id === active ? 'none' : 'grayscale(0.5)',
-                opacity: t.id === active ? 1 : isNight ? 0.4 : 0.5,
+                filter: tab.id === active ? 'none' : 'grayscale(0.5)',
+                opacity: tab.id === active ? 1 : isNight ? 0.4 : 0.5,
                 transition: 'all 0.2s',
               }}
             >
-              {t.icon}
+              {tab.icon}
             </div>
           </button>
         ))}
@@ -74,7 +78,6 @@ export const BottomNav = ({ active, onChange, theme = 'morning', placement = 'si
     );
   }
 
-  // Side placement (tablet / desktop)
   return (
     <div
       style={{
@@ -87,25 +90,28 @@ export const BottomNav = ({ active, onChange, theme = 'morning', placement = 'si
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        gap: 4,
-        padding: '16px 8px',
+        gap: 2,
+        padding: '10px 8px',
         zIndex: 30,
         fontFamily: "'Fredoka', system-ui, sans-serif",
+        overflowY: 'auto',
       }}
     >
-      {TABS.map((t) => (
+      {TABS.map((tab) => (
         <button
-          key={t.id}
-          onClick={() => onChange(t.id)}
+          key={tab.id}
+          type="button"
+          aria-pressed={tab.id === active}
+          onClick={() => onChange(tab.id)}
           style={{
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
-            gap: 8,
-            padding: '16px 10px',
-            borderRadius: 24,
+            gap: 5,
+            padding: '10px',
+            borderRadius: 20,
             width: 144,
-            background: t.id === active ? `${activeTint}22` : 'transparent',
+            background: tab.id === active ? `${activeTint}22` : 'transparent',
             border: 'none',
             cursor: 'pointer',
             fontFamily: 'inherit',
@@ -115,25 +121,24 @@ export const BottomNav = ({ active, onChange, theme = 'morning', placement = 'si
         >
           <div
             style={{
-              fontSize: 52,
+              fontSize: 40,
               lineHeight: 1,
-              filter: t.id === active ? 'none' : 'grayscale(0.6)',
-              opacity: t.id === active ? 1 : isNight ? 0.4 : 0.45,
+              filter: tab.id === active ? 'none' : 'grayscale(0.6)',
+              opacity: tab.id === active ? 1 : isNight ? 0.4 : 0.45,
               transition: 'all 0.2s',
             }}
           >
-            {t.icon}
+            {tab.icon}
           </div>
           <div
             style={{
-              fontSize: 18,
+              fontSize: 15,
               fontWeight: 700,
-              letterSpacing: '0.02em',
-              color: t.id === active ? activeTint : isNight ? 'rgba(255,255,255,0.45)' : '#8a7866',
+              color: tab.id === active ? activeTint : isNight ? 'rgba(255,255,255,0.45)' : '#8a7866',
               transition: 'color 0.2s',
             }}
           >
-            {t.label}
+            {tab.label}
           </div>
         </button>
       ))}

--- a/src/components/KidApp.tsx
+++ b/src/components/KidApp.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { MascotBubble } from './MascotBubble';
 import { BottomNav, type KidTab } from './BottomNav';
 import { RoutinesTab } from './RoutinesTab';
+import { ScheduleTab } from './ScheduleTab';
 import { AffirmationsTab } from './AffirmationsTab';
 import { AchievementsTab } from './AchievementsTab';
 import { MoodTab } from './MoodTab';
@@ -29,7 +30,6 @@ const CATEGORIES: {
   label: string;
   desc: string;
   bg: string;
-  bgNight: string;
 }[] = [
   {
     id: 'routines',
@@ -37,7 +37,13 @@ const CATEGORIES: {
     label: 'Routines',
     desc: 'Your daily tasks',
     bg: 'linear-gradient(145deg,#4338ca,#818cf8)',
-    bgNight: 'linear-gradient(145deg,#4338ca,#818cf8)',
+  },
+  {
+    id: 'schedule',
+    emoji: '📅',
+    label: 'Schedule',
+    desc: "What's happening today?",
+    bg: 'linear-gradient(145deg,#0284c7,#38bdf8)',
   },
   {
     id: 'affirmations',
@@ -45,7 +51,6 @@ const CATEGORIES: {
     label: 'Affirmations',
     desc: 'You are amazing!',
     bg: 'linear-gradient(145deg,#c2410c,#fdba74)',
-    bgNight: 'linear-gradient(145deg,#c2410c,#fdba74)',
   },
   {
     id: 'achievements',
@@ -53,7 +58,6 @@ const CATEGORIES: {
     label: 'Awards',
     desc: 'Badges & streaks',
     bg: 'linear-gradient(145deg,#047857,#6ee7b7)',
-    bgNight: 'linear-gradient(145deg,#047857,#6ee7b7)',
   },
   {
     id: 'mood',
@@ -61,14 +65,22 @@ const CATEGORIES: {
     label: 'Mood',
     desc: 'How do you feel?',
     bg: 'linear-gradient(145deg,#9d174d,#fda4af)',
-    bgNight: 'linear-gradient(145deg,#9d174d,#fda4af)',
   },
 ];
 
-export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote, onAddAffirmation, onRemoveAffirmation }: KidAppProps) => {
+export const KidApp = ({
+  kid,
+  theme,
+  onBack,
+  onToggleTask,
+  onSetMood,
+  onSaveNote,
+  onAddAffirmation,
+  onRemoveAffirmation,
+}: KidAppProps) => {
   const [view, setView] = useState<KidView>('hub');
   const [isMobile, setIsMobile] = useState(() => window.innerWidth < 768);
-  const m = getMascot(kid.mascotId ?? kid.avatarAnimal);
+  const mascot = getMascot(kid.mascotId ?? kid.avatarAnimal);
   const streak = kid.streak ?? 0;
   const isNight = theme === 'evening';
 
@@ -78,7 +90,6 @@ export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote
     return () => window.removeEventListener('resize', check);
   }, []);
 
-  // ── Hub (category picker) ──────────────────────────────────────────────────
   if (view === 'hub') {
     return (
       <div
@@ -91,10 +102,8 @@ export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote
           fontFamily: "'Fredoka', system-ui, sans-serif",
         }}
       >
-        {/* Full-viewport backdrop */}
         {isNight ? <NightBackdrop /> : <MorningBackdrop />}
 
-        {/* Centred card */}
         <div
           style={{
             position: 'relative',
@@ -108,18 +117,19 @@ export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote
             overflow: 'hidden',
           }}
         >
-          {/* Top bar */}
           <div
             style={{
               display: 'flex',
               alignItems: 'center',
               gap: 12,
-              marginBottom: 24,
+              marginBottom: 18,
               flexShrink: 0,
             }}
           >
             <button
+              type="button"
               onClick={onBack}
+              aria-label="Back"
               style={{
                 width: 38,
                 height: 38,
@@ -135,7 +145,6 @@ export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote
                 cursor: 'pointer',
                 boxShadow: isNight ? 'none' : '0 2px 8px rgba(180,120,80,0.12)',
                 fontFamily: 'inherit',
-                WebkitTapHighlightColor: 'transparent',
               }}
             >
               ‹
@@ -146,7 +155,7 @@ export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote
             <div style={{ flex: 1 }}>
               <div
                 style={{
-                  fontSize: 18,
+                  fontSize: 15,
                   fontWeight: 600,
                   color: isNight ? 'rgba(255,255,255,0.55)' : '#8a7866',
                   letterSpacing: '0.08em',
@@ -157,14 +166,14 @@ export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote
               </div>
               <div
                 style={{
-                  fontSize: 32,
+                  fontSize: 29,
                   fontWeight: 700,
                   color: isNight ? '#fff' : '#3d2c1f',
                   lineHeight: 1.1,
                   marginTop: 2,
                 }}
               >
-                {kid.name}! {m.emoji}
+                {kid.name}! {mascot.emoji}
               </div>
             </div>
 
@@ -172,15 +181,11 @@ export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote
               <div
                 style={{
                   background: isNight ? 'rgba(255,255,255,0.12)' : 'rgba(255,255,255,0.9)',
-                  backdropFilter: 'blur(8px)',
                   borderRadius: 12,
                   padding: '6px 12px',
                   fontSize: 13,
                   fontWeight: 700,
                   color: '#f97316',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 4,
                 }}
               >
                 🔥 {streak}
@@ -188,25 +193,29 @@ export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote
             )}
           </div>
 
-          {/* 2×2 category grid — rows sized naturally, not stretched */}
           <div
             style={{
               flex: 1,
               display: 'grid',
-              gridTemplateColumns: '1fr 1fr',
-              gridAutoRows: 'minmax(160px, 220px)',
-              gap: 14,
-              alignContent: 'center',
+              gridTemplateColumns: 'repeat(2,minmax(0,1fr))',
+              gridAutoRows: 'minmax(135px,1fr)',
+              gap: 12,
               overflowY: 'auto',
+              alignContent: 'center',
+              paddingBottom: 2,
             }}
           >
-            {CATEGORIES.map((cat) => (
+            {CATEGORIES.map((category, index) => (
               <button
-                key={cat.id}
-                onClick={() => setView(cat.id)}
+                key={category.id}
+                type="button"
+                onClick={() => setView(category.id)}
                 style={{
-                  background: isNight ? cat.bgNight : cat.bg,
-                  borderRadius: 28,
+                  gridColumn: CATEGORIES.length % 2 === 1 && index === CATEGORIES.length - 1 ? '1 / -1' : undefined,
+                  width: CATEGORIES.length % 2 === 1 && index === CATEGORIES.length - 1 ? 'calc(50% - 6px)' : undefined,
+                  justifySelf: CATEGORIES.length % 2 === 1 && index === CATEGORIES.length - 1 ? 'center' : undefined,
+                  background: category.bg,
+                  borderRadius: 26,
                   border: 'none',
                   cursor: 'pointer',
                   fontFamily: 'inherit',
@@ -215,53 +224,30 @@ export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote
                   flexDirection: 'column',
                   alignItems: 'center',
                   justifyContent: 'center',
-                  gap: 8,
-                  padding: '16px 12px',
-                  boxShadow: isNight
-                    ? '0 8px 24px rgba(0,0,0,0.4)'
-                    : '0 8px 24px rgba(0,0,0,0.15)',
+                  gap: 6,
+                  padding: '14px 10px',
+                  boxShadow: isNight ? '0 8px 24px rgba(0,0,0,0.4)' : '0 8px 24px rgba(0,0,0,0.15)',
                   WebkitTapHighlightColor: 'transparent',
-                  transition: 'transform 0.12s, box-shadow 0.12s',
                   position: 'relative',
                   overflow: 'hidden',
                 }}
               >
-                {/* Subtle shine */}
                 <div
                   style={{
                     position: 'absolute',
-                    top: 0,
-                    left: 0,
-                    right: 0,
+                    inset: '0 0 auto',
                     height: '50%',
                     background: 'rgba(255,255,255,0.12)',
-                    borderRadius: '28px 28px 60% 60%',
+                    borderRadius: '26px 26px 60% 60%',
                     pointerEvents: 'none',
                   }}
                 />
-                <div style={{ fontSize: 56, lineHeight: 1, position: 'relative' }}>
-                  {cat.emoji}
+                <div style={{ fontSize: 45, lineHeight: 1, position: 'relative' }}>{category.emoji}</div>
+                <div style={{ fontSize: 21, fontWeight: 700, textAlign: 'center', position: 'relative' }}>
+                  {category.label}
                 </div>
-                <div
-                  style={{
-                    fontSize: 24,
-                    fontWeight: 700,
-                    textAlign: 'center',
-                    lineHeight: 1.2,
-                    position: 'relative',
-                  }}
-                >
-                  {cat.label}
-                </div>
-                <div
-                  style={{
-                    fontSize: 16,
-                    opacity: 0.8,
-                    textAlign: 'center',
-                    position: 'relative',
-                  }}
-                >
-                  {cat.desc}
+                <div style={{ fontSize: 13, opacity: 0.82, textAlign: 'center', position: 'relative' }}>
+                  {category.desc}
                 </div>
               </button>
             ))}
@@ -271,7 +257,6 @@ export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote
     );
   }
 
-  // ── Tab view ───────────────────────────────────────────────────────────────
   return (
     <div
       style={{
@@ -283,7 +268,6 @@ export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote
         fontFamily: "'Fredoka', system-ui, sans-serif",
       }}
     >
-      {/* Centred content card */}
       <div
         style={{
           width: '100%',
@@ -292,12 +276,9 @@ export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote
           display: 'flex',
           flexDirection: 'column',
           overflow: 'hidden',
-          boxShadow: isNight
-            ? '0 0 60px rgba(0,0,0,0.4)'
-            : '0 0 60px rgba(180,120,80,0.12)',
+          boxShadow: isNight ? '0 0 60px rgba(0,0,0,0.4)' : '0 0 60px rgba(180,120,80,0.12)',
         }}
       >
-        {/* Top bar */}
         <div
           style={{
             display: 'flex',
@@ -305,15 +286,15 @@ export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote
             gap: 10,
             padding: isMobile ? '8px 12px' : '10px 14px',
             background: isNight ? 'rgba(44,38,120,0.97)' : 'rgba(255,249,240,0.95)',
-            backdropFilter: 'blur(8px)',
             borderBottom: `1px solid ${isNight ? 'rgba(255,255,255,0.06)' : 'rgba(180,120,80,0.07)'}`,
-            position: 'relative',
-            zIndex: 10,
             flexShrink: 0,
+            zIndex: 10,
           }}
         >
           <button
+            type="button"
             onClick={() => setView('hub')}
+            aria-label="Back to sections"
             style={{
               width: isMobile ? 40 : 34,
               height: isMobile ? 40 : 34,
@@ -326,9 +307,7 @@ export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote
               color: isNight ? '#fff' : '#3d2c1f',
               border: 'none',
               cursor: 'pointer',
-              boxShadow: isNight ? 'none' : '0 2px 6px rgba(180,120,80,0.1)',
               fontFamily: 'inherit',
-              WebkitTapHighlightColor: 'transparent',
             }}
           >
             ‹
@@ -337,70 +316,35 @@ export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote
           <div style={{ flex: 1 }}>
             <div
               style={{
-                fontSize: isMobile ? 13 : 16,
+                fontSize: isMobile ? 12 : 14,
                 fontWeight: 700,
                 color: isNight ? 'rgba(255,255,255,0.45)' : '#8a7866',
                 letterSpacing: '0.06em',
                 textTransform: 'uppercase',
               }}
             >
-              with {m.name}
+              with {mascot.name}
             </div>
-            <div
-              style={{
-                fontSize: isMobile ? 18 : 22,
-                fontWeight: 700,
-                color: isNight ? '#fff' : '#3d2c1f',
-                marginTop: 1,
-              }}
-            >
+            <div style={{ fontSize: isMobile ? 18 : 22, fontWeight: 700, color: isNight ? '#fff' : '#3d2c1f' }}>
               Hi, {kid.name}!
             </div>
           </div>
           {streak > 0 && (
-            <div
-              style={{
-                background: isNight ? 'rgba(255,255,255,0.1)' : '#fff',
-                borderRadius: 10,
-                padding: '5px 10px',
-                fontSize: isMobile ? 14 : 11,
-                fontWeight: 700,
-                color: '#f97316',
-                display: 'flex',
-                alignItems: 'center',
-                gap: 4,
-                boxShadow: isNight ? 'none' : '0 2px 6px rgba(180,120,80,0.08)',
-              }}
-            >
+            <div style={{ borderRadius: 10, padding: '5px 10px', fontSize: 12, fontWeight: 700, color: '#f97316' }}>
               🔥 {streak}
             </div>
           )}
         </div>
 
-        {/* Tab content + nav — column on mobile (content above, nav below),
-            row on tablet (sidebar left, content right) */}
-        <div style={{
-          flex: 1,
-          display: 'flex',
-          flexDirection: isMobile ? 'column' : 'row',
-          overflow: 'hidden',
-        }}>
-          {/* Side nav — tablet only */}
-          {!isMobile && (
-            <BottomNav active={view as KidTab} onChange={setView} theme={theme} placement="side" />
-          )}
+        <div style={{ flex: 1, display: 'flex', flexDirection: isMobile ? 'column' : 'row', overflow: 'hidden' }}>
+          {!isMobile && <BottomNav active={view} onChange={setView} theme={theme} placement="side" />}
 
-          {/* Tab content */}
           <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
             <div style={{ position: 'absolute', inset: 0 }}>
               {view === 'routines' && (
-                <RoutinesTab
-                  kid={kid}
-                  theme={theme}
-                  onToggleTask={onToggleTask}
-                  onAllDone={onBack}
-                />
+                <RoutinesTab kid={kid} theme={theme} onToggleTask={onToggleTask} onAllDone={onBack} />
               )}
+              {view === 'schedule' && <ScheduleTab kid={kid} />}
               {view === 'affirmations' && (
                 <AffirmationsTab
                   kid={kid}
@@ -413,10 +357,7 @@ export const KidApp = ({ kid, theme, onBack, onToggleTask, onSetMood, onSaveNote
             </div>
           </div>
 
-          {/* Bottom nav — mobile only */}
-          {isMobile && (
-            <BottomNav active={view as KidTab} onChange={setView} theme={theme} placement="bottom" />
-          )}
+          {isMobile && <BottomNav active={view} onChange={setView} theme={theme} placement="bottom" />}
         </div>
       </div>
     </div>

--- a/src/components/ScheduleTab.tsx
+++ b/src/components/ScheduleTab.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useMemo, useState } from 'react';
+import { PainterlyBanner } from './PainterlyBanner';
+import { getMascot } from '@/lib/mascots';
+import {
+  getTodaySummerDay,
+  SUMMER_DAYS,
+  SUMMER_SCHEDULE,
+  timeToMinutes,
+  type SummerDay,
+} from '@/lib/summer-schedule';
+import type { Child } from '@/lib/types';
+
+interface ScheduleTabProps {
+  kid: Child;
+}
+
+const INK = '#3d2c1f';
+const INK_MUTE = '#8a7866';
+const BLUE = '#0ea5e9';
+
+export const ScheduleTab = ({ kid }: ScheduleTabProps) => {
+  const [selectedDay, setSelectedDay] = useState<SummerDay>(() => getTodaySummerDay());
+  const [now, setNow] = useState(() => new Date());
+  const mascot = getMascot(kid.mascotId ?? kid.avatarAnimal);
+  const today = getTodaySummerDay(now);
+  const items = SUMMER_SCHEDULE[selectedDay];
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(new Date()), 60_000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  const timing = useMemo(() => {
+    if (selectedDay !== today || now.getDay() === 0 || now.getDay() === 6) {
+      return { currentIndex: -1, nextIndex: -1 };
+    }
+
+    const minutes = now.getHours() * 60 + now.getMinutes();
+    const nextIndex = items.findIndex((item) => timeToMinutes(item.time) > minutes);
+    const currentIndex = nextIndex === 0 ? -1 : nextIndex === -1 ? items.length - 1 : nextIndex - 1;
+    return { currentIndex, nextIndex };
+  }, [items, now, selectedDay, today]);
+
+  const current = timing.currentIndex >= 0 ? items[timing.currentIndex] : null;
+  const next = timing.nextIndex >= 0 ? items[timing.nextIndex] : null;
+
+  return (
+    <div
+      style={{
+        height: '100%',
+        overflowY: 'auto',
+        paddingBottom: 88,
+        background: 'linear-gradient(180deg,#fff9f0 0%,#e0f2fe 100%)',
+        fontFamily: "'Fredoka', system-ui, sans-serif",
+        color: INK,
+      }}
+    >
+      <PainterlyBanner label={`${mascot.emoji} ${kid.name}'s`} title="Summer Schedule" palette="purple" />
+
+      <div style={{ padding: '0 14px 20px' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5,1fr)', gap: 6 }}>
+          {SUMMER_DAYS.map((day) => {
+            const selected = day === selectedDay;
+            const isToday = day === today && now.getDay() >= 1 && now.getDay() <= 5;
+            return (
+              <button
+                key={day}
+                type="button"
+                onClick={() => setSelectedDay(day)}
+                aria-pressed={selected}
+                style={{
+                  border: selected ? `2px solid ${BLUE}` : '1.5px solid rgba(14,165,233,0.14)',
+                  background: selected ? '#e0f2fe' : '#fff',
+                  borderRadius: 14,
+                  padding: '9px 2px 7px',
+                  cursor: 'pointer',
+                  fontFamily: 'inherit',
+                  color: selected ? '#0369a1' : INK_MUTE,
+                  boxShadow: selected ? '0 4px 12px rgba(14,165,233,0.15)' : 'none',
+                  WebkitTapHighlightColor: 'transparent',
+                }}
+              >
+                <div style={{ fontSize: 10, fontWeight: 800 }}>{day.slice(0, 3).toUpperCase()}</div>
+                <div style={{ fontSize: 12, height: 14, marginTop: 2 }}>{isToday ? '●' : '·'}</div>
+              </button>
+            );
+          })}
+        </div>
+
+        {selectedDay === today && now.getDay() >= 1 && now.getDay() <= 5 && (
+          <div
+            style={{
+              marginTop: 12,
+              borderRadius: 18,
+              background: 'linear-gradient(135deg,#0ea5e9,#38bdf8)',
+              color: '#fff',
+              padding: '12px 14px',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              boxShadow: '0 6px 16px rgba(14,165,233,0.2)',
+            }}
+          >
+            <div style={{ fontSize: 28 }}>{current?.icon ?? '☀️'}</div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 10, fontWeight: 800, opacity: 0.78, letterSpacing: '0.1em' }}>
+                {current ? 'NOW' : 'COMING UP'}
+              </div>
+              <div style={{ fontSize: 16, fontWeight: 700, marginTop: 1 }}>
+                {current?.title ?? next?.title ?? 'Enjoy your morning'}
+              </div>
+              {next && (
+                <div style={{ fontSize: 11, opacity: 0.82, marginTop: 2 }}>
+                  Next: {next.title} at {next.time}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        <div
+          style={{
+            marginTop: 14,
+            background: '#fff',
+            borderRadius: 22,
+            padding: '12px 10px',
+            border: '1.5px solid rgba(14,165,233,0.1)',
+            boxShadow: '0 5px 16px rgba(14,165,233,0.08)',
+          }}
+        >
+          <div
+            style={{
+              padding: '0 8px 9px',
+              fontSize: 11,
+              fontWeight: 800,
+              color: '#0369a1',
+              letterSpacing: '0.1em',
+              textTransform: 'uppercase',
+            }}
+          >
+            {selectedDay}'s timetable
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+            {items.map((item, index) => {
+              const isCurrent = index === timing.currentIndex;
+              return (
+                <div
+                  key={`${item.time}-${item.title}`}
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '54px 1fr',
+                    gap: 8,
+                    alignItems: 'stretch',
+                  }}
+                >
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      fontSize: 12,
+                      fontWeight: 800,
+                      color: isCurrent ? '#0369a1' : INK_MUTE,
+                    }}
+                  >
+                    {item.time}
+                  </div>
+                  <div
+                    style={{
+                      borderRadius: 15,
+                      padding: '10px 12px',
+                      background: isCurrent ? '#bae6fd' : index % 2 === 0 ? '#f0f9ff' : '#fff9f0',
+                      border: isCurrent ? `2px solid ${BLUE}` : '1.5px solid rgba(180,120,80,0.06)',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 10,
+                    }}
+                  >
+                    <div style={{ fontSize: 23, width: 30, textAlign: 'center', flexShrink: 0 }}>{item.icon}</div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontSize: 14, fontWeight: 700 }}>{item.title}</div>
+                      {item.note && (
+                        <div style={{ fontSize: 10, color: INK_MUTE, marginTop: 2, lineHeight: 1.3 }}>{item.note}</div>
+                      )}
+                    </div>
+                    {isCurrent && (
+                      <div
+                        style={{
+                          borderRadius: 99,
+                          background: BLUE,
+                          color: '#fff',
+                          padding: '3px 7px',
+                          fontSize: 9,
+                          fontWeight: 800,
+                        }}
+                      >
+                        NOW
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ScheduleTab.tsx
+++ b/src/components/ScheduleTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
 import { PainterlyBanner } from './PainterlyBanner';
 import { getMascot } from '@/lib/mascots';
 import { cloneSummerSchedule, DEFAULT_SUMMER_SCHEDULE, getTodaySummerDay, loadSummerSchedule, saveSummerSchedule, SUMMER_DAYS, timeToMinutes, type SummerDay, type SummerSchedule, type SummerScheduleItem } from '@/lib/summer-schedule';
@@ -54,5 +54,5 @@ export const ScheduleTab=({kid}:ScheduleTabProps)=>{
   </div>;
 };
 
-const inputStyle:React.CSSProperties={width:'100%',boxSizing:'border-box',border:'1.5px solid rgba(14,165,233,.16)',borderRadius:10,padding:'8px 9px',fontFamily:"'Fredoka',system-ui,sans-serif",color:INK,background:'#fff'};
-const buttonStyle=(background:string,color='#fff'):React.CSSProperties=>({border:'none',background,color,borderRadius:12,padding:'9px 12px',fontFamily:"'Fredoka',system-ui,sans-serif",fontSize:12,fontWeight:800,cursor:'pointer'});
+const inputStyle:CSSProperties={width:'100%',boxSizing:'border-box',border:'1.5px solid rgba(14,165,233,.16)',borderRadius:10,padding:'8px 9px',fontFamily:"'Fredoka',system-ui,sans-serif",color:INK,background:'#fff'};
+const buttonStyle=(background:string,color='#fff'):CSSProperties=>({border:'none',background,color,borderRadius:12,padding:'9px 12px',fontFamily:"'Fredoka',system-ui,sans-serif",fontSize:12,fontWeight:800,cursor:'pointer'});

--- a/src/components/ScheduleTab.tsx
+++ b/src/components/ScheduleTab.tsx
@@ -1,210 +1,58 @@
 import { useEffect, useMemo, useState } from 'react';
 import { PainterlyBanner } from './PainterlyBanner';
 import { getMascot } from '@/lib/mascots';
-import {
-  getTodaySummerDay,
-  SUMMER_DAYS,
-  SUMMER_SCHEDULE,
-  timeToMinutes,
-  type SummerDay,
-} from '@/lib/summer-schedule';
+import { cloneSummerSchedule, DEFAULT_SUMMER_SCHEDULE, getTodaySummerDay, loadSummerSchedule, saveSummerSchedule, SUMMER_DAYS, timeToMinutes, type SummerDay, type SummerSchedule, type SummerScheduleItem } from '@/lib/summer-schedule';
 import type { Child } from '@/lib/types';
 
-interface ScheduleTabProps {
-  kid: Child;
-}
+interface ScheduleTabProps { kid: Child }
+const INK='#3d2c1f', MUTE='#8a7866', BLUE='#0ea5e9';
 
-const INK = '#3d2c1f';
-const INK_MUTE = '#8a7866';
-const BLUE = '#0ea5e9';
+export const ScheduleTab=({kid}:ScheduleTabProps)=>{
+  const [selectedDay,setSelectedDay]=useState<SummerDay>(()=>getTodaySummerDay());
+  const [schedule,setSchedule]=useState<SummerSchedule>(()=>loadSummerSchedule());
+  const [draft,setDraft]=useState<SummerSchedule>(()=>loadSummerSchedule());
+  const [editing,setEditing]=useState(false);
+  const [now,setNow]=useState(()=>new Date());
+  const mascot=getMascot(kid.mascotId??kid.avatarAnimal);
+  const today=getTodaySummerDay(now);
+  const items=schedule[selectedDay];
 
-export const ScheduleTab = ({ kid }: ScheduleTabProps) => {
-  const [selectedDay, setSelectedDay] = useState<SummerDay>(() => getTodaySummerDay());
-  const [now, setNow] = useState(() => new Date());
-  const mascot = getMascot(kid.mascotId ?? kid.avatarAnimal);
-  const today = getTodaySummerDay(now);
-  const items = SUMMER_SCHEDULE[selectedDay];
+  useEffect(()=>{const timer=window.setInterval(()=>setNow(new Date()),60000);return()=>window.clearInterval(timer);},[]);
+  const timing=useMemo(()=>{if(selectedDay!==today||[0,6].includes(now.getDay()))return{currentIndex:-1,nextIndex:-1};const minutes=now.getHours()*60+now.getMinutes();const nextIndex=items.findIndex(entry=>timeToMinutes(entry.time)>minutes);return{currentIndex:nextIndex===0?-1:nextIndex===-1?items.length-1:nextIndex-1,nextIndex};},[items,now,selectedDay,today]);
+  const current=timing.currentIndex>=0?items[timing.currentIndex]:null;
+  const next=timing.nextIndex>=0?items[timing.nextIndex]:null;
 
-  useEffect(() => {
-    const timer = window.setInterval(() => setNow(new Date()), 60_000);
-    return () => window.clearInterval(timer);
-  }, []);
+  const updateEntry=(id:string,patch:Partial<SummerScheduleItem>)=>setDraft(prev=>({...prev,[selectedDay]:prev[selectedDay].map(entry=>entry.id===id?{...entry,...patch}:entry)}));
+  const removeEntry=(id:string)=>setDraft(prev=>({...prev,[selectedDay]:prev[selectedDay].filter(entry=>entry.id!==id)}));
+  const addEntry=()=>setDraft(prev=>({...prev,[selectedDay]:[...prev[selectedDay],{id:`custom-${Date.now()}`,time:'15:00',title:'New activity',icon:'⭐'}]}));
+  const save=()=>{const cleaned=cloneSummerSchedule(draft);SUMMER_DAYS.forEach(day=>cleaned[day].sort((a,b)=>timeToMinutes(a.time)-timeToMinutes(b.time)));saveSummerSchedule(cleaned);setSchedule(cleaned);setDraft(cloneSummerSchedule(cleaned));setEditing(false);};
+  const cancel=()=>{setDraft(cloneSummerSchedule(schedule));setEditing(false);};
+  const reset=()=>{if(!window.confirm('Reset the whole summer schedule to the original plan?'))return;const fresh=cloneSummerSchedule(DEFAULT_SUMMER_SCHEDULE);saveSummerSchedule(fresh);setSchedule(fresh);setDraft(cloneSummerSchedule(fresh));};
 
-  const timing = useMemo(() => {
-    if (selectedDay !== today || now.getDay() === 0 || now.getDay() === 6) {
-      return { currentIndex: -1, nextIndex: -1 };
-    }
-
-    const minutes = now.getHours() * 60 + now.getMinutes();
-    const nextIndex = items.findIndex((item) => timeToMinutes(item.time) > minutes);
-    const currentIndex = nextIndex === 0 ? -1 : nextIndex === -1 ? items.length - 1 : nextIndex - 1;
-    return { currentIndex, nextIndex };
-  }, [items, now, selectedDay, today]);
-
-  const current = timing.currentIndex >= 0 ? items[timing.currentIndex] : null;
-  const next = timing.nextIndex >= 0 ? items[timing.nextIndex] : null;
-
-  return (
-    <div
-      style={{
-        height: '100%',
-        overflowY: 'auto',
-        paddingBottom: 88,
-        background: 'linear-gradient(180deg,#fff9f0 0%,#e0f2fe 100%)',
-        fontFamily: "'Fredoka', system-ui, sans-serif",
-        color: INK,
-      }}
-    >
-      <PainterlyBanner label={`${mascot.emoji} ${kid.name}'s`} title="Summer Schedule" palette="purple" />
-
-      <div style={{ padding: '0 14px 20px' }}>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5,1fr)', gap: 6 }}>
-          {SUMMER_DAYS.map((day) => {
-            const selected = day === selectedDay;
-            const isToday = day === today && now.getDay() >= 1 && now.getDay() <= 5;
-            return (
-              <button
-                key={day}
-                type="button"
-                onClick={() => setSelectedDay(day)}
-                aria-pressed={selected}
-                style={{
-                  border: selected ? `2px solid ${BLUE}` : '1.5px solid rgba(14,165,233,0.14)',
-                  background: selected ? '#e0f2fe' : '#fff',
-                  borderRadius: 14,
-                  padding: '9px 2px 7px',
-                  cursor: 'pointer',
-                  fontFamily: 'inherit',
-                  color: selected ? '#0369a1' : INK_MUTE,
-                  boxShadow: selected ? '0 4px 12px rgba(14,165,233,0.15)' : 'none',
-                  WebkitTapHighlightColor: 'transparent',
-                }}
-              >
-                <div style={{ fontSize: 10, fontWeight: 800 }}>{day.slice(0, 3).toUpperCase()}</div>
-                <div style={{ fontSize: 12, height: 14, marginTop: 2 }}>{isToday ? '●' : '·'}</div>
-              </button>
-            );
-          })}
-        </div>
-
-        {selectedDay === today && now.getDay() >= 1 && now.getDay() <= 5 && (
-          <div
-            style={{
-              marginTop: 12,
-              borderRadius: 18,
-              background: 'linear-gradient(135deg,#0ea5e9,#38bdf8)',
-              color: '#fff',
-              padding: '12px 14px',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 12,
-              boxShadow: '0 6px 16px rgba(14,165,233,0.2)',
-            }}
-          >
-            <div style={{ fontSize: 28 }}>{current?.icon ?? '☀️'}</div>
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ fontSize: 10, fontWeight: 800, opacity: 0.78, letterSpacing: '0.1em' }}>
-                {current ? 'NOW' : 'COMING UP'}
-              </div>
-              <div style={{ fontSize: 16, fontWeight: 700, marginTop: 1 }}>
-                {current?.title ?? next?.title ?? 'Enjoy your morning'}
-              </div>
-              {next && (
-                <div style={{ fontSize: 11, opacity: 0.82, marginTop: 2 }}>
-                  Next: {next.title} at {next.time}
-                </div>
-              )}
-            </div>
-          </div>
-        )}
-
-        <div
-          style={{
-            marginTop: 14,
-            background: '#fff',
-            borderRadius: 22,
-            padding: '12px 10px',
-            border: '1.5px solid rgba(14,165,233,0.1)',
-            boxShadow: '0 5px 16px rgba(14,165,233,0.08)',
-          }}
-        >
-          <div
-            style={{
-              padding: '0 8px 9px',
-              fontSize: 11,
-              fontWeight: 800,
-              color: '#0369a1',
-              letterSpacing: '0.1em',
-              textTransform: 'uppercase',
-            }}
-          >
-            {selectedDay}'s timetable
-          </div>
-
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
-            {items.map((item, index) => {
-              const isCurrent = index === timing.currentIndex;
-              return (
-                <div
-                  key={`${item.time}-${item.title}`}
-                  style={{
-                    display: 'grid',
-                    gridTemplateColumns: '54px 1fr',
-                    gap: 8,
-                    alignItems: 'stretch',
-                  }}
-                >
-                  <div
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      fontSize: 12,
-                      fontWeight: 800,
-                      color: isCurrent ? '#0369a1' : INK_MUTE,
-                    }}
-                  >
-                    {item.time}
-                  </div>
-                  <div
-                    style={{
-                      borderRadius: 15,
-                      padding: '10px 12px',
-                      background: isCurrent ? '#bae6fd' : index % 2 === 0 ? '#f0f9ff' : '#fff9f0',
-                      border: isCurrent ? `2px solid ${BLUE}` : '1.5px solid rgba(180,120,80,0.06)',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 10,
-                    }}
-                  >
-                    <div style={{ fontSize: 23, width: 30, textAlign: 'center', flexShrink: 0 }}>{item.icon}</div>
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <div style={{ fontSize: 14, fontWeight: 700 }}>{item.title}</div>
-                      {item.note && (
-                        <div style={{ fontSize: 10, color: INK_MUTE, marginTop: 2, lineHeight: 1.3 }}>{item.note}</div>
-                      )}
-                    </div>
-                    {isCurrent && (
-                      <div
-                        style={{
-                          borderRadius: 99,
-                          background: BLUE,
-                          color: '#fff',
-                          padding: '3px 7px',
-                          fontSize: 9,
-                          fontWeight: 800,
-                        }}
-                      >
-                        NOW
-                      </div>
-                    )}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </div>
+  return <div style={{height:'100%',overflowY:'auto',paddingBottom:88,background:'linear-gradient(180deg,#fff9f0 0%,#e0f2fe 100%)',fontFamily:"'Fredoka',system-ui,sans-serif",color:INK}}>
+    <PainterlyBanner label={`${mascot.emoji} ${kid.name}'s`} title="Summer Schedule" palette="purple" />
+    <div style={{padding:'0 14px 20px'}}>
+      <div style={{display:'flex',justifyContent:'flex-end',gap:8,marginBottom:10}}>
+        {!editing?<button type="button" onClick={()=>{setDraft(cloneSummerSchedule(schedule));setEditing(true);}} style={buttonStyle(BLUE)}>✏️ Parent edit</button>:<><button type="button" onClick={cancel} style={buttonStyle('#fff',INK)}>Cancel</button><button type="button" onClick={save} style={buttonStyle(BLUE)}>Save changes</button></>}
       </div>
+      <div style={{display:'grid',gridTemplateColumns:'repeat(5,1fr)',gap:6}}>{SUMMER_DAYS.map(day=><button key={day} type="button" onClick={()=>setSelectedDay(day)} style={{border:day===selectedDay?`2px solid ${BLUE}`:'1.5px solid rgba(14,165,233,.14)',background:day===selectedDay?'#e0f2fe':'#fff',borderRadius:14,padding:'9px 2px 7px',fontFamily:'inherit',color:day===selectedDay?'#0369a1':MUTE,cursor:'pointer'}}><div style={{fontSize:10,fontWeight:800}}>{day.slice(0,3).toUpperCase()}</div><div style={{fontSize:12,height:14,marginTop:2}}>{day===today&&now.getDay()>=1&&now.getDay()<=5?'●':'·'}</div></button>)}</div>
+
+      {editing?<div style={{marginTop:14,background:'#fff',borderRadius:22,padding:14,border:'1.5px solid rgba(14,165,233,.12)',boxShadow:'0 5px 16px rgba(14,165,233,.08)'}}>
+        <div style={{display:'flex',justifyContent:'space-between',alignItems:'center',gap:10,marginBottom:12}}><div><div style={{fontSize:18,fontWeight:800}}>Edit {selectedDay}</div><div style={{fontSize:12,color:MUTE}}>Changes appear in the child timetable after saving.</div></div><button type="button" onClick={addEntry} style={buttonStyle(BLUE)}>+ Activity</button></div>
+        <div style={{display:'flex',flexDirection:'column',gap:8}}>{draft[selectedDay].map(entry=><div key={entry.id} style={{display:'grid',gridTemplateColumns:'86px 58px 1fr auto',gap:7,alignItems:'center',background:'#f8fafc',borderRadius:14,padding:8}}>
+          <input aria-label="Time" type="time" value={entry.time} onChange={e=>updateEntry(entry.id,{time:e.target.value})} style={inputStyle}/>
+          <input aria-label="Emoji" value={entry.icon} onChange={e=>updateEntry(entry.id,{icon:e.target.value})} style={{...inputStyle,textAlign:'center',fontSize:20,padding:'7px 4px'}}/>
+          <div style={{display:'flex',flexDirection:'column',gap:5}}><input aria-label="Activity" value={entry.title} onChange={e=>updateEntry(entry.id,{title:e.target.value})} style={inputStyle}/><input aria-label="Note" placeholder="Optional note" value={entry.note??''} onChange={e=>updateEntry(entry.id,{note:e.target.value})} style={{...inputStyle,fontSize:12}}/></div>
+          <button type="button" aria-label={`Delete ${entry.title}`} onClick={()=>removeEntry(entry.id)} style={{border:'none',background:'#fee2e2',color:'#b91c1c',borderRadius:10,width:34,height:34,cursor:'pointer'}}>×</button>
+        </div>)}</div>
+        <div style={{display:'flex',justifyContent:'space-between',gap:8,marginTop:14}}><button type="button" onClick={reset} style={buttonStyle('#fff1f2','#be123c')}>Reset all</button><button type="button" onClick={save} style={buttonStyle(BLUE)}>Save schedule</button></div>
+      </div>:<>
+        {selectedDay===today&&now.getDay()>=1&&now.getDay()<=5&&<div style={{marginTop:12,borderRadius:18,background:'linear-gradient(135deg,#0ea5e9,#38bdf8)',color:'#fff',padding:'12px 14px',display:'flex',alignItems:'center',gap:12,boxShadow:'0 6px 16px rgba(14,165,233,.2)'}}><div style={{fontSize:28}}>{current?.icon??'☀️'}</div><div style={{flex:1}}><div style={{fontSize:10,fontWeight:800,opacity:.78,letterSpacing:'.1em'}}>{current?'NOW':'COMING UP'}</div><div style={{fontSize:16,fontWeight:700}}>{current?.title??next?.title??'Enjoy your morning'}</div>{next&&<div style={{fontSize:11,opacity:.82}}>Next: {next.title} at {next.time}</div>}</div></div>}
+        <div style={{marginTop:14,background:'#fff',borderRadius:22,padding:'12px 10px',border:'1.5px solid rgba(14,165,233,.1)',boxShadow:'0 5px 16px rgba(14,165,233,.08)'}}><div style={{padding:'0 8px 9px',fontSize:11,fontWeight:800,color:'#0369a1',letterSpacing:'.1em',textTransform:'uppercase'}}>{selectedDay}'s timetable</div><div style={{display:'flex',flexDirection:'column',gap:7}}>{items.map((entry,index)=>{const active=index===timing.currentIndex;return <div key={entry.id} style={{display:'grid',gridTemplateColumns:'54px 1fr',gap:8,alignItems:'stretch'}}><div style={{display:'flex',alignItems:'center',justifyContent:'center',fontSize:12,fontWeight:800,color:active?'#0369a1':MUTE}}>{entry.time}</div><div style={{borderRadius:15,padding:'10px 12px',background:active?'#bae6fd':index%2===0?'#f0f9ff':'#fff9f0',border:active?`2px solid ${BLUE}`:'1.5px solid rgba(180,120,80,.06)',display:'flex',alignItems:'center',gap:10}}><div style={{fontSize:23,width:30,textAlign:'center'}}>{entry.icon}</div><div style={{flex:1}}><div style={{fontSize:14,fontWeight:700}}>{entry.title}</div>{entry.note&&<div style={{fontSize:10,color:MUTE,marginTop:2}}>{entry.note}</div>}</div>{active&&<div style={{borderRadius:99,background:BLUE,color:'#fff',padding:'3px 7px',fontSize:9,fontWeight:800}}>NOW</div>}</div></div>})}</div></div>
+      </>}
     </div>
-  );
+  </div>;
 };
+
+const inputStyle:React.CSSProperties={width:'100%',boxSizing:'border-box',border:'1.5px solid rgba(14,165,233,.16)',borderRadius:10,padding:'8px 9px',fontFamily:"'Fredoka',system-ui,sans-serif",color:INK,background:'#fff'};
+const buttonStyle=(background:string,color='#fff'):React.CSSProperties=>({border:'none',background,color,borderRadius:12,padding:'9px 12px',fontFamily:"'Fredoka',system-ui,sans-serif",fontSize:12,fontWeight:800,cursor:'pointer'});

--- a/src/components/ScheduleTab.tsx
+++ b/src/components/ScheduleTab.tsx
@@ -1,58 +1,41 @@
-import { useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { PainterlyBanner } from './PainterlyBanner';
 import { getMascot } from '@/lib/mascots';
-import { cloneSummerSchedule, DEFAULT_SUMMER_SCHEDULE, getTodaySummerDay, loadSummerSchedule, saveSummerSchedule, SUMMER_DAYS, timeToMinutes, type SummerDay, type SummerSchedule, type SummerScheduleItem } from '@/lib/summer-schedule';
+import { useAuth } from '@/lib/auth/use-auth';
+import { getSupabaseClient } from '@/lib/supabase/client';
+import { SupabaseScheduleRepository } from '@/lib/data/supabase-schedule-repository';
+import { getActiveScheduleForChild, getScheduleDay, SCHEDULE_DAYS, timeToMinutes, type HouseholdSchedules, type ScheduleDay } from '@/lib/summer-schedule';
 import type { Child } from '@/lib/types';
 
 interface ScheduleTabProps { kid: Child }
 const INK='#3d2c1f', MUTE='#8a7866', BLUE='#0ea5e9';
 
 export const ScheduleTab=({kid}:ScheduleTabProps)=>{
-  const [selectedDay,setSelectedDay]=useState<SummerDay>(()=>getTodaySummerDay());
-  const [schedule,setSchedule]=useState<SummerSchedule>(()=>loadSummerSchedule());
-  const [draft,setDraft]=useState<SummerSchedule>(()=>loadSummerSchedule());
-  const [editing,setEditing]=useState(false);
+  const { household }=useAuth();
+  const [selectedDay,setSelectedDay]=useState<ScheduleDay>(()=>getScheduleDay());
+  const [schedules,setSchedules]=useState<HouseholdSchedules>([]);
+  const [loading,setLoading]=useState(true);
   const [now,setNow]=useState(()=>new Date());
   const mascot=getMascot(kid.mascotId??kid.avatarAnimal);
-  const today=getTodaySummerDay(now);
-  const items=schedule[selectedDay];
+  const today=getScheduleDay(now);
+  const plan=getActiveScheduleForChild(schedules,kid.id);
+  const items=(plan?.days[selectedDay]??[]).slice().sort((a,b)=>timeToMinutes(a.time)-timeToMinutes(b.time));
 
   useEffect(()=>{const timer=window.setInterval(()=>setNow(new Date()),60000);return()=>window.clearInterval(timer);},[]);
-  const timing=useMemo(()=>{if(selectedDay!==today||[0,6].includes(now.getDay()))return{currentIndex:-1,nextIndex:-1};const minutes=now.getHours()*60+now.getMinutes();const nextIndex=items.findIndex(entry=>timeToMinutes(entry.time)>minutes);return{currentIndex:nextIndex===0?-1:nextIndex===-1?items.length-1:nextIndex-1,nextIndex};},[items,now,selectedDay,today]);
+  useEffect(()=>{const supabase=getSupabaseClient();if(!household||!supabase){setLoading(false);return;}const repo=new SupabaseScheduleRepository(supabase);void repo.load(household.id).then(setSchedules).finally(()=>setLoading(false));},[household]);
+
+  const timing=useMemo(()=>{if(selectedDay!==today)return{currentIndex:-1,nextIndex:-1};const minutes=now.getHours()*60+now.getMinutes();const nextIndex=items.findIndex(entry=>timeToMinutes(entry.time)>minutes);return{currentIndex:nextIndex===0?-1:nextIndex===-1?items.length-1:nextIndex-1,nextIndex};},[items,now,selectedDay,today]);
   const current=timing.currentIndex>=0?items[timing.currentIndex]:null;
   const next=timing.nextIndex>=0?items[timing.nextIndex]:null;
 
-  const updateEntry=(id:string,patch:Partial<SummerScheduleItem>)=>setDraft(prev=>({...prev,[selectedDay]:prev[selectedDay].map(entry=>entry.id===id?{...entry,...patch}:entry)}));
-  const removeEntry=(id:string)=>setDraft(prev=>({...prev,[selectedDay]:prev[selectedDay].filter(entry=>entry.id!==id)}));
-  const addEntry=()=>setDraft(prev=>({...prev,[selectedDay]:[...prev[selectedDay],{id:`custom-${Date.now()}`,time:'15:00',title:'New activity',icon:'⭐'}]}));
-  const save=()=>{const cleaned=cloneSummerSchedule(draft);SUMMER_DAYS.forEach(day=>cleaned[day].sort((a,b)=>timeToMinutes(a.time)-timeToMinutes(b.time)));saveSummerSchedule(cleaned);setSchedule(cleaned);setDraft(cloneSummerSchedule(cleaned));setEditing(false);};
-  const cancel=()=>{setDraft(cloneSummerSchedule(schedule));setEditing(false);};
-  const reset=()=>{if(!window.confirm('Reset the whole summer schedule to the original plan?'))return;const fresh=cloneSummerSchedule(DEFAULT_SUMMER_SCHEDULE);saveSummerSchedule(fresh);setSchedule(fresh);setDraft(cloneSummerSchedule(fresh));};
-
   return <div style={{height:'100%',overflowY:'auto',paddingBottom:88,background:'linear-gradient(180deg,#fff9f0 0%,#e0f2fe 100%)',fontFamily:"'Fredoka',system-ui,sans-serif",color:INK}}>
-    <PainterlyBanner label={`${mascot.emoji} ${kid.name}'s`} title="Summer Schedule" palette="purple" />
+    <PainterlyBanner label={`${mascot.emoji} ${kid.name}'s`} title={plan?.name??'Schedule'} palette="purple" />
     <div style={{padding:'0 14px 20px'}}>
-      <div style={{display:'flex',justifyContent:'flex-end',gap:8,marginBottom:10}}>
-        {!editing?<button type="button" onClick={()=>{setDraft(cloneSummerSchedule(schedule));setEditing(true);}} style={buttonStyle(BLUE)}>✏️ Parent edit</button>:<><button type="button" onClick={cancel} style={buttonStyle('#fff',INK)}>Cancel</button><button type="button" onClick={save} style={buttonStyle(BLUE)}>Save changes</button></>}
-      </div>
-      <div style={{display:'grid',gridTemplateColumns:'repeat(5,1fr)',gap:6}}>{SUMMER_DAYS.map(day=><button key={day} type="button" onClick={()=>setSelectedDay(day)} style={{border:day===selectedDay?`2px solid ${BLUE}`:'1.5px solid rgba(14,165,233,.14)',background:day===selectedDay?'#e0f2fe':'#fff',borderRadius:14,padding:'9px 2px 7px',fontFamily:'inherit',color:day===selectedDay?'#0369a1':MUTE,cursor:'pointer'}}><div style={{fontSize:10,fontWeight:800}}>{day.slice(0,3).toUpperCase()}</div><div style={{fontSize:12,height:14,marginTop:2}}>{day===today&&now.getDay()>=1&&now.getDay()<=5?'●':'·'}</div></button>)}</div>
-
-      {editing?<div style={{marginTop:14,background:'#fff',borderRadius:22,padding:14,border:'1.5px solid rgba(14,165,233,.12)',boxShadow:'0 5px 16px rgba(14,165,233,.08)'}}>
-        <div style={{display:'flex',justifyContent:'space-between',alignItems:'center',gap:10,marginBottom:12}}><div><div style={{fontSize:18,fontWeight:800}}>Edit {selectedDay}</div><div style={{fontSize:12,color:MUTE}}>Changes appear in the child timetable after saving.</div></div><button type="button" onClick={addEntry} style={buttonStyle(BLUE)}>+ Activity</button></div>
-        <div style={{display:'flex',flexDirection:'column',gap:8}}>{draft[selectedDay].map(entry=><div key={entry.id} style={{display:'grid',gridTemplateColumns:'86px 58px 1fr auto',gap:7,alignItems:'center',background:'#f8fafc',borderRadius:14,padding:8}}>
-          <input aria-label="Time" type="time" value={entry.time} onChange={e=>updateEntry(entry.id,{time:e.target.value})} style={inputStyle}/>
-          <input aria-label="Emoji" value={entry.icon} onChange={e=>updateEntry(entry.id,{icon:e.target.value})} style={{...inputStyle,textAlign:'center',fontSize:20,padding:'7px 4px'}}/>
-          <div style={{display:'flex',flexDirection:'column',gap:5}}><input aria-label="Activity" value={entry.title} onChange={e=>updateEntry(entry.id,{title:e.target.value})} style={inputStyle}/><input aria-label="Note" placeholder="Optional note" value={entry.note??''} onChange={e=>updateEntry(entry.id,{note:e.target.value})} style={{...inputStyle,fontSize:12}}/></div>
-          <button type="button" aria-label={`Delete ${entry.title}`} onClick={()=>removeEntry(entry.id)} style={{border:'none',background:'#fee2e2',color:'#b91c1c',borderRadius:10,width:34,height:34,cursor:'pointer'}}>×</button>
-        </div>)}</div>
-        <div style={{display:'flex',justifyContent:'space-between',gap:8,marginTop:14}}><button type="button" onClick={reset} style={buttonStyle('#fff1f2','#be123c')}>Reset all</button><button type="button" onClick={save} style={buttonStyle(BLUE)}>Save schedule</button></div>
-      </div>:<>
-        {selectedDay===today&&now.getDay()>=1&&now.getDay()<=5&&<div style={{marginTop:12,borderRadius:18,background:'linear-gradient(135deg,#0ea5e9,#38bdf8)',color:'#fff',padding:'12px 14px',display:'flex',alignItems:'center',gap:12,boxShadow:'0 6px 16px rgba(14,165,233,.2)'}}><div style={{fontSize:28}}>{current?.icon??'☀️'}</div><div style={{flex:1}}><div style={{fontSize:10,fontWeight:800,opacity:.78,letterSpacing:'.1em'}}>{current?'NOW':'COMING UP'}</div><div style={{fontSize:16,fontWeight:700}}>{current?.title??next?.title??'Enjoy your morning'}</div>{next&&<div style={{fontSize:11,opacity:.82}}>Next: {next.title} at {next.time}</div>}</div></div>}
-        <div style={{marginTop:14,background:'#fff',borderRadius:22,padding:'12px 10px',border:'1.5px solid rgba(14,165,233,.1)',boxShadow:'0 5px 16px rgba(14,165,233,.08)'}}><div style={{padding:'0 8px 9px',fontSize:11,fontWeight:800,color:'#0369a1',letterSpacing:'.1em',textTransform:'uppercase'}}>{selectedDay}'s timetable</div><div style={{display:'flex',flexDirection:'column',gap:7}}>{items.map((entry,index)=>{const active=index===timing.currentIndex;return <div key={entry.id} style={{display:'grid',gridTemplateColumns:'54px 1fr',gap:8,alignItems:'stretch'}}><div style={{display:'flex',alignItems:'center',justifyContent:'center',fontSize:12,fontWeight:800,color:active?'#0369a1':MUTE}}>{entry.time}</div><div style={{borderRadius:15,padding:'10px 12px',background:active?'#bae6fd':index%2===0?'#f0f9ff':'#fff9f0',border:active?`2px solid ${BLUE}`:'1.5px solid rgba(180,120,80,.06)',display:'flex',alignItems:'center',gap:10}}><div style={{fontSize:23,width:30,textAlign:'center'}}>{entry.icon}</div><div style={{flex:1}}><div style={{fontSize:14,fontWeight:700}}>{entry.title}</div>{entry.note&&<div style={{fontSize:10,color:MUTE,marginTop:2}}>{entry.note}</div>}</div>{active&&<div style={{borderRadius:99,background:BLUE,color:'#fff',padding:'3px 7px',fontSize:9,fontWeight:800}}>NOW</div>}</div></div>})}</div></div>
+      <div style={{display:'grid',gridTemplateColumns:'repeat(7,1fr)',gap:4}}>{SCHEDULE_DAYS.map(day=><button key={day} type="button" onClick={()=>setSelectedDay(day)} style={{border:day===selectedDay?`2px solid ${BLUE}`:'1px solid rgba(14,165,233,.14)',background:day===selectedDay?'#e0f2fe':'#fff',borderRadius:12,padding:'8px 1px',fontFamily:'inherit',color:day===selectedDay?'#0369a1':MUTE,cursor:'pointer'}}><div style={{fontSize:9,fontWeight:800}}>{day.slice(0,2).toUpperCase()}</div><div style={{fontSize:10,height:12}}>{day===today?'●':'·'}</div></button>)}</div>
+      {loading?<div style={{padding:30,textAlign:'center',color:MUTE}}>Loading schedule…</div>:!plan?<div style={{marginTop:18,padding:24,textAlign:'center',background:'#fff',borderRadius:22,color:MUTE}}><div style={{fontSize:34}}>📅</div><div style={{fontSize:16,fontWeight:700,color:INK,marginTop:8}}>No active schedule yet</div><div style={{fontSize:13,marginTop:4}}>A parent can create and assign one from Parent Schedules.</div></div>:<>
+        {selectedDay===today&&<div style={{marginTop:12,borderRadius:18,background:'linear-gradient(135deg,#0ea5e9,#38bdf8)',color:'#fff',padding:'12px 14px',display:'flex',alignItems:'center',gap:12}}><div style={{fontSize:28}}>{current?.icon??next?.icon??'☀️'}</div><div style={{flex:1}}><div style={{fontSize:10,fontWeight:800,opacity:.78}}>{current?'NOW':'COMING UP'}</div><div style={{fontSize:16,fontWeight:700}}>{current?.title??next?.title??'Enjoy your day'}</div>{next&&<div style={{fontSize:11,opacity:.82}}>Next: {next.title} at {next.time}</div>}</div></div>}
+        <div style={{marginTop:14,background:'#fff',borderRadius:22,padding:'12px 10px',border:'1.5px solid rgba(14,165,233,.1)'}}><div style={{padding:'0 8px 9px',fontSize:11,fontWeight:800,color:'#0369a1',letterSpacing:'.1em',textTransform:'uppercase'}}>{selectedDay}'s timetable</div>{items.length===0?<div style={{padding:22,textAlign:'center',color:MUTE}}>Nothing planned. Summer has officially won.</div>:<div style={{display:'flex',flexDirection:'column',gap:7}}>{items.map((entry,index)=>{const active=index===timing.currentIndex;return <div key={entry.id} style={{display:'grid',gridTemplateColumns:'54px 1fr',gap:8}}><div style={{display:'flex',alignItems:'center',justifyContent:'center',fontSize:12,fontWeight:800,color:active?'#0369a1':MUTE}}>{entry.time}</div><div style={{borderRadius:15,padding:'10px 12px',background:active?'#bae6fd':index%2===0?'#f0f9ff':'#fff9f0',border:active?`2px solid ${BLUE}`:'1px solid rgba(180,120,80,.06)',display:'flex',alignItems:'center',gap:10}}><div style={{fontSize:23,width:30,textAlign:'center'}}>{entry.icon}</div><div style={{flex:1}}><div style={{fontSize:14,fontWeight:700}}>{entry.title}</div>{entry.note&&<div style={{fontSize:10,color:MUTE,marginTop:2}}>{entry.note}</div>}</div></div></div>})}</div>}</div>
       </>}
     </div>
   </div>;
 };
-
-const inputStyle:CSSProperties={width:'100%',boxSizing:'border-box',border:'1.5px solid rgba(14,165,233,.16)',borderRadius:10,padding:'8px 9px',fontFamily:"'Fredoka',system-ui,sans-serif",color:INK,background:'#fff'};
-const buttonStyle=(background:string,color='#fff'):CSSProperties=>({border:'none',background,color,borderRadius:12,padding:'9px 12px',fontFamily:"'Fredoka',system-ui,sans-serif",fontSize:12,fontWeight:800,cursor:'pointer'});

--- a/src/lib/data/supabase-schedule-repository.ts
+++ b/src/lib/data/supabase-schedule-repository.ts
@@ -1,0 +1,26 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { HouseholdSchedules } from '@/lib/summer-schedule';
+
+export class SupabaseScheduleRepository {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async load(householdId: string): Promise<HouseholdSchedules> {
+    const { data, error } = await this.supabase
+      .from('households')
+      .select('schedules')
+      .eq('id', householdId)
+      .single();
+
+    if (error) throw error;
+    return Array.isArray(data?.schedules) ? (data.schedules as HouseholdSchedules) : [];
+  }
+
+  async save(householdId: string, schedules: HouseholdSchedules): Promise<void> {
+    const { error } = await this.supabase
+      .from('households')
+      .update({ schedules })
+      .eq('id', householdId);
+
+    if (error) throw error;
+  }
+}

--- a/src/lib/summer-schedule.ts
+++ b/src/lib/summer-schedule.ts
@@ -1,24 +1,77 @@
-export const SUMMER_DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'] as const;
-export type SummerDay = (typeof SUMMER_DAYS)[number];
-export type SummerScheduleItem = { id: string; time: string; title: string; icon: string; note?: string };
-export type SummerSchedule = Record<SummerDay, SummerScheduleItem[]>;
+export const SCHEDULE_DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'] as const;
+export type ScheduleDay = (typeof SCHEDULE_DAYS)[number];
 
-const item = (time: string, title: string, icon: string, note?: string): SummerScheduleItem => ({
-  id: `${time}-${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`,
-  time, title, icon, note,
-});
-const morning = [item('10:00','Math','🔢','A short challenge for each age'),item('10:30','Reading','📚','Read alone, together, or to Lily'),item('11:00','Creative time','🎨','Drawing, colouring, or making something'),item('12:00','Free play','🧸'),item('13:00','Lunch','🍽️')];
-const evening = [item('16:00','Fruit snack','🍎'),item('17:30','Free play','🪁'),item('19:00','Dinner','🍽️'),item('20:00','Evening routine','🌙')];
-export const DEFAULT_SUMMER_SCHEDULE: SummerSchedule = {
-  Monday:[...morning,item('14:00','Beach','🏖️'),evening[0],item('16:30','Cooking class','👩‍🍳','Help prepare a snack or part of dinner'),...evening.slice(1)],
-  Tuesday:[item('09:00','Bakery mission','🥖','Get bread together with a grown-up nearby'),...morning,item('14:00','Pool','🏊'),evening[0],item('16:30','Sewing with Grandma','🧵'),...evening.slice(1)],
-  Wednesday:[...morning,item('14:00','Beach','🏖️'),evening[0],item('16:30','Prepare a snack','🥣','Wash, cut, mix, or plate something simple'),...evening.slice(1)],
-  Thursday:[item('09:00','Bakery mission','🥖','Get bread together with a grown-up nearby'),...morning,item('14:00','Pool','🏊'),evening[0],item('16:30','Cooking class','👩‍🍳'),...evening.slice(1)],
-  Friday:[...morning,item('14:00','Beach or pool','🌊'),evening[0],item('16:30','Prepare the showcase','✨'),item('18:00','Friday showcase','🎤','Share something learned, made, read, or practised'),...evening.slice(2)],
+export type ScheduleItem = {
+  id: string;
+  time: string;
+  title: string;
+  icon: string;
+  note?: string;
 };
-const STORAGE_KEY='little-loops-summer-schedule-v1';
-export const cloneSummerSchedule=(schedule:SummerSchedule):SummerSchedule=>Object.fromEntries(SUMMER_DAYS.map(day=>[day,schedule[day].map(entry=>({...entry}))])) as SummerSchedule;
-export const loadSummerSchedule=():SummerSchedule=>{try{const raw=window.localStorage.getItem(STORAGE_KEY);if(!raw)return cloneSummerSchedule(DEFAULT_SUMMER_SCHEDULE);const parsed=JSON.parse(raw) as Partial<SummerSchedule>;if(!SUMMER_DAYS.every(day=>Array.isArray(parsed[day])))throw new Error('Invalid schedule');return parsed as SummerSchedule;}catch{return cloneSummerSchedule(DEFAULT_SUMMER_SCHEDULE);}};
-export const saveSummerSchedule=(schedule:SummerSchedule)=>window.localStorage.setItem(STORAGE_KEY,JSON.stringify(schedule));
-export const getTodaySummerDay=(date=new Date()):SummerDay=>date.getDay()>=1&&date.getDay()<=5?SUMMER_DAYS[date.getDay()-1]:'Monday';
-export const timeToMinutes=(value:string)=>{const [hours,minutes]=value.split(':').map(Number);return hours*60+minutes;};
+
+export type SchedulePlan = {
+  id: string;
+  name: string;
+  description?: string;
+  active: boolean;
+  childIds: string[];
+  days: Partial<Record<ScheduleDay, ScheduleItem[]>>;
+};
+
+export type HouseholdSchedules = SchedulePlan[];
+
+const item = (time: string, title: string, icon: string, note?: string): ScheduleItem => ({
+  id: crypto.randomUUID(),
+  time,
+  title,
+  icon,
+  note,
+});
+
+const standardMorning = () => [
+  item('10:00', 'Math', '🔢', 'A short challenge for each age'),
+  item('10:30', 'Reading', '📚', 'Read alone, together, or to Lily'),
+  item('11:00', 'Creative time', '🎨', 'Drawing, colouring, or making something'),
+  item('12:00', 'Free play', '🧸'),
+  item('13:00', 'Lunch', '🍽️'),
+];
+
+const standardEvening = () => [
+  item('16:00', 'Fruit snack', '🍎'),
+  item('17:30', 'Free play', '🪁'),
+  item('19:00', 'Dinner', '🍽️'),
+  item('20:00', 'Evening routine', '🌙'),
+];
+
+export const createCroatiaSummerSchedule = (childIds: string[]): SchedulePlan => ({
+  id: crypto.randomUUID(),
+  name: 'Summer Croatia',
+  description: 'Our weekday rhythm for the six weeks in Croatia.',
+  active: true,
+  childIds,
+  days: {
+    Monday: [...standardMorning(), item('14:00', 'Beach', '🏖️'), item('16:00', 'Fruit snack', '🍎'), item('16:30', 'Cooking class', '👩‍🍳'), ...standardEvening().slice(1)],
+    Tuesday: [item('09:00', 'Bakery mission', '🥖'), ...standardMorning(), item('14:00', 'Pool', '🏊'), item('16:00', 'Fruit snack', '🍎'), item('16:30', 'Sewing with Grandma', '🧵'), ...standardEvening().slice(1)],
+    Wednesday: [...standardMorning(), item('14:00', 'Beach', '🏖️'), item('16:00', 'Fruit snack', '🍎'), item('16:30', 'Prepare a snack', '🥣'), ...standardEvening().slice(1)],
+    Thursday: [item('09:00', 'Bakery mission', '🥖'), ...standardMorning(), item('14:00', 'Pool', '🏊'), item('16:00', 'Fruit snack', '🍎'), item('16:30', 'Cooking class', '👩‍🍳'), ...standardEvening().slice(1)],
+    Friday: [...standardMorning(), item('14:00', 'Beach or pool', '🌊'), item('16:00', 'Fruit snack', '🍎'), item('16:30', 'Prepare the showcase', '✨'), item('18:00', 'Friday showcase', '🎤'), item('19:00', 'Dinner', '🍽️'), item('20:00', 'Evening routine', '🌙')],
+  },
+});
+
+export const getScheduleDay = (date = new Date()): ScheduleDay => SCHEDULE_DAYS[(date.getDay() + 6) % 7];
+export const timeToMinutes = (value: string) => {
+  const [hours, minutes] = value.split(':').map(Number);
+  return hours * 60 + minutes;
+};
+
+export const cloneSchedules = (schedules: HouseholdSchedules): HouseholdSchedules =>
+  schedules.map((schedule) => ({
+    ...schedule,
+    childIds: [...schedule.childIds],
+    days: Object.fromEntries(
+      Object.entries(schedule.days).map(([day, entries]) => [day, entries?.map((entry) => ({ ...entry })) ?? []])
+    ) as SchedulePlan['days'],
+  }));
+
+export const getActiveScheduleForChild = (schedules: HouseholdSchedules, childId: string) =>
+  schedules.find((schedule) => schedule.active && (schedule.childIds.length === 0 || schedule.childIds.includes(childId))) ?? null;

--- a/src/lib/summer-schedule.ts
+++ b/src/lib/summer-schedule.ts
@@ -1,0 +1,79 @@
+export const SUMMER_DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'] as const;
+
+export type SummerDay = (typeof SUMMER_DAYS)[number];
+
+export type SummerScheduleItem = {
+  time: string;
+  title: string;
+  icon: string;
+  note?: string;
+};
+
+export type SummerSchedule = Record<SummerDay, SummerScheduleItem[]>;
+
+const DAILY_MORNING: SummerScheduleItem[] = [
+  { time: '10:00', title: 'Math', icon: '🔢', note: 'A short challenge for each age' },
+  { time: '10:30', title: 'Reading', icon: '📚', note: 'Read alone, together, or to Lily' },
+  { time: '11:00', title: 'Creative time', icon: '🎨', note: 'Drawing, colouring, or making something' },
+  { time: '12:00', title: 'Free play', icon: '🧸' },
+  { time: '13:00', title: 'Lunch', icon: '🍽️' },
+];
+
+const DAILY_EVENING: SummerScheduleItem[] = [
+  { time: '16:00', title: 'Fruit snack', icon: '🍎' },
+  { time: '17:30', title: 'Free play', icon: '🪁' },
+  { time: '19:00', title: 'Dinner', icon: '🍽️' },
+  { time: '20:00', title: 'Evening routine', icon: '🌙' },
+];
+
+export const SUMMER_SCHEDULE: SummerSchedule = {
+  Monday: [
+    ...DAILY_MORNING,
+    { time: '14:00', title: 'Beach', icon: '🏖️' },
+    ...DAILY_EVENING.slice(0, 1),
+    { time: '16:30', title: 'Cooking class', icon: '👩‍🍳', note: 'Help prepare a snack or part of dinner' },
+    ...DAILY_EVENING.slice(1),
+  ],
+  Tuesday: [
+    { time: '09:00', title: 'Bakery mission', icon: '🥖', note: 'Get bread together with a grown-up nearby' },
+    ...DAILY_MORNING,
+    { time: '14:00', title: 'Pool', icon: '🏊' },
+    ...DAILY_EVENING.slice(0, 1),
+    { time: '16:30', title: 'Sewing with Grandma', icon: '🧵' },
+    ...DAILY_EVENING.slice(1),
+  ],
+  Wednesday: [
+    ...DAILY_MORNING,
+    { time: '14:00', title: 'Beach', icon: '🏖️' },
+    ...DAILY_EVENING.slice(0, 1),
+    { time: '16:30', title: 'Prepare a snack', icon: '🥣', note: 'Wash, cut, mix, or plate something simple' },
+    ...DAILY_EVENING.slice(1),
+  ],
+  Thursday: [
+    { time: '09:00', title: 'Bakery mission', icon: '🥖', note: 'Get bread together with a grown-up nearby' },
+    ...DAILY_MORNING,
+    { time: '14:00', title: 'Pool', icon: '🏊' },
+    ...DAILY_EVENING.slice(0, 1),
+    { time: '16:30', title: 'Cooking class', icon: '👩‍🍳' },
+    ...DAILY_EVENING.slice(1),
+  ],
+  Friday: [
+    ...DAILY_MORNING,
+    { time: '14:00', title: 'Beach or pool', icon: '🌊' },
+    ...DAILY_EVENING.slice(0, 1),
+    { time: '16:30', title: 'Prepare the showcase', icon: '✨' },
+    { time: '18:00', title: 'Friday showcase', icon: '🎤', note: 'Share something learned, made, read, or practised' },
+    ...DAILY_EVENING.slice(2),
+  ],
+};
+
+export const getTodaySummerDay = (date = new Date()): SummerDay => {
+  const day = date.getDay();
+  if (day >= 1 && day <= 5) return SUMMER_DAYS[day - 1];
+  return 'Monday';
+};
+
+export const timeToMinutes = (value: string) => {
+  const [hours, minutes] = value.split(':').map(Number);
+  return hours * 60 + minutes;
+};

--- a/src/lib/summer-schedule.ts
+++ b/src/lib/summer-schedule.ts
@@ -1,79 +1,24 @@
 export const SUMMER_DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'] as const;
-
 export type SummerDay = (typeof SUMMER_DAYS)[number];
-
-export type SummerScheduleItem = {
-  time: string;
-  title: string;
-  icon: string;
-  note?: string;
-};
-
+export type SummerScheduleItem = { id: string; time: string; title: string; icon: string; note?: string };
 export type SummerSchedule = Record<SummerDay, SummerScheduleItem[]>;
 
-const DAILY_MORNING: SummerScheduleItem[] = [
-  { time: '10:00', title: 'Math', icon: '🔢', note: 'A short challenge for each age' },
-  { time: '10:30', title: 'Reading', icon: '📚', note: 'Read alone, together, or to Lily' },
-  { time: '11:00', title: 'Creative time', icon: '🎨', note: 'Drawing, colouring, or making something' },
-  { time: '12:00', title: 'Free play', icon: '🧸' },
-  { time: '13:00', title: 'Lunch', icon: '🍽️' },
-];
-
-const DAILY_EVENING: SummerScheduleItem[] = [
-  { time: '16:00', title: 'Fruit snack', icon: '🍎' },
-  { time: '17:30', title: 'Free play', icon: '🪁' },
-  { time: '19:00', title: 'Dinner', icon: '🍽️' },
-  { time: '20:00', title: 'Evening routine', icon: '🌙' },
-];
-
-export const SUMMER_SCHEDULE: SummerSchedule = {
-  Monday: [
-    ...DAILY_MORNING,
-    { time: '14:00', title: 'Beach', icon: '🏖️' },
-    ...DAILY_EVENING.slice(0, 1),
-    { time: '16:30', title: 'Cooking class', icon: '👩‍🍳', note: 'Help prepare a snack or part of dinner' },
-    ...DAILY_EVENING.slice(1),
-  ],
-  Tuesday: [
-    { time: '09:00', title: 'Bakery mission', icon: '🥖', note: 'Get bread together with a grown-up nearby' },
-    ...DAILY_MORNING,
-    { time: '14:00', title: 'Pool', icon: '🏊' },
-    ...DAILY_EVENING.slice(0, 1),
-    { time: '16:30', title: 'Sewing with Grandma', icon: '🧵' },
-    ...DAILY_EVENING.slice(1),
-  ],
-  Wednesday: [
-    ...DAILY_MORNING,
-    { time: '14:00', title: 'Beach', icon: '🏖️' },
-    ...DAILY_EVENING.slice(0, 1),
-    { time: '16:30', title: 'Prepare a snack', icon: '🥣', note: 'Wash, cut, mix, or plate something simple' },
-    ...DAILY_EVENING.slice(1),
-  ],
-  Thursday: [
-    { time: '09:00', title: 'Bakery mission', icon: '🥖', note: 'Get bread together with a grown-up nearby' },
-    ...DAILY_MORNING,
-    { time: '14:00', title: 'Pool', icon: '🏊' },
-    ...DAILY_EVENING.slice(0, 1),
-    { time: '16:30', title: 'Cooking class', icon: '👩‍🍳' },
-    ...DAILY_EVENING.slice(1),
-  ],
-  Friday: [
-    ...DAILY_MORNING,
-    { time: '14:00', title: 'Beach or pool', icon: '🌊' },
-    ...DAILY_EVENING.slice(0, 1),
-    { time: '16:30', title: 'Prepare the showcase', icon: '✨' },
-    { time: '18:00', title: 'Friday showcase', icon: '🎤', note: 'Share something learned, made, read, or practised' },
-    ...DAILY_EVENING.slice(2),
-  ],
+const item = (time: string, title: string, icon: string, note?: string): SummerScheduleItem => ({
+  id: `${time}-${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`,
+  time, title, icon, note,
+});
+const morning = [item('10:00','Math','🔢','A short challenge for each age'),item('10:30','Reading','📚','Read alone, together, or to Lily'),item('11:00','Creative time','🎨','Drawing, colouring, or making something'),item('12:00','Free play','🧸'),item('13:00','Lunch','🍽️')];
+const evening = [item('16:00','Fruit snack','🍎'),item('17:30','Free play','🪁'),item('19:00','Dinner','🍽️'),item('20:00','Evening routine','🌙')];
+export const DEFAULT_SUMMER_SCHEDULE: SummerSchedule = {
+  Monday:[...morning,item('14:00','Beach','🏖️'),evening[0],item('16:30','Cooking class','👩‍🍳','Help prepare a snack or part of dinner'),...evening.slice(1)],
+  Tuesday:[item('09:00','Bakery mission','🥖','Get bread together with a grown-up nearby'),...morning,item('14:00','Pool','🏊'),evening[0],item('16:30','Sewing with Grandma','🧵'),...evening.slice(1)],
+  Wednesday:[...morning,item('14:00','Beach','🏖️'),evening[0],item('16:30','Prepare a snack','🥣','Wash, cut, mix, or plate something simple'),...evening.slice(1)],
+  Thursday:[item('09:00','Bakery mission','🥖','Get bread together with a grown-up nearby'),...morning,item('14:00','Pool','🏊'),evening[0],item('16:30','Cooking class','👩‍🍳'),...evening.slice(1)],
+  Friday:[...morning,item('14:00','Beach or pool','🌊'),evening[0],item('16:30','Prepare the showcase','✨'),item('18:00','Friday showcase','🎤','Share something learned, made, read, or practised'),...evening.slice(2)],
 };
-
-export const getTodaySummerDay = (date = new Date()): SummerDay => {
-  const day = date.getDay();
-  if (day >= 1 && day <= 5) return SUMMER_DAYS[day - 1];
-  return 'Monday';
-};
-
-export const timeToMinutes = (value: string) => {
-  const [hours, minutes] = value.split(':').map(Number);
-  return hours * 60 + minutes;
-};
+const STORAGE_KEY='little-loops-summer-schedule-v1';
+export const cloneSummerSchedule=(schedule:SummerSchedule):SummerSchedule=>Object.fromEntries(SUMMER_DAYS.map(day=>[day,schedule[day].map(entry=>({...entry}))])) as SummerSchedule;
+export const loadSummerSchedule=():SummerSchedule=>{try{const raw=window.localStorage.getItem(STORAGE_KEY);if(!raw)return cloneSummerSchedule(DEFAULT_SUMMER_SCHEDULE);const parsed=JSON.parse(raw) as Partial<SummerSchedule>;if(!SUMMER_DAYS.every(day=>Array.isArray(parsed[day])))throw new Error('Invalid schedule');return parsed as SummerSchedule;}catch{return cloneSummerSchedule(DEFAULT_SUMMER_SCHEDULE);}};
+export const saveSummerSchedule=(schedule:SummerSchedule)=>window.localStorage.setItem(STORAGE_KEY,JSON.stringify(schedule));
+export const getTodaySummerDay=(date=new Date()):SummerDay=>date.getDay()>=1&&date.getDay()<=5?SUMMER_DAYS[date.getDay()-1]:'Monday';
+export const timeToMinutes=(value:string)=>{const [hours,minutes]=value.split(':').map(Number);return hours*60+minutes;};

--- a/src/pages/SchedulesPage.tsx
+++ b/src/pages/SchedulesPage.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/lib/auth/use-auth';
+import { getSupabaseClient } from '@/lib/supabase/client';
+import { SupabaseChildProfileRepository } from '@/lib/data/supabase-child-profile-repository';
+import { SupabaseScheduleRepository } from '@/lib/data/supabase-schedule-repository';
+import { cloneSchedules, createCroatiaSummerSchedule, SCHEDULE_DAYS, timeToMinutes, type HouseholdSchedules, type ScheduleDay, type ScheduleItem, type SchedulePlan } from '@/lib/summer-schedule';
+
+const ink='#3d2c1f', mute='#8a7866', blue='#0ea5e9';
+const input:CSSProperties={width:'100%',boxSizing:'border-box',border:'1.5px solid rgba(14,165,233,.18)',borderRadius:12,padding:'9px 10px',fontFamily:"'Fredoka',system-ui,sans-serif",fontSize:14,color:ink,background:'#fff'};
+const button=(background:string,color='#fff'):CSSProperties=>({border:'none',borderRadius:12,padding:'10px 14px',background,color,fontFamily:"'Fredoka',system-ui,sans-serif",fontWeight:800,cursor:'pointer'});
+
+export default function SchedulesPage(){
+  const navigate=useNavigate();
+  const { household }=useAuth();
+  const [children,setChildren]=useState<Array<{id:string;name:string}>>([]);
+  const [schedules,setSchedules]=useState<HouseholdSchedules>([]);
+  const [selectedId,setSelectedId]=useState<string|null>(null);
+  const [selectedDay,setSelectedDay]=useState<ScheduleDay>('Monday');
+  const [status,setStatus]=useState<'loading'|'idle'|'saving'|'saved'|'error'>('loading');
+  const selected=useMemo(()=>schedules.find(schedule=>schedule.id===selectedId)??null,[schedules,selectedId]);
+
+  useEffect(()=>{const supabase=getSupabaseClient();if(!household||!supabase){setStatus('error');return;}const scheduleRepo=new SupabaseScheduleRepository(supabase);const childRepo=new SupabaseChildProfileRepository(supabase);void Promise.all([scheduleRepo.load(household.id),childRepo.listByHousehold(household.id)]).then(([loaded,profiles])=>{setSchedules(loaded);setChildren(profiles.map(child=>({id:child.id,name:child.name})));setSelectedId(loaded[0]?.id??null);setStatus('idle');}).catch(()=>setStatus('error'));},[household]);
+
+  const updatePlan=(patch:Partial<SchedulePlan>)=>setSchedules(prev=>prev.map(schedule=>schedule.id===selectedId?{...schedule,...patch}:schedule));
+  const updateItems=(items:ScheduleItem[])=>{if(!selected)return;updatePlan({days:{...selected.days,[selectedDay]:items}});};
+  const createPlan=()=>{const plan=createCroatiaSummerSchedule(children.map(child=>child.id));setSchedules(prev=>[...prev,plan]);setSelectedId(plan.id);};
+  const addItem=()=>updateItems([...(selected?.days[selectedDay]??[]),{id:crypto.randomUUID(),time:'15:00',title:'New activity',icon:'⭐'}]);
+  const save=async()=>{const supabase=getSupabaseClient();if(!household||!supabase)return;setStatus('saving');const cleaned=cloneSchedules(schedules).map(schedule=>({...schedule,days:Object.fromEntries(Object.entries(schedule.days).map(([day,items])=>[day,(items??[]).slice().sort((a,b)=>timeToMinutes(a.time)-timeToMinutes(b.time))]))}));try{await new SupabaseScheduleRepository(supabase).save(household.id,cleaned);setSchedules(cleaned);setStatus('saved');window.setTimeout(()=>setStatus('idle'),1500);}catch{setStatus('error');}};
+
+  return <div style={{minHeight:'100vh',background:'#fff9f0',fontFamily:"'Fredoka',system-ui,sans-serif",color:ink,padding:'24px 16px'}}><div style={{maxWidth:1100,margin:'0 auto'}}>
+    <div style={{display:'flex',justifyContent:'space-between',alignItems:'center',gap:12,marginBottom:20}}><div><button onClick={()=>navigate('/')} style={{...button('#fff',ink),border:'1px solid rgba(0,0,0,.08)',marginBottom:10}}>← Back</button><div style={{fontSize:13,fontWeight:800,color:blue,textTransform:'uppercase',letterSpacing:'.12em'}}>Parent settings</div><h1 style={{margin:'4px 0 0',fontSize:36}}>Schedules</h1><p style={{margin:'6px 0 0',color:mute}}>Create reusable plans, assign them to children, and choose which one is active.</p></div><button onClick={createPlan} style={button(blue)}>+ Create schedule</button></div>
+    {status==='loading'?<div>Loading…</div>:status==='error'?<div style={{padding:16,borderRadius:14,background:'#fee2e2',color:'#b91c1c'}}>Could not load or save schedules. Make sure the Supabase migration has been applied.</div>:<div style={{display:'grid',gridTemplateColumns:'minmax(220px,300px) minmax(0,1fr)',gap:18}}>
+      <aside style={{background:'#fff',borderRadius:22,padding:14,border:'1px solid rgba(0,0,0,.07)',height:'fit-content'}}>{schedules.length===0?<div style={{padding:16,color:mute}}>No schedules yet.</div>:schedules.map(schedule=><button key={schedule.id} onClick={()=>setSelectedId(schedule.id)} style={{width:'100%',textAlign:'left',padding:12,marginBottom:7,borderRadius:14,border:schedule.id===selectedId?`2px solid ${blue}`:'1px solid rgba(0,0,0,.07)',background:schedule.id===selectedId?'#e0f2fe':'#fff',fontFamily:'inherit',cursor:'pointer'}}><div style={{fontWeight:800}}>{schedule.name}</div><div style={{fontSize:12,color:mute,marginTop:3}}>{schedule.active?'Active':'Inactive'} · {schedule.childIds.length===0?'All children':`${schedule.childIds.length} assigned`}</div></button>)}</aside>
+      <main>{!selected?<div style={{background:'#fff',borderRadius:22,padding:28,textAlign:'center',color:mute}}>Create or select a schedule.</div>:<div style={{background:'#fff',borderRadius:22,padding:18,border:'1px solid rgba(0,0,0,.07)'}}>
+        <div style={{display:'grid',gridTemplateColumns:'1fr auto',gap:12,alignItems:'start'}}><div><input value={selected.name} onChange={e=>updatePlan({name:e.target.value})} style={{...input,fontSize:22,fontWeight:800}}/><input value={selected.description??''} onChange={e=>updatePlan({description:e.target.value})} placeholder="Description" style={{...input,marginTop:8}}/></div><label style={{display:'flex',gap:7,alignItems:'center',fontWeight:700}}><input type="checkbox" checked={selected.active} onChange={e=>{const checked=e.target.checked;setSchedules(prev=>prev.map(schedule=>({...schedule,active:schedule.id===selected.id?checked:checked?false:schedule.active})));}}/> Active</label></div>
+        <div style={{marginTop:16,fontWeight:800}}>Applies to</div><div style={{display:'flex',flexWrap:'wrap',gap:8,marginTop:8}}>{children.map(child=><label key={child.id} style={{padding:'8px 11px',borderRadius:99,background:selected.childIds.includes(child.id)?'#e0f2fe':'#f5ede2',cursor:'pointer'}}><input type="checkbox" checked={selected.childIds.includes(child.id)} onChange={e=>updatePlan({childIds:e.target.checked?[...selected.childIds,child.id]:selected.childIds.filter(id=>id!==child.id)})}/> {child.name}</label>)}</div>
+        <div style={{display:'grid',gridTemplateColumns:'repeat(7,1fr)',gap:5,marginTop:18}}>{SCHEDULE_DAYS.map(day=><button key={day} onClick={()=>setSelectedDay(day)} style={{...button(day===selectedDay?blue:'#f0f9ff',day===selectedDay?'#fff':'#0369a1'),padding:'9px 2px',fontSize:11}}>{day.slice(0,3)}</button>)}</div>
+        <div style={{display:'flex',justifyContent:'space-between',alignItems:'center',marginTop:16}}><h2 style={{margin:0}}>{selectedDay}</h2><button onClick={addItem} style={button(blue)}>+ Activity</button></div>
+        <div style={{display:'flex',flexDirection:'column',gap:8,marginTop:10}}>{(selected.days[selectedDay]??[]).map(entry=><div key={entry.id} style={{display:'grid',gridTemplateColumns:'90px 60px 1fr auto',gap:8,alignItems:'center',padding:9,borderRadius:14,background:'#f8fafc'}}><input type="time" value={entry.time} onChange={e=>updateItems((selected.days[selectedDay]??[]).map(item=>item.id===entry.id?{...item,time:e.target.value}:item))} style={input}/><input value={entry.icon} onChange={e=>updateItems((selected.days[selectedDay]??[]).map(item=>item.id===entry.id?{...item,icon:e.target.value}:item))} style={{...input,textAlign:'center',fontSize:20}}/><div><input value={entry.title} onChange={e=>updateItems((selected.days[selectedDay]??[]).map(item=>item.id===entry.id?{...item,title:e.target.value}:item))} style={input}/><input value={entry.note??''} onChange={e=>updateItems((selected.days[selectedDay]??[]).map(item=>item.id===entry.id?{...item,note:e.target.value}:item))} placeholder="Optional note" style={{...input,marginTop:5,fontSize:12}}/></div><button onClick={()=>updateItems((selected.days[selectedDay]??[]).filter(item=>item.id!==entry.id))} style={button('#fee2e2','#b91c1c')}>×</button></div>)}</div>
+        <div style={{display:'flex',justifyContent:'flex-end',alignItems:'center',gap:10,marginTop:18}}><span style={{fontSize:13,color:status==='saved'?'#15803d':mute}}>{status==='saving'?'Saving…':status==='saved'?'Saved to cloud':''}</span><button onClick={()=>void save()} style={button(blue)}>Save schedules</button></div>
+      </div>}</main>
+    </div>}
+  </div></div>;
+}

--- a/supabase/migrations/20260717170000_add_household_schedules.sql
+++ b/supabase/migrations/20260717170000_add_household_schedules.sql
@@ -1,0 +1,5 @@
+alter table public.households
+  add column if not exists schedules jsonb not null default '[]'::jsonb;
+
+comment on column public.households.schedules is
+  'Reusable household schedule plans, including child assignments and timetable items.';


### PR DESCRIPTION
## What changed
- adds Schedule as the fifth child-facing Little Loops section
- makes the child schedule read-only and loads it from the signed-in household in Supabase
- adds a reusable schedule model with named plans, active/inactive state, seven weekday timetables, and child assignments
- adds a dedicated parent editor at `/parent/schedules`
- lets parents create the Croatia summer template, edit names, descriptions, days, times, activities, emoji and notes, assign children, and save
- stores schedules in the household record through a new `schedules` JSONB column
- adds the Supabase migration and repository required to load and save schedules across devices

## Product behaviour
- schedules are household-level, rather than duplicated on each child
- an empty child assignment means the schedule applies to all children
- the active schedule assigned to a child is shown in that child’s Schedule section
- only one schedule can be made active from the editor at a time

## Test flow
1. Apply `supabase/migrations/20260717170000_add_household_schedules.sql`
2. Sign in and open `/parent/schedules`
3. Create the `Summer Croatia` schedule, edit it and assign Ellie, Mila and Lily
4. Save schedules
5. Return to Little Loops, open any assigned child and choose Schedule
6. Confirm the saved cloud timetable is shown

## Validation and remaining integration
- the branch is mergeable
- no pull-request preview or CI checks are configured for this branch
- the parent editor has its own authenticated route, but a navigation button inside the existing Parent Settings screen still needs to be added before this is considered polished for release